### PR TITLE
Admin議案一覧をカードビューからテーブルビューに変更

### DIFF
--- a/admin/src/features/bills/components/bill-list/bill-list.tsx
+++ b/admin/src/features/bills/components/bill-list/bill-list.tsx
@@ -1,21 +1,15 @@
-import {
-  BarChart3,
-  Calendar,
-  Edit,
-  FileText,
-  MessageCircle,
-  Plus,
-} from "lucide-react";
+import { BarChart3, Edit, FileText, MessageCircle, Plus } from "lucide-react";
 import Link from "next/link";
 
 import { Button } from "@/components/ui/button";
 import {
-  Card,
-  CardContent,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
 import { BILL_STATUS_CONFIG } from "../../constants/bill-config";
 import { getBills } from "../../loaders/get-bills";
 import type { Bill, BillStatus } from "../../types";
@@ -36,94 +30,10 @@ function StatusBadge({
   const Icon = config.icon;
 
   return (
-    <div
-      className={`inline-flex items-center gap-1.5 py-1 rounded-full text-sm font-bold`}
-    >
+    <div className="inline-flex items-center gap-1.5 py-1 rounded-full text-sm font-bold">
       <Icon className="h-4 w-4" />
       <span>{getBillStatusLabel(status, originatingHouse)}</span>
     </div>
-  );
-}
-
-function BillCard({ bill }: { bill: Bill }) {
-  return (
-    <Card>
-      <CardHeader>
-        <div className="flex flex-row justify-between items-center gap-3">
-          <CardTitle className="text-lg font-semibold text-gray-900 leading-6">
-            {bill.name}
-          </CardTitle>
-          <BillActionsMenu billId={bill.id} billName={bill.name} />
-        </div>
-        <div className="flex flex-none flex-wrap gap-2">
-          <PublishStatusBadge
-            billId={bill.id}
-            publishStatus={bill.publish_status}
-          />
-          {(bill.publish_status === "draft" ||
-            bill.publish_status === "coming_soon") && (
-            <PreviewButton billId={bill.id} />
-          )}
-          {bill.publish_status === "published" && (
-            <ViewButton billId={bill.id} />
-          )}
-        </div>
-      </CardHeader>
-      <CardContent>
-        <div className="text-sm">
-          <div className="mb-2 flex items-center gap-2">
-            <StatusBadge
-              status={bill.status}
-              originatingHouse={bill.originating_house}
-            />
-            <div className="font-medium text-gray-900">
-              {bill.status_note || "-"}
-            </div>
-          </div>
-          <div className="">
-            <span className="text-gray-500 flex items-center gap-1">
-              <Calendar className="h-4 w-4" />
-              公開日:
-              <span className="font-medium text-gray-900">
-                {bill.published_at
-                  ? new Date(bill.published_at).toLocaleDateString("ja-JP")
-                  : "-"}
-              </span>
-            </span>
-          </div>
-        </div>
-      </CardContent>
-      <CardFooter>
-        <div className="flex flex-col sm:flex-row items-start sm:items-center gap-2">
-          <div className="flex items-center gap-2">
-            <Link href={`/bills/${bill.id}/edit`}>
-              <Button variant="outline" size="sm">
-                <Edit className="h-4 w-4 mr-1" />
-                基本情報
-              </Button>
-            </Link>
-            <Link href={`/bills/${bill.id}/contents/edit`}>
-              <Button variant="outline" size="sm">
-                <FileText className="h-4 w-4 mr-1" />
-                コンテンツ
-              </Button>
-            </Link>
-            <Link href={`/bills/${bill.id}/interview/edit`}>
-              <Button variant="outline" size="sm">
-                <MessageCircle className="h-4 w-4 mr-1" />
-                インタビュー設定
-              </Button>
-            </Link>
-            <Link href={`/bills/${bill.id}/reports`}>
-              <Button variant="outline" size="sm">
-                <BarChart3 className="h-4 w-4 mr-1" />
-                レポート一覧
-              </Button>
-            </Link>
-          </div>
-        </div>
-      </CardFooter>
-    </Card>
   );
 }
 
@@ -142,11 +52,90 @@ export async function BillList() {
         </Link>
       </div>
 
-      <div className="space-y-4">
-        {bills.map((bill) => (
-          <BillCard key={bill.id} bill={bill} />
-        ))}
+      <div className="rounded-md border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="min-w-[240px]">議案名</TableHead>
+              <TableHead>公開ステータス</TableHead>
+              <TableHead>審議ステータス</TableHead>
+              <TableHead>公開日</TableHead>
+              <TableHead>操作</TableHead>
+              <TableHead className="w-[50px]" />
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {bills.map((bill) => (
+              <BillRow key={bill.id} bill={bill} />
+            ))}
+          </TableBody>
+        </Table>
       </div>
     </div>
+  );
+}
+
+function BillRow({ bill }: { bill: Bill }) {
+  return (
+    <TableRow>
+      <TableCell className="font-medium">{bill.name}</TableCell>
+      <TableCell>
+        <div className="flex items-center gap-2">
+          <PublishStatusBadge
+            billId={bill.id}
+            publishStatus={bill.publish_status}
+          />
+          {(bill.publish_status === "draft" ||
+            bill.publish_status === "coming_soon") && (
+            <PreviewButton billId={bill.id} />
+          )}
+          {bill.publish_status === "published" && (
+            <ViewButton billId={bill.id} />
+          )}
+        </div>
+      </TableCell>
+      <TableCell>
+        <StatusBadge
+          status={bill.status}
+          originatingHouse={bill.originating_house}
+        />
+      </TableCell>
+      <TableCell className="text-gray-600">
+        {bill.published_at
+          ? new Date(bill.published_at).toLocaleDateString("ja-JP")
+          : "-"}
+      </TableCell>
+      <TableCell>
+        <div className="flex items-center gap-1">
+          <Link href={`/bills/${bill.id}/edit`}>
+            <Button variant="outline" size="sm">
+              <Edit className="h-4 w-4 mr-1" />
+              基本情報
+            </Button>
+          </Link>
+          <Link href={`/bills/${bill.id}/contents/edit`}>
+            <Button variant="outline" size="sm">
+              <FileText className="h-4 w-4 mr-1" />
+              コンテンツ
+            </Button>
+          </Link>
+          <Link href={`/bills/${bill.id}/interview/edit`}>
+            <Button variant="outline" size="sm">
+              <MessageCircle className="h-4 w-4 mr-1" />
+              インタビュー設定
+            </Button>
+          </Link>
+          <Link href={`/bills/${bill.id}/reports`}>
+            <Button variant="outline" size="sm">
+              <BarChart3 className="h-4 w-4 mr-1" />
+              レポート一覧
+            </Button>
+          </Link>
+        </div>
+      </TableCell>
+      <TableCell>
+        <BillActionsMenu billId={bill.id} billName={bill.name} />
+      </TableCell>
+    </TableRow>
   );
 }


### PR DESCRIPTION
## Summary
- Admin画面の議案一覧をカードレイアウトからshadcn/uiのTableコンポーネントを使用したテーブルレイアウトに変更
- テーブル列: 議案名、公開ステータス、審議ステータス、公開日、操作ボタン、アクションメニュー
- 既存の公開ステータス変更、プレビュー、各種編集ボタンなどの機能はそのまま維持

## Test plan
- [ ] `pnpm dev` でAdmin画面を起動し、議案一覧ページ (`/bills`) がテーブル表示になっていることを確認
- [ ] 公開ステータスの変更（下書き・Coming Soon・公開中）が正常に動作すること
- [ ] プレビュー/公開ページを見るボタンが正常に動作すること
- [ ] 基本情報・コンテンツ・インタビュー設定・レポート一覧への遷移が正常に動作すること
- [ ] 複製・削除のアクションメニューが正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Redesigned bill list layout from cards to a table format with organized columns for bill name, publish status, review status, publication date, and actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->