### PR TITLE
ステータス表示修正

### DIFF
--- a/web/src/features/bills/components/bill-detail/bill-detail-header.tsx
+++ b/web/src/features/bills/components/bill-detail/bill-detail-header.tsx
@@ -2,6 +2,7 @@ import Image from "next/image";
 import { formatDateWithDots } from "@/lib/utils/date";
 import type { BillWithContent } from "../../types";
 import { getBillShareData } from "../../utils/share";
+import { BillStatusBadge } from "../bill-list/bill-status-badge";
 import { BillTag } from "../bill-list/bill-tag";
 import { BillDetailShareButton } from "./bill-detail-share-button";
 
@@ -32,10 +33,18 @@ export async function BillDetailHeader({ bill }: BillDetailHeaderProps) {
         <div className="w-full h-20 bg-white-100" />
       )}
 
-      <div className="px-4 pt-8">
+      <div className="px-4 pt-8 mb-3">
         {displayTitle && (
-          <h1 className="text-2xl font-bold mb-4">{displayTitle}</h1>
+          <h1 className="text-2xl font-bold mb-3">{displayTitle}</h1>
         )}
+        <div className="flex flex-row gap-4">
+          <BillStatusBadge status={bill.status} className="w-fit" />
+          <div className="flex items-center gap-2 text-xs font-medium text-muted-foreground">
+            {bill.published_at && (
+              <time>{formatDateWithDots(bill.published_at)} 提出</time>
+            )}
+          </div>
+        </div>
       </div>
 
       <div className="px-4 pb-8">
@@ -55,15 +64,6 @@ export async function BillDetailHeader({ bill }: BillDetailHeaderProps) {
         <p className="text-sm text-muted-foreground font-medium mb-4">
           {bill.name}
         </p>
-        <div className="font-bold text-xs text-muted-foreground mb-4">
-          {bill.published_at ? (
-            <time dateTime={bill.published_at}>
-              {formatDateWithDots(bill.published_at)} 提出
-            </time>
-          ) : (
-            <span>法案提出前</span>
-          )}
-        </div>
         <BillDetailShareButton
           shareMessage={shareMessage}
           shareUrl={shareUrl}

--- a/web/src/features/bills/components/bill-list/bill-card.tsx
+++ b/web/src/features/bills/components/bill-list/bill-card.tsx
@@ -51,10 +51,8 @@ export function BillCard({ bill }: BillCardProps) {
               <div className="flex flex-row gap-4">
                 <BillStatusBadge status={bill.status} className="w-fit" />
                 <div className="flex items-center gap-2 text-xs font-medium text-muted-foreground">
-                  {bill.published_at ? (
+                  {bill.published_at && (
                     <time>{formatDateWithDots(bill.published_at)} 提出</time>
-                  ) : (
-                    <span>法案提出前</span>
                   )}
                 </div>
               </div>


### PR DESCRIPTION
- 法案提出前が、二重に表示されてしまうのを修正
- 法案詳細ページにもステータスバッジを表示

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **UI Updates**
  * Reorganized bill header to display status badge and publication date in a more structured layout
  * Removed fallback placeholder text for unpublished bills
  * Improved rendering logic for date display in bill list and detail components

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->