### PR TITLE
TOPページのHTML titleタグを「みらい議会」から「みらい議会｜チームみらい」に変える

### DIFF
--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -22,45 +22,38 @@ const lexendGiga = Lexend_Giga({
   weight: ["400", "500", "700", "800", "900"],
 });
 
+const siteTitle = "みらい議会｜チームみらい";
+const siteDescription =
+  "国会で今どんな法案が検討されているか、わかりやすく伝えるプラットフォーム";
+const siteName = "みらい議会";
+const ogImage = {
+  url: "/ogp.jpg",
+  width: 1200,
+  height: 630,
+  alt: "みらい議会のOGPイメージ",
+};
+
 export const metadata: Metadata = {
   metadataBase: new URL(env.webUrl),
-  title: "みらい議会｜チームみらい",
-  description:
-    "国会で今どんな法案が検討されているか、わかりやすく伝えるプラットフォーム",
-  keywords: [
-    "みらい議会",
-    "議案",
-    "政治",
-    "日本",
-    "政策",
-    "解説",
-    "チームみらい",
-  ],
+  title: siteTitle,
+  description: siteDescription,
+  keywords: [siteName, "議案", "政治", "日本", "政策", "解説", "チームみらい"],
   icons: {
     icon: "/icons/pwa/icon_android_192.png",
     apple: "/icons/pwa/icon_ios.png",
   },
   manifest: "/manifest.json",
   openGraph: {
-    title: "みらい議会｜チームみらい",
-    description:
-      "国会で今どんな法案が検討されているか、わかりやすく伝えるプラットフォーム",
-    images: [
-      {
-        url: "/ogp.jpg",
-        width: 1200,
-        height: 630,
-        alt: "みらい議会のOGPイメージ",
-      },
-    ],
-    siteName: "みらい議会",
+    title: siteTitle,
+    description: siteDescription,
+    images: [ogImage],
+    siteName,
   },
   twitter: {
     card: "summary_large_image",
-    title: "みらい議会｜チームみらい",
-    description:
-      "国会で今どんな法案が検討されているか、わかりやすく伝えるプラットフォーム",
-    images: ["/ogp.jpg"],
+    title: siteTitle,
+    description: siteDescription,
+    images: [ogImage.url],
   },
   robots: {
     index: true,


### PR DESCRIPTION
fix title, refactor to constants

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated browser tab title and site description for refreshed branding.
  * Updated social media preview content — title, description, site name, and preview image — to ensure consistent sharing metadata across platforms.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->