### PR TITLE
管理画面のインタビュー設定に複製機能を追加

### DIFF
--- a/admin/src/features/interview-config/components/interview-config-list.tsx
+++ b/admin/src/features/interview-config/components/interview-config-list.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Pencil, Plus, Trash2 } from "lucide-react";
+import { Copy, Pencil, Plus, Trash2 } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
@@ -20,7 +20,10 @@ import {
 } from "@/components/ui/alert-dialog";
 import { Badge } from "@/components/ui/badge";
 import type { InterviewConfig } from "../types";
-import { deleteInterviewConfig } from "../actions/upsert-interview-config";
+import {
+  deleteInterviewConfig,
+  duplicateInterviewConfig,
+} from "../actions/upsert-interview-config";
 
 interface InterviewConfigListProps {
   billId: string;
@@ -36,6 +39,25 @@ export function InterviewConfigList({
     null
   );
   const [isDeleting, setIsDeleting] = useState(false);
+  const [isDuplicating, setIsDuplicating] = useState<string | null>(null);
+
+  const handleDuplicate = async (configId: string) => {
+    setIsDuplicating(configId);
+    try {
+      const result = await duplicateInterviewConfig(configId);
+      if (result.success) {
+        toast.success("インタビュー設定を複製しました");
+        router.push(`/bills/${billId}/interview/${result.data.id}/edit`);
+      } else {
+        toast.error(result.error || "複製に失敗しました");
+      }
+    } catch (error) {
+      console.error("Duplicate interview config error:", error);
+      toast.error("予期しないエラーが発生しました");
+    } finally {
+      setIsDuplicating(null);
+    }
+  };
 
   const handleDelete = async () => {
     if (!deleteTarget) return;
@@ -107,6 +129,15 @@ export function InterviewConfigList({
                         編集
                       </Button>
                     </Link>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => handleDuplicate(config.id)}
+                      disabled={isDuplicating === config.id}
+                    >
+                      <Copy className="mr-2 h-4 w-4" />
+                      {isDuplicating === config.id ? "複製中..." : "複製"}
+                    </Button>
                     <Button
                       variant="outline"
                       size="sm"


### PR DESCRIPTION
## Summary
- インタビュー設定一覧に「複製」ボタンを追加
- 複製時、設定内容（名前、モード、テーマ、ナレッジソース）と全質問をコピー
- 複製された設定は「非公開」状態で作成され、名前に「（コピー）」が付与される
- 複製完了後、新しい設定の編集画面に自動遷移

## Test plan
- [ ] インタビュー設定一覧で「複製」ボタンが表示されること
- [ ] 複製ボタンクリック後、設定と質問がコピーされること
- [ ] 複製された設定のステータスが「非公開」になること
- [ ] 複製完了後、新しい設定の編集画面に遷移すること
- [ ] 質問のないインタビュー設定も正しく複製できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to duplicate interview configurations with a new copy button per configuration
  * Duplicated configurations automatically maintain existing settings
  * Users are navigated to the newly created configuration upon successful duplication
  * Success and error notifications provide feedback on the duplication outcome

<!-- end of auto-generated comment: release notes by coderabbit.ai -->