### PR TITLE
chore: db:reset と db:migrate の script 修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "scripts": {
     "db:types:gen": "npx supabase gen types typescript --local > packages/supabase/types/supabase.types.ts",
-    "db:migrate": "npx supabase migration up && pnpm run supabase:types:gen",
-    "db:reset": "dotenv -e .env -- npx supabase db reset && pnpm supabase:types:gen && pnpm seed",
+    "db:migrate": "npx supabase migration up && pnpm run db:types:gen",
+    "db:reset": "dotenv -e .env -- npx supabase db reset && pnpm db:types:gen && pnpm seed",
     "dev": "dotenv -e .env -- pnpm -r --stream --parallel run dev",
     "seed": "dotenv -e .env -- pnpm --filter @mirai-gikai/seed seed",
     "test": "pnpm -r --parallel run test",


### PR DESCRIPTION
`pnpm db:reset` と `pnpm db:migrate`  を実行してみたところ、  
supabase:types:gen が見つからないためエラーになりました。  
db:types:gen が正しいかと思うので修正しました。