### PR TITLE
fix: ユーザ入力とAIレスポンスがHTMLタグを含んでいる場合はサニタイズする

### DIFF
--- a/web/src/components/ai-elements/response.tsx
+++ b/web/src/components/ai-elements/response.tsx
@@ -2,17 +2,19 @@
 
 import { cn } from "@/lib/utils";
 import { type ComponentProps, memo } from "react";
+import rehypeSanitize from "rehype-sanitize";
 import { Streamdown } from "streamdown";
 
 type ResponseProps = ComponentProps<typeof Streamdown>;
 
 export const Response = memo(
-  ({ className, ...props }: ResponseProps) => (
+  ({ className, rehypePlugins, ...props }: ResponseProps) => (
     <Streamdown
       className={cn(
         "size-full [&>*:first-child]:mt-0 [&>*:last-child]:mb-0",
         className
       )}
+      rehypePlugins={[rehypeSanitize, ...(rehypePlugins ?? [])]}
       {...props}
     />
   ),


### PR DESCRIPTION
# 概要
`<iframe />`といった危ないタブをサニタイズする対応を追加

対応前

<img width="513" height="447" alt="image" src="https://github.com/user-attachments/assets/50b03333-e048-4f62-8ca0-40705cf04a5e" />

対応後

<img width="447" height="324" alt="image" src="https://github.com/user-attachments/assets/d76080c6-e5c7-49e5-8231-7bf82f648487" />
