### PR TITLE
summaryフェーズからchatフェーズへの逆遷移を可能にする

### DIFF
--- a/web/src/features/interview-session/server/utils/interview-logic/bulk-mode.ts
+++ b/web/src/features/interview-session/server/utils/interview-logic/bulk-mode.ts
@@ -207,7 +207,7 @@ ${modeInstructions}
       stageGuidance = `現在のステージ: summary（要約フェーズ）
 - ユーザーがレポート内容に同意し、完了すべきと判断した場合は nextStage を "summary_complete" にしてください。
 - まだ修正や追加の要約が必要な場合は nextStage を "summary" にしてください。
-- 必ず summary → summary_complete の順に進むようにしてください。`;
+- ユーザーが明確にインタビューの再開や追加の質問への回答を希望した場合は nextStage を "chat" にしてください。`;
     } else {
       stageGuidance = `現在のステージ: summary_complete（完了済み）
 - このステージでは判定は不要です。nextStage を "summary_complete" にしてください。`;
@@ -255,7 +255,7 @@ ${remainingQuestionsList}
 
 ## 注意
 - JSON以外のテキストを出力しないでください。
-- ステージ遷移は必ず chat → summary → summary_complete の順に進むようにしてください。
+- 基本的なステージ遷移は chat → summary → summary_complete の順ですが、summaryフェーズでユーザーがインタビュー再開を希望した場合は chat に戻ることができます。
 `;
   },
 };

--- a/web/src/features/interview-session/server/utils/interview-logic/loop-mode.ts
+++ b/web/src/features/interview-session/server/utils/interview-logic/loop-mode.ts
@@ -150,7 +150,7 @@ ${modeInstructions}
       stageGuidance = `現在のステージ: summary（要約フェーズ）
 - ユーザーがレポート内容に同意し、完了すべきと判断した場合は nextStage を "summary_complete" にしてください。
 - まだ修正や追加の要約が必要な場合は nextStage を "summary" にしてください。
-- 必ず summary → summary_complete の順に進むようにしてください。`;
+- ユーザーが明確にインタビューの再開や追加の質問への回答を希望した場合は nextStage を "chat" にしてください。`;
     } else {
       stageGuidance = `現在のステージ: summary_complete（完了済み）
 - このステージでは判定は不要です。nextStage を "summary_complete" にしてください。`;
@@ -198,7 +198,7 @@ ${remainingQuestionsList}
 
 ## 注意
 - JSON以外のテキストを出力しないでください。
-- ステージ遷移は必ず chat → summary → summary_complete の順に進むようにしてください。
+- 基本的なステージ遷移は chat → summary → summary_complete の順ですが、summaryフェーズでユーザーがインタビュー再開を希望した場合は chat に戻ることができます。
 `;
   },
 };


### PR DESCRIPTION
- bulk-mode.ts: summaryステージでchatへの遷移を許可するプロンプトを追加
- loop-mode.ts: 同様のプロンプト修正
- use-interview-chat.ts: summaryフェーズでもファシリテーターAPIを呼び出すようにリファクタリング

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now resume their interview and continue answering additional questions from the summary stage.

* **Improvements**
  * Interview phase transitions are now more adaptive, enabling smoother navigation through the interview workflow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->