### PR TITLE
インタビュー開始時の挨拶に法案名を含める

### DIFF
--- a/web/src/features/interview-session/server/services/generate-initial-question.ts
+++ b/web/src/features/interview-session/server/services/generate-initial-question.ts
@@ -46,7 +46,8 @@ export async function generateInitialQuestion({
 
     // インタビュー開始の指示を追加（最初の質問にはクイックリプライとquestion_idを含める）
     const firstQuestionId = questions[0]?.id;
-    const enhancedSystemPrompt = `${systemPrompt}\n\n## 重要: これはインタビューの開始です。ユーザーからのメッセージはありません。事前定義質問の最初の質問から始めてください。挨拶は温かく丁寧に（2文程度）、すぐに最初の質問をしてください。最初の質問にクイックリプライが設定されている場合は、必ず quick_replies フィールドに含めてください。${firstQuestionId ? `最初の質問は ID: ${firstQuestionId} であり、レスポンスの question_id にこの値を含めてください。` : ""}`;
+    const billTitle = bill?.bill_content?.title ?? bill?.name ?? "この法案";
+    const enhancedSystemPrompt = `${systemPrompt}\n\n## 重要: これはインタビューの開始です。ユーザーからのメッセージはありません。事前定義質問の最初の質問から始めてください。挨拶は温かく丁寧に（2文程度）、「${billTitle}」についてのインタビューであることを明確に伝えた上で、すぐに最初の質問をしてください。最初の質問にクイックリプライが設定されている場合は、必ず quick_replies フィールドに含めてください。${firstQuestionId ? `最初の質問は ID: ${firstQuestionId} であり、レスポンスの question_id にこの値を含めてください。` : ""}`;
 
     // メッセージ履歴なしで最初の質問を生成（構造化出力）
     const result = await generateText({


### PR DESCRIPTION
Resolve GitHub issue #273
インタビュー開始時のシステムプロンプトを修正し、挨拶の際に法案名を明確に伝えるよう指示を追加。bill_content.title または bill.name を使用して法案名を取得する。