### PR TITLE
インタビュー設定にモード切り替え機能を追加

### DIFF
--- a/admin/src/features/interview-config/actions/upsert-interview-config.ts
+++ b/admin/src/features/interview-config/actions/upsert-interview-config.ts
@@ -57,6 +57,7 @@ export async function createInterviewConfig(
         bill_id: billId,
         name: validatedData.name,
         status: validatedData.status,
+        mode: validatedData.mode,
         themes: validatedData.themes || null,
         knowledge_source: validatedData.knowledge_source || null,
       })
@@ -126,6 +127,7 @@ export async function updateInterviewConfig(
       .update({
         name: validatedData.name,
         status: validatedData.status,
+        mode: validatedData.mode,
         themes: validatedData.themes || null,
         knowledge_source: validatedData.knowledge_source || null,
         updated_at: new Date().toISOString(),

--- a/admin/src/features/interview-config/components/interview-config-form.tsx
+++ b/admin/src/features/interview-config/components/interview-config-form.tsx
@@ -58,6 +58,7 @@ export function InterviewConfigForm({
     defaultValues: {
       name: config?.name || "",
       status: config?.status || "closed",
+      mode: config?.mode || "loop",
       themes: config?.themes || [],
       knowledge_source: config?.knowledge_source || "",
     },
@@ -198,6 +199,32 @@ export function InterviewConfigForm({
                     </Select>
                     <FormDescription>
                       インタビュー機能の有効/無効を設定します。公開設定は法案ごとに1つのみ可能です。
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="mode"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>インタビューモード</FormLabel>
+                    <Select onValueChange={field.onChange} value={field.value}>
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue placeholder="モードを選択" />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        <SelectItem value="loop">逐次深掘り（loop）</SelectItem>
+                        <SelectItem value="bulk">一括深掘り（bulk）</SelectItem>
+                      </SelectContent>
+                    </Select>
+                    <FormDescription>
+                      loop: 質問ごとに深掘り / bulk:
+                      事前定義質問を先にすべて消化してから深掘り
                     </FormDescription>
                     <FormMessage />
                   </FormItem>

--- a/admin/src/features/interview-config/types/index.ts
+++ b/admin/src/features/interview-config/types/index.ts
@@ -23,6 +23,7 @@ export const interviewConfigSchema = z.object({
     .min(1, "設定名は必須です")
     .max(100, "設定名は100文字以内で入力してください"),
   status: z.enum(["public", "closed"]),
+  mode: z.enum(["loop", "bulk"]),
   themes: z.array(z.string().min(1)).optional(),
   knowledge_source: z.string().optional(),
 });

--- a/packages/supabase/types/supabase.types.ts
+++ b/packages/supabase/types/supabase.types.ts
@@ -292,6 +292,7 @@ export type Database = {
           created_at: string
           id: string
           knowledge_source: string | null
+          mode: Database["public"]["Enums"]["interview_mode_enum"]
           name: string
           status: Database["public"]["Enums"]["interview_config_status_enum"]
           themes: string[] | null
@@ -302,6 +303,7 @@ export type Database = {
           created_at?: string
           id?: string
           knowledge_source?: string | null
+          mode?: Database["public"]["Enums"]["interview_mode_enum"]
           name: string
           status?: Database["public"]["Enums"]["interview_config_status_enum"]
           themes?: string[] | null
@@ -312,6 +314,7 @@ export type Database = {
           created_at?: string
           id?: string
           knowledge_source?: string | null
+          mode?: Database["public"]["Enums"]["interview_mode_enum"]
           name?: string
           status?: Database["public"]["Enums"]["interview_config_status_enum"]
           themes?: string[] | null
@@ -635,6 +638,7 @@ export type Database = {
       difficulty_level_enum: "normal" | "hard"
       house_enum: "HR" | "HC"
       interview_config_status_enum: "public" | "closed"
+      interview_mode_enum: "loop" | "bulk"
       interview_report_role_enum:
         | "subject_expert"
         | "work_related"
@@ -792,6 +796,7 @@ export const Constants = {
       difficulty_level_enum: ["normal", "hard"],
       house_enum: ["HR", "HC"],
       interview_config_status_enum: ["public", "closed"],
+      interview_mode_enum: ["loop", "bulk"],
       interview_report_role_enum: [
         "subject_expert",
         "work_related",

--- a/supabase/migrations/20260111133342_add_mode_to_interview_configs.sql
+++ b/supabase/migrations/20260111133342_add_mode_to_interview_configs.sql
@@ -1,0 +1,12 @@
+-- Add interview mode to interview_configs
+-- Modes: loop (逐次深掘り) and bulk (一括深掘り)
+
+-- Step 1: Create enum type for interview mode
+CREATE TYPE interview_mode_enum AS ENUM ('loop', 'bulk');
+
+-- Step 2: Add mode column with default value 'loop'
+ALTER TABLE interview_configs
+ADD COLUMN mode interview_mode_enum NOT NULL DEFAULT 'loop';
+
+-- Step 3: Add comment for documentation
+COMMENT ON COLUMN interview_configs.mode IS 'インタビューモード: loop（逐次深掘り）または bulk（一括深掘り）';

--- a/web/src/features/interview-session/server/services/handle-interview-chat-request.ts
+++ b/web/src/features/interview-session/server/services/handle-interview-chat-request.ts
@@ -17,7 +17,6 @@ import type { InterviewChatRequestParams } from "@/features/interview-session/sh
 import { AI_MODELS } from "@/lib/ai/models";
 import { logger } from "@/lib/logger";
 import { injectJsonFields } from "@/lib/stream/inject-json-fields";
-import { GLOBAL_INTERVIEW_MODE } from "../../shared/constants";
 import {
   buildInterviewSystemPrompt,
   buildSummarySystemPrompt,
@@ -82,8 +81,8 @@ export async function handleInterviewChatRequest({
   // 事前定義質問を取得
   const questions = await getInterviewQuestions(interviewConfig.id);
 
-  // モードに応じたロジックを取得
-  const mode = GLOBAL_INTERVIEW_MODE;
+  // モードに応じたロジックを取得（DBの設定を使用）
+  const mode = interviewConfig.mode;
   const logic = modeLogicMap[mode] ?? bulkModeLogic;
 
   // DBから最新を含む全メッセージを取得

--- a/web/src/features/interview-session/server/utils/build-interview-system-prompt.ts
+++ b/web/src/features/interview-session/server/utils/build-interview-system-prompt.ts
@@ -3,7 +3,6 @@ import "server-only";
 import type { BillWithContent } from "@/features/bills/shared/types";
 import type { getInterviewConfig } from "@/features/interview-config/server/loaders/get-interview-config";
 import type { getInterviewQuestions } from "@/features/interview-config/server/loaders/get-interview-questions";
-import { GLOBAL_INTERVIEW_MODE } from "../../shared/constants";
 import { bulkModeLogic } from "./interview-logic/bulk-mode";
 import { loopModeLogic } from "./interview-logic/loop-mode";
 
@@ -28,7 +27,8 @@ export function buildInterviewSystemPrompt({
   questions: Awaited<ReturnType<typeof getInterviewQuestions>>;
   nextQuestionId?: string;
 }): string {
-  const mode = GLOBAL_INTERVIEW_MODE;
+  // DBの設定からモードを取得
+  const mode = interviewConfig?.mode ?? "loop";
   const logic = modeLogicMap[mode] ?? bulkModeLogic;
 
   return logic.buildSystemPrompt({

--- a/web/src/features/interview-session/shared/constants.ts
+++ b/web/src/features/interview-session/shared/constants.ts
@@ -1,8 +1,1 @@
 export type InterviewMode = "loop" | "bulk";
-
-/**
- * 現在のインタビューモードをハードコードで設定します。
- * - loop: 逐次深掘りモード（通常）
- * - bulk: 一括深掘りモード（事前定義質問を先にすべて消化）
- */
-export const GLOBAL_INTERVIEW_MODE: InterviewMode = "loop";


### PR DESCRIPTION
- interview_configs テーブルに mode カラムを追加（loop/bulk）
- 管理画面にモード選択ドロップダウンを追加
- ハードコードされた GLOBAL_INTERVIEW_MODE を DB 設定に置き換え
- Supabase 型定義を更新

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-interview configurable "mode" with options "loop" and "bulk", editable in the admin form and stored in the database (default: "loop").
  * Interview handling now respects each configuration's selected mode, so sessions follow the configured behavior rather than a single global setting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->