### PR TITLE
feat: フッターにソースコードリンクを追加

### DIFF
--- a/web/src/components/layouts/footer/footer.config.ts
+++ b/web/src/components/layouts/footer/footer.config.ts
@@ -28,6 +28,11 @@ export const primaryLinks: FooterLink[] = [
     external: true,
   },
   {
+    label: "ソースコード",
+    href: EXTERNAL_LINKS.GITHUB,
+    external: true,
+  },
+  {
     label: "寄附で応援する",
     href: EXTERNAL_LINKS.DONATION,
     external: true,

--- a/web/src/components/layouts/footer/footer.tsx
+++ b/web/src/components/layouts/footer/footer.tsx
@@ -39,7 +39,6 @@ function FooterPrimaryLinks() {
       <ul
         className="
       flex flex-col items-center gap-3 text-[14px] font-semibold text-slate-800
-      md:flex-row md:justify-center md:gap-5
       "
       >
         {primaryLinks.map((link) => (

--- a/web/src/config/external-links.ts
+++ b/web/src/config/external-links.ts
@@ -6,6 +6,7 @@ export const EXTERNAL_LINKS = {
   ABOUT_NOTE: "https://note.com/team_mirai_jp/n/nd1656aa5f86d",
   DONATION: "https://team-mir.ai/support/donation",
   TEAM_MIRAI_ABOUT: "https://team-mir.ai/about",
+  GITHUB: "https://github.com/team-mirai-volunteer/mirai-gikai",
   TERMS: "https://team-mir.ai/terms",
   PRIVACY: "https://team-mir.ai/privacy",
   FAQ: "https://team-mirai.notion.site/FAQ-28cf6f56bae180bd84e7f7ae80f806a1",


### PR DESCRIPTION
## 概要

フッターに「ソースコード」リンクを追加しました。
OSSでコードをせっかく公開しているのにGitHubリポジトリへのリンクがなかったので、リンクを追加し、GitHubのリポジトリへのアクセスを容易にしました。

SNSへのリンクの並びに置くことも検討しましたが、エンジニア以外が使う可能性は低いものであり対象が限られるものなので控えめな位置であるフッターに配置しました。

文字を追加したことで、デスクトップで表示する際にフッターでリンクを横並びにすると文字が途中で改行されてしまうので、デスクトップでもモバイル同様フッターのリンクを縦並びにしました。
<img width="1385" height="949" alt="スクリーンショット 2025-10-20 12 49 24" src="https://github.com/user-attachments/assets/09f15f8e-f607-4505-8e2a-e7b453e399a2" />

## 変更内容

  - `web/src/config/external-links.ts`:
  GitHubリポジトリのURLを追加（TEAM_MIRAI_ABOUTの下に配置）
  - `web/src/components/layouts/footer/footer.config.ts`:
  フッターのprimaryLinksに「ソースコード」を追加
  - `web/src/components/layouts/footer/footer.tsx`:
  デスクトップでの横並びレイアウトを削除（全デバイスで縦並びに統一）

## リンクの配置

1. TOP
2. みらい議会とは
3. チームみらいについて
4. **ソースコード** ← 新規追加
5. 寄附で応援する