### PR TITLE
管理画面の議案アクションメニューのインタビュー設定リンクを修正

### DIFF
--- a/admin/src/features/bills/components/bill-actions-menu/bill-actions-menu.tsx
+++ b/admin/src/features/bills/components/bill-actions-menu/bill-actions-menu.tsx
@@ -44,7 +44,7 @@ export function BillActionsMenu({ billId, billName }: BillActionsMenuProps) {
               コンテンツ
             </Button>
           </Link>
-          <Link href={`/bills/${billId}/interview/edit`}>
+          <Link href={`/bills/${billId}/interview`}>
             <Button variant="ghost" size="sm" className="w-full justify-start">
               <MessageCircle className="h-4 w-4 mr-2" />
               インタビュー設定


### PR DESCRIPTION
## Summary
- 議案一覧のアクションメニュー「インタビュー設定」のリンクが旧パス(`/interview/edit`)のままで404になっていた問題を修正
- 複数インタビューコンフィグ対応後の正しいパス(`/interview` = 一覧ページ)に変更

## Test plan
- [ ] 管理画面の議案一覧でアクションメニューの「インタビュー設定」をクリックし、インタビューコンフィグ一覧ページに遷移することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)