### PR TITLE
管理画面の公開ステータスバッジの幅を統一

### DIFF
--- a/admin/src/features/bills/components/bill-list/publish-status-badge.tsx
+++ b/admin/src/features/bills/components/bill-list/publish-status-badge.tsx
@@ -77,7 +77,7 @@ export function PublishStatusBadge({
         <Button
           variant="ghost"
           size="sm"
-          className={`inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-sm font-medium border-2 hover:opacity-80 ${currentConfig.badgeClass}`}
+          className={`inline-flex items-center justify-center gap-1.5 px-3 py-1 rounded-full text-sm font-medium border-2 hover:opacity-80 min-w-[152px] ${currentConfig.badgeClass}`}
         >
           <CurrentIcon className="h-4 w-4" />
           <span>{currentConfig.label}</span>


### PR DESCRIPTION
## Summary
- 議案一覧の公開ステータスバッジ（下書き / Coming Soon / 公開中）に `min-w-[152px]` と `justify-center` を追加し、すべてのステータスで同じ幅で表示されるように統一

## Test plan
- [ ] 管理画面の議案一覧で「下書き」「Coming Soon」「公開中」の各バッジが同じ幅で表示されることを確認
- [ ] バッジのポップオーバーが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)