### PR TITLE
feat: 議案詳細ページにデータ出典と免責事項を追加

### DIFF
--- a/web/src/features/bills/components/bill-detail/bill-detail-layout.tsx
+++ b/web/src/features/bills/components/bill-detail/bill-detail-layout.tsx
@@ -4,6 +4,7 @@ import { BillShareButtons } from "../share/bill-share-buttons";
 import { BillContent } from "./bill-content";
 import { BillDetailClient } from "./bill-detail-client";
 import { BillDetailHeader } from "./bill-detail-header";
+import { BillDisclaimer } from "./bill-disclaimer";
 import { BillStatusProgress } from "./bill-status-progress";
 import { MiraiStanceCard } from "./mirai-stance-card";
 
@@ -50,6 +51,11 @@ export function BillDetailLayout({
       {/* シェアボタン */}
       <div className="my-8">
         <BillShareButtons bill={bill} />
+      </div>
+
+      {/* データの出典と免責事項 */}
+      <div className="my-8">
+        <BillDisclaimer />
       </div>
     </div>
   );

--- a/web/src/features/bills/components/bill-detail/bill-disclaimer.tsx
+++ b/web/src/features/bills/components/bill-detail/bill-disclaimer.tsx
@@ -1,0 +1,23 @@
+export function BillDisclaimer() {
+  return (
+    <div className="space-y-6">
+      {/* データの出典について */}
+      <div className="space-y-3">
+        <h3 className="text-sm font-bold text-black">データの出典について</h3>
+        <p className="text-xs leading-relaxed text-[#4C4C4C]">
+          コンテンツは、一部AIを用いて生成され、チームみらいによってレビューされています。チームみらいの理解をもとにAIが生成したものだよ。全然間違ってる可能性があるよ。面責事項のテキストが入ります。面責事項のテキストが入ります。面責事項のテキストが入ります。面責事項のテキストが入ります。面責事項のテキストが入ります
+        </p>
+      </div>
+
+      {/* 掲載コンテンツについての免責事項 */}
+      <div className="space-y-3">
+        <h3 className="text-sm font-bold text-black">
+          掲載コンテンツについての免責事項
+        </h3>
+        <p className="text-xs leading-relaxed text-[#4C4C4C]">
+          コンテンツは、一部AIを用いて生成され、チームみらいによってレビューされています。チームみらいの理解をもとにAIが生成したものだよ。全然間違ってる可能性があるよ。面責事項のテキストが入ります。面責事項のテキストが入ります。面責事項のテキストが入ります。面責事項のテキストが入ります。面責事項のテ
+        </p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- 議案詳細ページの下部にデータ出典と免責事項のセクションを追加
- BillDisclaimerコンポーネントを新規作成
- データの出典についてと掲載コンテンツについての免責事項を表示

## Changes
- `BillDisclaimer`コンポーネントを追加（[bill-disclaimer.tsx](web/src/features/bills/components/bill-detail/bill-disclaimer.tsx)）
- `BillDetailLayout`に免責事項セクションを統合（[bill-detail-layout.tsx](web/src/features/bills/components/bill-detail/bill-detail-layout.tsx)）

## Test plan
- [ ] 議案詳細ページに免責事項が表示されることを確認
- [ ] テキストが適切にフォーマットされていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)