### PR TITLE
プライバシーポリシーと利用規約ページのレイアウト調整

### DIFF
--- a/web/src/app/privacy/page.tsx
+++ b/web/src/app/privacy/page.tsx
@@ -15,7 +15,7 @@ export const metadata: Metadata = {
 export default function PrivacyPage() {
   return (
     <LegalPageLayout
-      className="bg-transparent"
+      className="bg-transparent pt-24 md:pt-12"
       title="プライバシーポリシー"
       description="みらい議会における個人情報の取り扱いについてご説明します。"
     >

--- a/web/src/app/terms/page.tsx
+++ b/web/src/app/terms/page.tsx
@@ -17,6 +17,7 @@ export default function TermsPage() {
     <LegalPageLayout
       title="利用規約"
       description="みらい議会をご利用いただくにあたっての基本的なルールを定めています。"
+      className="pt-24 md:pt-12"
     >
       <Container className="space-y-10">
         <LegalParagraph>


### PR DESCRIPTION
プライバシーポリシーと利用規約のページで、画面の横幅を小さくすると、
「利用規約」、「プライバシーポリシー」がヘッダーの裏に隠れてしまっていたため修正

[対応前]

https://github.com/user-attachments/assets/379eb49b-3a2d-4299-a24d-4674166e0dd9


https://github.com/user-attachments/assets/21e7f95d-5d6c-40da-a0fd-232772cce528

[対応後]


https://github.com/user-attachments/assets/59308bdb-68f3-4302-a906-9b20364bb96b



https://github.com/user-attachments/assets/51fb054e-360a-4bfe-8b11-e58aca020730

