### PR TITLE
議案一覧テーブルのUI改善

### DIFF
--- a/admin/src/features/bills/components/bill-actions-menu/bill-actions-menu.tsx
+++ b/admin/src/features/bills/components/bill-actions-menu/bill-actions-menu.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { MoreVertical } from "lucide-react";
+import {
+  BarChart3,
+  Edit,
+  FileText,
+  MessageCircle,
+  MoreVertical,
+} from "lucide-react";
+import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import {
   Popover,
@@ -23,8 +30,33 @@ export function BillActionsMenu({ billId, billName }: BillActionsMenuProps) {
           <MoreVertical className="h-4 w-4" />
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-40 p-1" align="end">
+      <PopoverContent className="w-48 p-1" align="end">
         <div className="flex flex-col">
+          <Link href={`/bills/${billId}/edit`}>
+            <Button variant="ghost" size="sm" className="w-full justify-start">
+              <Edit className="h-4 w-4 mr-2" />
+              基本情報
+            </Button>
+          </Link>
+          <Link href={`/bills/${billId}/contents/edit`}>
+            <Button variant="ghost" size="sm" className="w-full justify-start">
+              <FileText className="h-4 w-4 mr-2" />
+              コンテンツ
+            </Button>
+          </Link>
+          <Link href={`/bills/${billId}/interview/edit`}>
+            <Button variant="ghost" size="sm" className="w-full justify-start">
+              <MessageCircle className="h-4 w-4 mr-2" />
+              インタビュー設定
+            </Button>
+          </Link>
+          <Link href={`/bills/${billId}/reports`}>
+            <Button variant="ghost" size="sm" className="w-full justify-start">
+              <BarChart3 className="h-4 w-4 mr-2" />
+              レポート一覧
+            </Button>
+          </Link>
+          <div className="my-1 border-t" />
           <DuplicateBillButton billId={billId} billName={billName} />
           <DeleteBillButton billId={billId} billName={billName} />
         </div>

--- a/admin/src/features/bills/components/bill-list/bill-list.tsx
+++ b/admin/src/features/bills/components/bill-list/bill-list.tsx
@@ -1,4 +1,4 @@
-import { BarChart3, Edit, FileText, MessageCircle, Plus } from "lucide-react";
+import { Plus } from "lucide-react";
 import Link from "next/link";
 
 import { Button } from "@/components/ui/button";
@@ -52,16 +52,15 @@ export async function BillList() {
         </Link>
       </div>
 
-      <div className="rounded-md border">
+      <div className="rounded-md border bg-white">
         <Table>
           <TableHeader>
             <TableRow>
-              <TableHead className="min-w-[240px]">議案名</TableHead>
+              <TableHead>議案名</TableHead>
               <TableHead>国会会期</TableHead>
               <TableHead>公開ステータス</TableHead>
               <TableHead>審議ステータス</TableHead>
               <TableHead>公開日</TableHead>
-              <TableHead>操作</TableHead>
               <TableHead className="w-[50px]" />
             </TableRow>
           </TableHeader>
@@ -79,7 +78,14 @@ export async function BillList() {
 function BillRow({ bill }: { bill: BillWithDietSession }) {
   return (
     <TableRow>
-      <TableCell className="font-medium">{bill.name}</TableCell>
+      <TableCell className="max-w-[400px]">
+        <Link
+          href={`/bills/${bill.id}/edit`}
+          className="block truncate font-medium text-blue-600 hover:text-blue-800 hover:underline"
+        >
+          {bill.name}
+        </Link>
+      </TableCell>
       <TableCell className="text-gray-600">
         {bill.diet_sessions?.name ?? "-"}
       </TableCell>
@@ -108,34 +114,6 @@ function BillRow({ bill }: { bill: BillWithDietSession }) {
         {bill.published_at
           ? new Date(bill.published_at).toLocaleDateString("ja-JP")
           : "-"}
-      </TableCell>
-      <TableCell>
-        <div className="flex items-center gap-1">
-          <Link href={`/bills/${bill.id}/edit`}>
-            <Button variant="outline" size="sm">
-              <Edit className="h-4 w-4 mr-1" />
-              基本情報
-            </Button>
-          </Link>
-          <Link href={`/bills/${bill.id}/contents/edit`}>
-            <Button variant="outline" size="sm">
-              <FileText className="h-4 w-4 mr-1" />
-              コンテンツ
-            </Button>
-          </Link>
-          <Link href={`/bills/${bill.id}/interview/edit`}>
-            <Button variant="outline" size="sm">
-              <MessageCircle className="h-4 w-4 mr-1" />
-              インタビュー設定
-            </Button>
-          </Link>
-          <Link href={`/bills/${bill.id}/reports`}>
-            <Button variant="outline" size="sm">
-              <BarChart3 className="h-4 w-4 mr-1" />
-              レポート一覧
-            </Button>
-          </Link>
-        </div>
       </TableCell>
       <TableCell>
         <BillActionsMenu billId={bill.id} billName={bill.name} />


### PR DESCRIPTION
## Summary
- テーブル背景を白色に変更
- 議案名が長い場合は省略記号(…)で切り詰め（最大幅400px）
- 議案名をクリックで基本情報編集ページへ遷移（青色リンクスタイル）
- 操作ボタン（基本情報・コンテンツ・インタビュー設定・レポート一覧）をアクションメニュー（⋮）に統合し、横スクロールなしで全操作にアクセス可能に

## Test plan
- [ ] `pnpm dev` でAdmin画面の議案一覧を表示し、テーブル背景が白色であること
- [ ] 長い議案名が省略記号で切り詰められること
- [ ] 議案名クリックで基本情報編集ページに遷移すること
- [ ] ⋮メニューから基本情報・コンテンツ・インタビュー設定・レポート一覧にアクセスできること
- [ ] ⋮メニューから複製・削除が引き続き動作すること
- [ ] 横スクロールなしで全列が表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)