### PR TITLE
add label selection

### DIFF
--- a/docs/20251007_2159_Langfuse導入設計.md
+++ b/docs/20251007_2159_Langfuse導入設計.md
@@ -309,6 +309,7 @@ export async function POST(req: Request) {
 LANGFUSE_PUBLIC_KEY=pk-lf-xxx
 LANGFUSE_SECRET_KEY=sk-lf-xxx
 LANGFUSE_BASE_URL=https://cloud.langfuse.com
+LANGFUSE_PROMPT_LABEL=production
 
 # 環境ラベル（Vercelでは自動設定される）
 # VERCEL_ENV=production|preview|development

--- a/web/src/lib/env.ts
+++ b/web/src/lib/env.ts
@@ -36,6 +36,7 @@ export const env = {
     publicKey: process.env.LANGFUSE_PUBLIC_KEY,
     secretKey: process.env.LANGFUSE_SECRET_KEY,
     baseUrl: process.env.LANGFUSE_BASE_URL || "https://cloud.langfuse.com",
+    promptLabel: process.env.LANGFUSE_PROMPT_LABEL || "production",
   },
   chat: {
     dailyCostLimitUsd: chatDailyCostLimitUsd,

--- a/web/src/lib/prompt/langfuse/langfuse-prompt-provider.ts
+++ b/web/src/lib/prompt/langfuse/langfuse-prompt-provider.ts
@@ -1,6 +1,7 @@
 import type { Langfuse } from "langfuse";
 import type { PromptProvider } from "../interface/prompt-provider";
 import type { CompiledPrompt, PromptVariables } from "../interface/types";
+import { env } from "@/lib/env";
 
 export class LangfusePromptProvider implements PromptProvider {
   constructor(private client: Langfuse) {}
@@ -10,7 +11,9 @@ export class LangfusePromptProvider implements PromptProvider {
     variables?: PromptVariables
   ): Promise<CompiledPrompt> {
     try {
-      const fetchedPrompt = await this.client.getPrompt(name);
+      const fetchedPrompt = await this.client.getPrompt(name, undefined, {
+        label: env.langfuse.promptLabel,
+      });
 
       const content = fetchedPrompt.compile(variables || {});
 


### PR DESCRIPTION
- [x] LANGFUSE_PROMPT_LABEL を設定し production 以外の label で実験可能に

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Langfuse integration design and configuration documentation.

* **Chores**
  * Added LANGFUSE_PROMPT_LABEL environment variable to customize prompt labels in Langfuse (defaults to 'production').
  * Updated Langfuse prompt provider to apply the new labeling configuration during prompt retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->