### PR TITLE
rate limiting

### DIFF
--- a/docs/20251006_1146_AIチャットレート制限機能要件定義と実装計画.md
+++ b/docs/20251006_1146_AIチャットレート制限機能要件定義と実装計画.md
@@ -57,11 +57,12 @@
   - 新たに1日10,000トークンの上限を付与
   - 過去の使用履歴とは紐づかない
 
-#### 2.5 トークンリセット機能
-- **日次リセット**
-  - `last_reset_at` から24時間以上経過していたら、使用量をリセット
-  - チャット利用時またはトークンチェック時にクライアント側で判定
-  - サーバー側の定期実行は不要（シンプルな実装）
+#### 2.5 トークン使用量の日次管理
+- **日次レコード管理**
+  - 各ユーザーの `(user_id, date)` の組み合わせで日次レコードを作成
+  - 今日の日付のレコードが存在しない場合、新規作成（`token_used = 0`）
+  - 今日の日付のレコードが存在する場合、そのレコードの使用量をチェック
+  - 過去の日付のレコードは保持（履歴として残る）
 
 ### 3. 非機能要件
 
@@ -107,18 +108,18 @@
 CREATE TABLE user_token_usage (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
     user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    date DATE NOT NULL DEFAULT CURRENT_DATE,
     token_used INTEGER NOT NULL DEFAULT 0,
     token_limit INTEGER NOT NULL DEFAULT 10000,
-    last_reset_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
-    CONSTRAINT unique_user_id UNIQUE(user_id)
+    CONSTRAINT unique_user_date UNIQUE(user_id, date)
 );
 
 -- インデックス
 CREATE INDEX idx_user_token_usage_user_id ON user_token_usage(user_id);
-CREATE INDEX idx_user_token_usage_token_used ON user_token_usage(token_used);
-CREATE INDEX idx_user_token_usage_last_reset_at ON user_token_usage(last_reset_at);
+CREATE INDEX idx_user_token_usage_date ON user_token_usage(date);
+CREATE INDEX idx_user_token_usage_user_date ON user_token_usage(user_id, date);
 
 -- updated_at自動更新トリガー
 CREATE TRIGGER update_user_token_usage_updated_at
@@ -127,8 +128,9 @@ CREATE TRIGGER update_user_token_usage_updated_at
     EXECUTE FUNCTION update_updated_at_column();
 
 -- コメント
-COMMENT ON TABLE user_token_usage IS 'ユーザーごとのトークン使用量を管理するテーブル';
-COMMENT ON COLUMN user_token_usage.last_reset_at IS '最後にトークンがリセットされた日時';
+COMMENT ON TABLE user_token_usage IS 'ユーザーごとの日次トークン使用量を管理するテーブル';
+COMMENT ON COLUMN user_token_usage.date IS '使用日（日次レート制限のキー）';
+COMMENT ON COLUMN user_token_usage.token_used IS 'その日に使用したトークン数';
 ```
 
 #### 1.2 RLS ポリシー
@@ -148,13 +150,19 @@ ALTER TABLE user_token_usage ENABLE ROW LEVEL SECURITY;
 ```
 web/src/
 ├── features/
-│   └── auth/
+│   └── chat/
 │       ├── actions/
-│       │   └── anonymous-auth.ts       # 匿名認証Server Action
+│       │   ├── anonymous-auth.ts       # 匿名認証Server Action
+│       │   ├── check-token-limit.ts    # トークン制限チェック
+│       │   └── update-token-usage.ts   # トークン使用量更新
 │       ├── hooks/
 │       │   └── use-anonymous-auth.ts   # 匿名認証フック
 │       ├── constants/
 │       │   └── token-limits.ts         # トークン制限定数
+│       ├── components/
+│       │   ├── chat-button.tsx
+│       │   ├── chat-window.tsx
+│       │   └── ...
 │       └── types/
 │           └── index.ts
 └── lib/
@@ -165,7 +173,7 @@ web/src/
 #### 2.2 定数定義
 
 ```typescript
-// features/auth/constants/token-limits.ts
+// features/chat/constants/token-limits.ts
 /**
  * 1日あたりのトークン使用上限
  * 匿名ユーザーが1日に使用できる最大トークン数
@@ -176,7 +184,7 @@ export const DAILY_TOKEN_LIMIT = 10000;
 #### 2.3 匿名認証実装
 
 ```typescript
-// features/auth/actions/anonymous-auth.ts
+// features/chat/actions/anonymous-auth.ts
 "use server";
 
 import { createClient } from "@/lib/supabase/server";
@@ -208,13 +216,15 @@ export async function ensureAnonymousUser() {
 async function initializeUserTokenUsage(userId: string) {
   const supabase = await createClient();
 
+  const today = new Date().toISOString().split('T')[0]; // YYYY-MM-DD
+
   const { error } = await supabase
     .from("user_token_usage")
     .insert({
       user_id: userId,
+      date: today,
       token_used: 0,
       token_limit: DAILY_TOKEN_LIMIT,
-      last_reset_at: new Date().toISOString(),
     });
 
   if (error) {
@@ -223,35 +233,7 @@ async function initializeUserTokenUsage(userId: string) {
 }
 ```
 
-```typescript
-// features/auth/hooks/use-anonymous-auth.ts
-"use client";
-
-import { useEffect, useState } from "react";
-import { ensureAnonymousUser } from "../actions/anonymous-auth";
-
-export function useAnonymousAuth() {
-  const [userId, setUserId] = useState<string | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
-
-  useEffect(() => {
-    async function init() {
-      try {
-        const { userId } = await ensureAnonymousUser();
-        setUserId(userId);
-      } catch (error) {
-        console.error("Anonymous auth error:", error);
-      } finally {
-        setIsLoading(false);
-      }
-    }
-
-    init();
-  }, []);
-
-  return { userId, isLoading };
-}
-```
+- クライアント側からは認証しないので実装は必要ない
 
 ### Phase 3: トークン使用量管理機能
 
@@ -266,42 +248,50 @@ import { createClient } from "@/lib/supabase/server";
 export async function checkTokenLimit(userId: string) {
   const supabase = await createClient();
 
+  const today = new Date().toISOString().split('T')[0]; // YYYY-MM-DD
+
+  // 今日の日付のレコードを取得
   const { data, error } = await supabase
     .from("user_token_usage")
-    .select("token_used, token_limit, last_reset_at")
+    .select("token_used, token_limit")
     .eq("user_id", userId)
+    .eq("date", today)
     .single();
 
-  if (error || !data) {
-    return { canUse: false, remaining: 0, error: "Failed to fetch token usage" };
-  }
+  let tokenUsed = 0;
+  let tokenLimit = DAILY_TOKEN_LIMIT;
 
-  // 最後のリセットから24時間以上経過していたらリセット
-  const lastReset = new Date(data.last_reset_at);
-  const now = new Date();
-  const hoursSinceReset = (now.getTime() - lastReset.getTime()) / (1000 * 60 * 60);
+  if (error) {
+    // レコードが存在しない場合、新規作成
+    if (error.code === 'PGRST116') {
+      const { error: insertError } = await supabase
+        .from("user_token_usage")
+        .insert({
+          user_id: userId,
+          date: today,
+          token_used: 0,
+          token_limit: DAILY_TOKEN_LIMIT,
+        });
 
-  let tokenUsed = data.token_used;
+      if (insertError) {
+        console.error("Failed to create today's token usage:", insertError);
+        return { canUse: false, remaining: 0, error: "Failed to create token usage" };
+      }
 
-  if (hoursSinceReset >= 24) {
-    // トークン使用量をリセット
-    const { error: resetError } = await supabase
-      .from("user_token_usage")
-      .update({
-        token_used: 0,
-        last_reset_at: now.toISOString(),
-      })
-      .eq("user_id", userId);
-
-    if (!resetError) {
       tokenUsed = 0;
+      tokenLimit = DAILY_TOKEN_LIMIT;
+    } else {
+      return { canUse: false, remaining: 0, error: "Failed to fetch token usage" };
     }
+  } else {
+    tokenUsed = data.token_used;
+    tokenLimit = data.token_limit;
   }
 
-  const remaining = data.token_limit - tokenUsed;
+  const remaining = tokenLimit - tokenUsed;
   const canUse = remaining > 0;
 
-  return { canUse, remaining, tokenUsed, tokenLimit: data.token_limit };
+  return { canUse, remaining, tokenUsed, tokenLimit };
 }
 ```
 
@@ -320,17 +310,19 @@ export async function updateTokenUsage(
 ) {
   const supabase = await createClient();
 
+  const today = new Date().toISOString().split('T')[0]; // YYYY-MM-DD
   const totalTokens = inputTokens + outputTokens;
 
-  // 現在の使用量を取得
+  // 今日の使用量を取得
   const { data: current } = await supabase
     .from("user_token_usage")
     .select("token_used")
     .eq("user_id", userId)
+    .eq("date", today)
     .single();
 
   if (!current) {
-    throw new Error("User token usage not found");
+    throw new Error("Today's token usage record not found");
   }
 
   // 使用量を更新
@@ -339,7 +331,8 @@ export async function updateTokenUsage(
     .update({
       token_used: current.token_used + totalTokens
     })
-    .eq("user_id", userId);
+    .eq("user_id", userId)
+    .eq("date", today);
 
   if (error) {
     console.error("Failed to update token usage:", error);
@@ -438,7 +431,7 @@ export async function POST(req: Request) {
 
 import { useChat } from "ai/react";
 import { useEffect, useState } from "react";
-import { useAnonymousAuth } from "@/features/auth/hooks/use-anonymous-auth";
+import { useAnonymousAuth } from "@/features/chat/hooks/use-anonymous-auth";
 import { checkTokenLimit } from "@/features/chat/actions/check-token-limit";
 
 export function ChatWindow({ billContext, onClose }: ChatWindowProps) {
@@ -561,7 +554,7 @@ export function ChatWindow({ billContext, onClose }: ChatWindowProps) {
 import { MessageCircle } from "lucide-react";
 import { useState, useEffect } from "react";
 import { ChatWindow } from "./chat-window";
-import { useAnonymousAuth } from "@/features/auth/hooks/use-anonymous-auth";
+import { useAnonymousAuth } from "@/features/chat/hooks/use-anonymous-auth";
 import { checkTokenLimit } from "../actions/check-token-limit";
 
 export function ChatButton({ billContext }: ChatButtonProps) {
@@ -612,7 +605,7 @@ export function ChatButton({ billContext }: ChatButtonProps) {
 - [ ] 匿名ユーザー作成が正常に動作する
 - [ ] トークン使用量の記録が正確
 - [ ] トークン制限チェックが正常に動作する
-- [ ] 24時間経過後の自動リセットが動作する
+- [ ] 新しい日の自動レコード作成が動作する
 - [ ] 制限到達時にチャットボタンが非表示になる
 - [ ] DAILY_TOKEN_LIMIT定数が正しく適用される
 
@@ -622,19 +615,19 @@ export function ChatButton({ billContext }: ChatButtonProps) {
 - [ ] 10,000トークン到達後にチャットボタンが消える
 - [ ] ブラウザリロード後もセッションが維持される
 - [ ] キャッシュクリア後に新しい匿名ユーザーとして扱われる
-- [ ] `last_reset_at`から24時間経過後、次回チェック時にリセットされる
+- [ ] 新しい日になると、自動的に新しいレコードが作成される（`token_used = 0`）
 
 #### 6.3 手動テスト項目
 - [ ] 複数メッセージでトークンが累積される
 - [ ] 残りトークン表示が正確
 - [ ] 制限到達時にチャットボタンが非表示
-- [ ] 24時間後にチャットボタンが再表示される
+- [ ] 翌日にチャットボタンが再表示される
 - [ ] エラーハンドリングが適切
 
 ## 📊 実装スケジュール
 
 ### Phase 1: データベース準備（30分）
-- スキーマ作成（`last_reset_at`カラム含む）
+- スキーマ作成（`date`カラムで日次管理）
 - RLSポリシー設定
 - マイグレーション実行
 
@@ -645,8 +638,8 @@ export function ChatButton({ billContext }: ChatButtonProps) {
 - 基本的な動作確認
 
 ### Phase 3: トークン管理機能（1.5時間）
-- チェック機能実装（24時間リセットロジック含む）
-- 更新機能実装
+- チェック機能実装（日次レコード自動作成含む）
+- 更新機能実装（日付ベース）
 - エラーハンドリング
 
 ### Phase 4: API統合（1時間）


### PR DESCRIPTION
AI chat 用に rate limit の実装をまとめる。
まずは
- session + supabase auth を使ったrate limit の実装
- rate limit 到達後の挙動 (AI chat ボタンが消える）
- rate limit の更新（日毎）
を実装する