### PR TITLE
議案一覧の公開ページボタンのラベルを短縮

### DIFF
--- a/admin/src/features/bills/components/bill-list/view-button.tsx
+++ b/admin/src/features/bills/components/bill-list/view-button.tsx
@@ -18,7 +18,7 @@ export function ViewButton({ billId }: ViewButtonProps) {
       onClick={() => window.open(billUrl, "_blank")}
     >
       <ExternalLink className="h-4 w-4" />
-      公開ページを見る
+      公開ページ
     </Button>
   );
 }


### PR DESCRIPTION
## Summary
- 議案一覧の公開ページボタンのラベルを「公開ページを見る」から「公開ページ」に短縮し、テーブルの横幅を節約

## Test plan
- [ ] 管理画面の議案一覧で公開中の議案の「公開ページ」ボタンが正しく表示されることを確認
- [ ] ボタンクリックで公開ページが新しいタブで開くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)