### PR TITLE
fix: チャットボタンの微修正

### DIFF
--- a/web/src/features/chat/components/chat-button.tsx
+++ b/web/src/features/chat/components/chat-button.tsx
@@ -51,7 +51,8 @@ export const ChatButton = forwardRef<ChatButtonRef, ChatButtonProps>(
 
       const handleScroll = () => {
         const currentScrollY = window.scrollY;
-        const shouldCompact = currentScrollY > lastScrollY && currentScrollY > 0 && !isCompact;
+        const shouldCompact =
+          currentScrollY > lastScrollY && currentScrollY > 0 && !isCompact;
         const shouldExpand = currentScrollY < lastScrollY && isCompact;
 
         if (shouldCompact || shouldExpand) {
@@ -105,7 +106,9 @@ export const ChatButton = forwardRef<ChatButtonRef, ChatButtonProps>(
                 }`}
                 style={
                   showText
-                    ? { transitionDuration: `${ANIMATION_DURATION.TEXT_FADE_IN}ms` }
+                    ? {
+                        transitionDuration: `${ANIMATION_DURATION.TEXT_FADE_IN}ms`,
+                      }
                     : undefined
                 }
               >


### PR DESCRIPTION
## Summary
- チャットボタンの横幅を画面幅に応じて調整
- スクロール処理のロジックをDRY化
- アニメーション定数の使用を徹底

## Changes
- 展開時のボタン幅を固定340pxから画面幅100%に変更（親要素のpaddingで制限）
- 不要な`TEXT_FADE_OUT`定数を削除
- スクロール検知とアニメーション処理を共通化
- `duration`の指定を定数ベースに統一（動的評価のためstyle属性を使用）
- `flex-basis`はMobile Safariのアニメーション互換性のためstyle属性で指定

## Test plan
- [ ] モバイルでボタンが画面幅いっぱいに広がることを確認
- [ ] スクロールでボタンがコンパクト/展開に切り替わることを確認
- [ ] アニメーションが滑らかに動作することを確認（特にMobile Safari）

🤖 Generated with [Claude Code](https://claude.com/claude-code)