### PR TITLE
レイアウトをページによって変更

### DIFF
--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -4,9 +4,9 @@ import { SpeedInsights } from "@vercel/speed-insights/next";
 import type { Metadata, Viewport } from "next";
 import { Lexend_Giga, Noto_Sans_JP } from "next/font/google";
 import NextTopLoader from "nextjs-toploader";
-import { useId } from "react";
 import { Header } from "@/components/header";
 import { Footer } from "@/components/layouts/footer/footer";
+import { MainLayout } from "@/components/layouts/main-layout";
 import { env } from "@/lib/env";
 import { RubyfulInitializer } from "@/lib/rubyful";
 
@@ -80,8 +80,6 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const mainContentId = useId();
-
   return (
     <html lang="ja">
       <body
@@ -92,19 +90,11 @@ export default function RootLayout({
         <GoogleAnalytics gaId={env.analytics.gaTrackingId ?? ""} />
         <RubyfulInitializer />
 
-        <div
-          // xlサイズでは、横幅1180px（メイン + チャット）の中央寄せにする
-          className="
-            relative max-w-[700px] mx-auto sm:shadow-lg md:mt-24
-            pc:mr-[500px] xl:ml-[calc(calc(100vw-1180px)/2)]
-          "
-        >
+        <MainLayout>
           <Header />
-          <main id={mainContentId} className="min-h-screen bg-[#F7F4F0]">
-            {children}
-          </main>
+          <main className="min-h-screen bg-[#F7F4F0]">{children}</main>
           <Footer />
-        </div>
+        </MainLayout>
       </body>
     </html>
   );

--- a/web/src/components/header/header-client.tsx
+++ b/web/src/components/header/header-client.tsx
@@ -2,8 +2,10 @@
 
 import Image from "next/image";
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import { DifficultySelector } from "@/features/bill-difficulty/components/difficulty-selector";
 import type { DifficultyLevelEnum } from "@/features/bill-difficulty/types";
+import { isMainPage } from "@/lib/page-layout-utils";
 import { HamburgerMenu } from "./hamburger-menu";
 
 interface HeaderClientProps {
@@ -11,6 +13,9 @@ interface HeaderClientProps {
 }
 
 export function HeaderClient({ difficultyLevel }: HeaderClientProps) {
+  const pathname = usePathname();
+  const showDifficultySelector = isMainPage(pathname);
+
   return (
     <header className="px-3 fixed top-4 left-0 right-0 z-10 max-w-[1440px] mx-auto">
       <div className="rounded-2xl bg-white shadow-sm mx-auto px-4 sm:px-6 lg:px-8">
@@ -37,7 +42,9 @@ export function HeaderClient({ difficultyLevel }: HeaderClientProps) {
             className="flex items-center space-x-2"
             aria-label="補助ナビゲーション"
           >
-            <DifficultySelector currentLevel={difficultyLevel} />
+            {showDifficultySelector && (
+              <DifficultySelector currentLevel={difficultyLevel} />
+            )}
             <HamburgerMenu />
           </nav>
         </div>

--- a/web/src/components/layouts/main-layout.tsx
+++ b/web/src/components/layouts/main-layout.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import type { ReactNode } from "react";
+import { isMainPage } from "@/lib/page-layout-utils";
+import { cn } from "@/lib/utils";
+
+interface MainLayoutProps {
+  children: ReactNode;
+}
+
+export function MainLayout({ children }: MainLayoutProps) {
+  const pathname = usePathname();
+  const useSidebarLayout = isMainPage(pathname);
+
+  return (
+    <div
+      className={cn(
+        "relative max-w-[700px] mx-auto sm:shadow-lg md:mt-24",
+        // TOPページと法案詳細ページのみ、チャットサイドバー用のオフセット
+        useSidebarLayout && "pc:mr-[500px] xl:ml-[calc(calc(100vw-1180px)/2)]"
+      )}
+    >
+      {children}
+    </div>
+  );
+}

--- a/web/src/lib/page-layout-utils.ts
+++ b/web/src/lib/page-layout-utils.ts
@@ -1,0 +1,16 @@
+/**
+ * ページレイアウトに関するユーティリティ
+ *
+ * TOPページと法案詳細ページは「メインページ」として扱い、
+ * - DifficultySelectorを表示
+ * - チャットサイドバー用のオフセットレイアウトを使用
+ */
+
+/** メインページ（TOP、法案詳細）かどうかを判定 */
+export function isMainPage(pathname: string): boolean {
+  // トップページ
+  if (pathname === "/") return true;
+  // 法案詳細ページ（/bills/[id]）- サブパスは除外
+  if (/^\/bills\/[^/]+$/.test(pathname)) return true;
+  return false;
+}


### PR DESCRIPTION
トップページと法案ページ以外で、
- 難易度切り替えボタンを非表示
- PCのメインコンテンツエリアを中央寄せ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Difficulty selector now intelligently displays based on page context, appearing on main pages and relevant sections while staying hidden elsewhere for a cleaner, more focused interface.

* **Refactor**
  * Improved layout component structure with enhanced responsive design capabilities and better management of dynamic page-specific sidebar adjustments and layout configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->