### PR TITLE
議案タイトルリンクの文字色を黒色に変更

### DIFF
--- a/admin/src/features/bills/components/bill-list/bill-list.tsx
+++ b/admin/src/features/bills/components/bill-list/bill-list.tsx
@@ -81,7 +81,7 @@ function BillRow({ bill }: { bill: BillWithDietSession }) {
       <TableCell className="max-w-[400px]">
         <Link
           href={`/bills/${bill.id}/edit`}
-          className="block truncate font-medium text-blue-600 hover:text-blue-800 hover:underline"
+          className="block truncate font-medium hover:underline"
         >
           {bill.name}
         </Link>


### PR DESCRIPTION
## Summary
- 議案一覧テーブルの議案名リンクの文字色を青色から黒色に変更
- ホバー時の下線表示は維持

## Test plan
- [ ] `pnpm dev` でAdmin議案一覧を表示し、議案名が黒色で表示されること
- [ ] 議案名ホバー時に下線が表示されること
- [ ] 議案名クリックで基本情報編集ページに遷移すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)