### PR TITLE
Admin議案一覧テーブルに国会会期列を追加

### DIFF
--- a/admin/src/features/bills/components/bill-list/bill-list.tsx
+++ b/admin/src/features/bills/components/bill-list/bill-list.tsx
@@ -12,7 +12,7 @@ import {
 } from "@/components/ui/table";
 import { BILL_STATUS_CONFIG } from "../../constants/bill-config";
 import { getBills } from "../../loaders/get-bills";
-import type { Bill, BillStatus } from "../../types";
+import type { BillStatus, BillWithDietSession } from "../../types";
 import { getBillStatusLabel } from "../../types";
 import { BillActionsMenu } from "../bill-actions-menu/bill-actions-menu";
 import { PreviewButton } from "./preview-button";
@@ -24,7 +24,7 @@ function StatusBadge({
   originatingHouse,
 }: {
   status: BillStatus;
-  originatingHouse: Bill["originating_house"];
+  originatingHouse: BillWithDietSession["originating_house"];
 }) {
   const config = BILL_STATUS_CONFIG[status];
   const Icon = config.icon;
@@ -57,6 +57,7 @@ export async function BillList() {
           <TableHeader>
             <TableRow>
               <TableHead className="min-w-[240px]">議案名</TableHead>
+              <TableHead>国会会期</TableHead>
               <TableHead>公開ステータス</TableHead>
               <TableHead>審議ステータス</TableHead>
               <TableHead>公開日</TableHead>
@@ -75,10 +76,13 @@ export async function BillList() {
   );
 }
 
-function BillRow({ bill }: { bill: Bill }) {
+function BillRow({ bill }: { bill: BillWithDietSession }) {
   return (
     <TableRow>
       <TableCell className="font-medium">{bill.name}</TableCell>
+      <TableCell className="text-gray-600">
+        {bill.diet_sessions?.name ?? "-"}
+      </TableCell>
       <TableCell>
         <div className="flex items-center gap-2">
           <PublishStatusBadge

--- a/admin/src/features/bills/loaders/get-bills.ts
+++ b/admin/src/features/bills/loaders/get-bills.ts
@@ -1,12 +1,12 @@
 import { createAdminClient } from "@mirai-gikai/supabase";
-import type { Bill } from "../types";
+import type { BillWithDietSession } from "../types";
 
-export async function getBills(): Promise<Bill[]> {
+export async function getBills(): Promise<BillWithDietSession[]> {
   const supabase = createAdminClient();
 
   const { data, error } = await supabase
     .from("bills")
-    .select("*")
+    .select("*, diet_sessions(name)")
     .order("created_at", { ascending: false });
 
   if (error) {

--- a/admin/src/features/bills/types/index.ts
+++ b/admin/src/features/bills/types/index.ts
@@ -13,6 +13,10 @@ export type BillWithContent = Bill & {
   bill_content?: Database["public"]["Tables"]["bill_contents"]["Row"];
 };
 
+export type BillWithDietSession = Bill & {
+  diet_sessions: { name: string } | null;
+};
+
 // House display mapping
 export const HOUSE_LABELS: Record<OriginatingHouse, string> = {
   HR: "衆議院",


### PR DESCRIPTION
## Summary
- `getBills` loaderで `diet_sessions` テーブルをjoinし、国会会期名を取得するように変更
- `BillWithDietSession` 型を新規追加
- 議案一覧テーブルに「国会会期」列を追加（議案名の隣に配置）
- 国会会期が未設定の議案は「-」と表示

**Note:** このPRは #291 (テーブルビュー変更) の内容を含んでいます。#291 を先にマージしてください。

## Test plan
- [ ] `pnpm dev` でAdmin画面を起動し、議案一覧に国会会期列が表示されていることを確認
- [ ] 国会会期が設定されている議案で会期名が正しく表示されること
- [ ] 国会会期が未設定の議案で「-」が表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)