### PR TITLE
README に DeepWiki のバッジを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # みらい議会
 
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/team-mirai-volunteer/mirai-gikai)
+
 ## セットアップ
 
 ```bash


### PR DESCRIPTION
marumie のリポジトリに DeepWiki のバッジがあったため、  
mirai-gikai の README にも DeepWiki のバッジを追加