### PR TITLE
インタビューLPにセッションステータスを表示

### DIFF
--- a/web/src/features/interview-config/client/components/interview-lp-page.tsx
+++ b/web/src/features/interview-config/client/components/interview-lp-page.tsx
@@ -3,6 +3,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import type { BillWithContent } from "@/features/bills/shared/types";
+import { InterviewStatusBadge } from "@/features/interview-session/client/components/interview-status-badge";
 import type { LatestInterviewSession } from "@/features/interview-session/server/loaders/get-latest-interview-session";
 import type { InterviewConfig } from "../../server/loaders/get-interview-config";
 import { InterviewActionButtons } from "./interview-action-buttons";
@@ -77,6 +78,7 @@ function _InterviewLPHero({
             </span>
           </div>
         </Link>
+        {sessionInfo && <InterviewStatusBadge status={sessionInfo.status} />}
       </div>
 
       <div className="flex flex-col gap-4 w-full max-w-[334px] pl-4">

--- a/web/src/features/interview-session/client/components/interview-status-badge.tsx
+++ b/web/src/features/interview-session/client/components/interview-status-badge.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { cva } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+import type { InterviewSessionStatus } from "../../server/loaders/get-latest-interview-session";
+
+const interviewStatusBadgeVariants = cva(
+  "inline-flex items-center justify-center rounded px-3 py-1 text-sm font-medium",
+  {
+    variants: {
+      status: {
+        active: "bg-[#FFFD96] text-black",
+        completed: "bg-mirai-gradient text-black",
+      },
+    },
+  }
+);
+
+const statusLabels: Record<Exclude<InterviewSessionStatus, "none">, string> = {
+  active: "中断中",
+  completed: "回答完了",
+};
+
+interface InterviewStatusBadgeProps {
+  status: InterviewSessionStatus;
+  className?: string;
+}
+
+export function InterviewStatusBadge({
+  status,
+  className,
+}: InterviewStatusBadgeProps) {
+  if (status === "none") {
+    return null;
+  }
+
+  return (
+    <span className={cn(interviewStatusBadgeVariants({ status }), className)}>
+      {statusLabels[status]}
+    </span>
+  );
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Interview landing page now displays a session status indicator in the hero section. When an active session is present, the status badge shows whether the interview is active or completed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->