### PR TITLE
ポスティングイベント YAML管理機能の実装 (#1578)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "dev": "dotenv -e .env -- pnpm -r --stream --parallel run dev",
     "seed": "dotenv -e .env -- pnpm --filter @mirai-gikai/seed seed",
     "seed:csv": "dotenv -e .env -- pnpm --filter @mirai-gikai/seed seed:csv",
+    "posting:sync": "dotenv -e .env -- pnpm --filter @mirai-gikai/posting-data sync",
+    "posting:sync:dry": "dotenv -e .env -- pnpm --filter @mirai-gikai/posting-data sync:dry",
     "test": "pnpm -r --parallel run test",
     "typecheck": "pnpm -r run typecheck",
     "lint": "biome format . && biome lint .",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,6 +159,31 @@ importers:
         specifier: ^5.6.2
         version: 5.9.3
 
+  posting_data:
+    dependencies:
+      '@mirai-gikai/supabase':
+        specifier: workspace:*
+        version: link:../packages/supabase
+      '@supabase/supabase-js':
+        specifier: ^2.57.0
+        version: 2.74.0
+      commander:
+        specifier: ^13.1.0
+        version: 13.1.0
+      yaml:
+        specifier: ^2.8.0
+        version: 2.8.1
+    devDependencies:
+      '@types/node':
+        specifier: ^22.5.5
+        version: 22.18.8
+      tsx:
+        specifier: ^4.19.1
+        version: 4.20.6
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+
   web:
     dependencies:
       '@ai-sdk/openai':
@@ -5638,7 +5663,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 20.19.28
+      '@types/node': 22.18.8
 
   '@ungap/structured-clone@1.3.0': {}
 
@@ -7215,7 +7240,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 20.19.28
+      '@types/node': 22.18.8
       long: 5.3.2
 
   quansync@0.2.11: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,5 @@
 packages:
   - "packages/*"
+  - "posting_data"
   - "admin"
   - "web"

--- a/posting_data/package.json
+++ b/posting_data/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@mirai-gikai/posting-data",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "sync": "tsx src/sync.ts",
+    "sync:dry": "tsx src/sync.ts --dry-run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@mirai-gikai/supabase": "workspace:*",
+    "@supabase/supabase-js": "^2.57.0",
+    "commander": "^13.1.0",
+    "yaml": "^2.8.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.5.5",
+    "tsx": "^4.19.1",
+    "typescript": "^5.0.0"
+  }
+}

--- a/posting_data/posting_events.yaml
+++ b/posting_data/posting_events.yaml
@@ -1,0 +1,13 @@
+# ポスティングイベント定義
+# このファイルで定義されたイベントは `pnpm posting:sync` でデータベースに同期されます
+
+events:
+  - slug: "sample-event-2026"
+    title: "サンプルポスティングイベント2026"
+    description: "これはサンプルのポスティングイベントです。実際のイベントに置き換えてください。"
+    active: true
+
+  - slug: "inactive-event-example"
+    title: "非アクティブイベントサンプル"
+    description: "このイベントは非アクティブです。active: false に設定されています。"
+    active: false

--- a/posting_data/src/db.ts
+++ b/posting_data/src/db.ts
@@ -1,0 +1,15 @@
+import { createClient } from "@supabase/supabase-js";
+import type { Database } from "@mirai-gikai/supabase";
+
+export function createAdminClient() {
+  const supabaseUrl = process.env.SUPABASE_URL;
+  const supabaseServiceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!supabaseUrl || !supabaseServiceRoleKey) {
+    throw new Error(
+      "Missing environment variables: SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY"
+    );
+  }
+
+  return createClient<Database>(supabaseUrl, supabaseServiceRoleKey);
+}

--- a/posting_data/src/sync.ts
+++ b/posting_data/src/sync.ts
@@ -1,0 +1,91 @@
+import { program } from "commander";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { parse } from "yaml";
+import { createAdminClient } from "./db";
+import type { PostingEventsConfig } from "./types";
+
+// Note: posting_events table types will be available after running migration
+// and executing `pnpm db:types:gen`
+interface PostingEventRow {
+  slug: string;
+  title: string;
+  description: string | null;
+  active: boolean;
+}
+
+async function syncPostingEvents(dryRun: boolean): Promise<void> {
+  const yamlPath = resolve(import.meta.dirname, "..", "posting_events.yaml");
+  const yamlContent = readFileSync(yamlPath, "utf-8");
+  const config: PostingEventsConfig = parse(yamlContent);
+
+  if (!config.events || config.events.length === 0) {
+    console.log("No events found in YAML file");
+    return;
+  }
+
+  console.log(`Found ${config.events.length} events in YAML file`);
+
+  if (dryRun) {
+    console.log("\n[DRY RUN] Would sync the following events:\n");
+    for (const event of config.events) {
+      console.log(`  - ${event.slug}`);
+      console.log(`    Title: ${event.title}`);
+      console.log(`    Description: ${event.description || "(none)"}`);
+      console.log(`    Active: ${event.active}`);
+      console.log("");
+    }
+    console.log("[DRY RUN] No changes were made to the database.");
+    return;
+  }
+
+  const supabase = createAdminClient();
+
+  console.log("\nSyncing events to database...\n");
+
+  for (const event of config.events) {
+    const { slug, title, description, active } = event;
+
+    const row: PostingEventRow = {
+      slug,
+      title,
+      description: description || null,
+      active,
+    };
+
+    // Type assertion needed until migration is run and types are regenerated
+    const { error } = await (supabase as unknown as {
+      from: (table: string) => {
+        upsert: (
+          data: PostingEventRow,
+          options: { onConflict: string }
+        ) => Promise<{ error: { message: string } | null }>;
+      };
+    })
+      .from("posting_events")
+      .upsert(row, { onConflict: "slug" });
+
+    if (error) {
+      console.error(`Failed to sync event "${slug}":`, error.message);
+    } else {
+      console.log(`Synced: ${slug}`);
+    }
+  }
+
+  console.log("\nSync completed.");
+}
+
+program
+  .name("posting-sync")
+  .description("Sync posting events from YAML to database")
+  .option("--dry-run", "Show what would be synced without making changes")
+  .action(async (options: { dryRun?: boolean }) => {
+    try {
+      await syncPostingEvents(options.dryRun ?? false);
+    } catch (error) {
+      console.error("Error:", error);
+      process.exit(1);
+    }
+  });
+
+program.parse();

--- a/posting_data/src/types.ts
+++ b/posting_data/src/types.ts
@@ -1,0 +1,10 @@
+export interface PostingEvent {
+  slug: string;
+  title: string;
+  description?: string;
+  active: boolean;
+}
+
+export interface PostingEventsConfig {
+  events: PostingEvent[];
+}

--- a/posting_data/tsconfig.json
+++ b/posting_data/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/supabase/migrations/20260111000000_create_posting_events_table.sql
+++ b/supabase/migrations/20260111000000_create_posting_events_table.sql
@@ -1,0 +1,48 @@
+-- Create posting_events table for managing posting events via YAML sync
+CREATE TABLE IF NOT EXISTS posting_events (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  slug TEXT UNIQUE NOT NULL,
+  title TEXT NOT NULL,
+  description TEXT,
+  active BOOLEAN NOT NULL DEFAULT true,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Enable RLS
+ALTER TABLE posting_events ENABLE ROW LEVEL SECURITY;
+
+-- Policy for admin users to manage posting_events
+CREATE POLICY "Admin users can do all operations on posting_events"
+  ON posting_events
+  FOR ALL
+  TO authenticated
+  USING (is_admin())
+  WITH CHECK (is_admin());
+
+-- Policy for public read access to active posting events
+CREATE POLICY "Public can read active posting events"
+  ON posting_events
+  FOR SELECT
+  TO anon, authenticated
+  USING (active = true);
+
+-- Add index for slug lookups
+CREATE INDEX idx_posting_events_slug ON posting_events (slug);
+
+-- Add index for active events
+CREATE INDEX idx_posting_events_active ON posting_events (active);
+
+-- Add trigger to automatically update updated_at
+CREATE OR REPLACE FUNCTION update_posting_events_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trigger_update_posting_events_updated_at
+  BEFORE UPDATE ON posting_events
+  FOR EACH ROW
+  EXECUTE FUNCTION update_posting_events_updated_at();


### PR DESCRIPTION
- posting_data パッケージを新規作成
- posting_events テーブル用のマイグレーションを追加
- YAML からデータベースへの同期スクリプトを実装
- pnpm posting:sync / posting:sync:dry コマンドを追加

Resolves #1578

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added posting events management system with database synchronization capability
  * Introduced dry-run mode to preview event changes before applying them to the database
  * Events can now be configured via YAML configuration files

* **Chores**
  * Expanded workspace to include new posting data package
  * Added database migration to support posting events with role-based access controls and automatic timestamp tracking

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->