### PR TITLE
コメント・理由が空欄のときは「コメント・理由」も非表示に

### DIFF
--- a/web/src/features/bills/components/bill-detail/mirai-stance-card.tsx
+++ b/web/src/features/bills/components/bill-detail/mirai-stance-card.tsx
@@ -51,6 +51,9 @@ export function MiraiStanceCard({ stance, billStatus }: MiraiStanceCardProps) {
   };
 
   const styles = getStanceStyles();
+  const comment = isPreparing
+    ? "法案提出後に賛否を表明します。"
+    : stance?.comment;
 
   return (
     <>
@@ -81,13 +84,11 @@ export function MiraiStanceCard({ stance, billStatus }: MiraiStanceCardProps) {
             </div>
 
             {/* コメント部分 */}
-            {(isPreparing || stance?.comment) && (
+            {comment != null && (
               <div className="flex flex-col gap-2">
                 <h3 className="text-lg font-bold">コメント・理由</h3>
                 <p className="text-base font-medium leading-relaxed whitespace-pre-wrap">
-                  {isPreparing
-                    ? "法案提出後に賛否を表明します。"
-                    : stance?.comment}
+                  {comment}
                 </p>
               </div>
             )}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The comment/reason section in bill details now only appears when there is content, preventing empty sections from showing.
  * When an item is marked as preparing, a default "preparing" message is shown in place of a missing comment for clearer status feedback.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->