### PR TITLE
fix: @supabase/ssr の依存関係を追加

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -197,6 +197,9 @@ importers:
       '@radix-ui/react-use-controllable-state':
         specifier: ^1.2.2
         version: 1.2.2(@types/react@19.2.2)(react@19.1.0)
+      '@supabase/ssr':
+        specifier: ^0.5.2
+        version: 0.5.2(@supabase/supabase-js@2.74.0)
       '@types/react-syntax-highlighter':
         specifier: ^15.5.13
         version: 15.5.13

--- a/web/package.json
+++ b/web/package.json
@@ -28,6 +28,7 @@
     "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@radix-ui/react-use-controllable-state": "^1.2.2",
+    "@supabase/ssr": "^0.5.2",
     "@types/react-syntax-highlighter": "^15.5.13",
     "@types/unist": "^3.0.3",
     "@vercel/speed-insights": "^1.2.0",


### PR DESCRIPTION
## Summary
- ビルドエラーを修正するため `@supabase/ssr` パッケージを追加

## 問題
- ビルド時に `Module not found: Can't resolve '@supabase/ssr'` エラーが発生
- `web/src/features/chat/lib/supabase-server.ts` で使用されているが `package.json` に依存関係が定義されていなかった

## 変更内容
- `@supabase/ssr ^0.5.2` を dependencies に追加

## Test plan
- [ ] ビルドが成功することを確認
- [ ] チャット機能が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)