### PR TITLE
プログレスバーの進捗計算を純粋関数に切り出しテストを追加

### DIFF
--- a/web/src/features/interview-session/client/utils/calc-interview-progress.test.ts
+++ b/web/src/features/interview-session/client/utils/calc-interview-progress.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import { calcInterviewProgress } from "./calc-interview-progress";
+
+describe("calcInterviewProgress", () => {
+  describe("totalQuestionsが未定義または0の場合", () => {
+    it("undefinedならnullを返す", () => {
+      expect(calcInterviewProgress(undefined, "chat", [])).toBeNull();
+    });
+
+    it("0ならnullを返す", () => {
+      expect(calcInterviewProgress(0, "chat", [])).toBeNull();
+    });
+  });
+
+  describe("summary_completeステージ", () => {
+    it("100%を返す", () => {
+      const result = calcInterviewProgress(5, "summary_complete", []);
+      expect(result).toEqual({
+        percentage: 100,
+        currentTopic: null,
+        showSkip: false,
+      });
+    });
+  });
+
+  describe("summaryステージ", () => {
+    it("90%固定を返す", () => {
+      const result = calcInterviewProgress(5, "summary", []);
+      expect(result).toEqual({
+        percentage: 90,
+        currentTopic: null,
+        showSkip: false,
+      });
+    });
+  });
+
+  describe("chatステージ", () => {
+    it("質問が未開始なら0%", () => {
+      const result = calcInterviewProgress(5, "chat", []);
+      expect(result).toEqual({
+        percentage: 0,
+        currentTopic: null,
+        showSkip: true,
+      });
+    });
+
+    it("1つ目の質問を聞いている最中は0%（現在の質問は完了扱いしない）", () => {
+      const messages = [
+        { role: "assistant" as const, questionId: "q1", topicTitle: "経済" },
+      ];
+      const result = calcInterviewProgress(5, "chat", messages);
+      expect(result).toEqual({
+        percentage: 0,
+        currentTopic: "経済",
+        showSkip: true,
+      });
+    });
+
+    it("2問目に進んだら1問完了で16%（1/5 × 80）", () => {
+      const messages = [
+        { role: "assistant" as const, questionId: "q1", topicTitle: "経済" },
+        { role: "user" as const },
+        {
+          role: "assistant" as const,
+          questionId: "q2",
+          topicTitle: "社会保障",
+        },
+      ];
+      const result = calcInterviewProgress(5, "chat", messages);
+      expect(result).toEqual({
+        percentage: 16,
+        currentTopic: "社会保障",
+        showSkip: true,
+      });
+    });
+
+    it("5問中4問完了で64%（4/5 × 80）", () => {
+      const messages = [
+        { role: "assistant" as const, questionId: "q1", topicTitle: "テーマ1" },
+        { role: "user" as const },
+        { role: "assistant" as const, questionId: "q2", topicTitle: "テーマ2" },
+        { role: "user" as const },
+        { role: "assistant" as const, questionId: "q3", topicTitle: "テーマ3" },
+        { role: "user" as const },
+        { role: "assistant" as const, questionId: "q4", topicTitle: "テーマ4" },
+        { role: "user" as const },
+        { role: "assistant" as const, questionId: "q5", topicTitle: "テーマ5" },
+      ];
+      const result = calcInterviewProgress(5, "chat", messages);
+      expect(result).toEqual({
+        percentage: 64,
+        currentTopic: "テーマ5",
+        showSkip: true,
+      });
+    });
+
+    it("同じquestionIdの重複メッセージはカウントしない", () => {
+      const messages = [
+        { role: "assistant" as const, questionId: "q1", topicTitle: "経済" },
+        { role: "user" as const },
+        { role: "assistant" as const, questionId: "q1" },
+        { role: "user" as const },
+        { role: "assistant" as const, questionId: "q2", topicTitle: "教育" },
+      ];
+      // askedIds = {q1, q2}, size=2, completedCount=1
+      const result = calcInterviewProgress(4, "chat", messages);
+      expect(result).toEqual({
+        percentage: 20, // 1/4 × 80 = 20
+        currentTopic: "教育",
+        showSkip: true,
+      });
+    });
+
+    it("topicTitleがないメッセージばかりならcurrentTopicはnull", () => {
+      const messages = [
+        { role: "assistant" as const, questionId: "q1" },
+        { role: "user" as const },
+        { role: "assistant" as const, questionId: "q2" },
+      ];
+      const result = calcInterviewProgress(3, "chat", messages);
+      expect(result?.currentTopic).toBeNull();
+    });
+
+    it("全問完了で80%", () => {
+      const messages = [
+        { role: "assistant" as const, questionId: "q1" },
+        { role: "user" as const },
+        { role: "assistant" as const, questionId: "q2" },
+        { role: "user" as const },
+        { role: "assistant" as const, questionId: "q3" },
+        { role: "user" as const },
+      ];
+      // askedIds = {q1, q2, q3}, size=3, completedCount=2
+      // → 2/2 × 80 = 80 (totalQuestions=2 だと全完了)
+      const result = calcInterviewProgress(2, "chat", messages);
+      expect(result?.percentage).toBe(80);
+    });
+  });
+});

--- a/web/src/features/interview-session/client/utils/calc-interview-progress.ts
+++ b/web/src/features/interview-session/client/utils/calc-interview-progress.ts
@@ -1,0 +1,54 @@
+import type { InterviewStage } from "../../shared/schemas";
+
+export interface InterviewProgress {
+  percentage: number;
+  currentTopic: string | null;
+  showSkip: boolean;
+}
+
+interface ProgressMessage {
+  role: "assistant" | "user";
+  questionId?: string | null;
+  topicTitle?: string | null;
+}
+
+/**
+ * インタビューのプログレスバー進捗を計算する純粋関数
+ *
+ * - summary_complete: 100%
+ * - summary: 90% 固定
+ * - chat: 完了質問数 / 全質問数 × 80%（残り20%はsummary+summary_complete）
+ */
+export function calcInterviewProgress(
+  totalQuestions: number | undefined,
+  stage: InterviewStage,
+  messages: ProgressMessage[]
+): InterviewProgress | null {
+  if (!totalQuestions || totalQuestions === 0) return null;
+
+  if (stage === "summary_complete") {
+    return { percentage: 100, currentTopic: null, showSkip: false };
+  }
+
+  if (stage === "summary") {
+    return { percentage: 90, currentTopic: null, showSkip: false };
+  }
+
+  // chat: 質問ベースの進捗
+  const askedIds = new Set(
+    messages
+      .filter((m) => m.role === "assistant" && m.questionId)
+      .map((m) => m.questionId as string)
+  );
+  // 現在聞いている質問は「完了」ではないので除外
+  const completedCount = Math.max(0, askedIds.size - 1);
+  // chatステージでは最大80%まで
+  const percentage = Math.round((completedCount / totalQuestions) * 80);
+
+  const lastTopicMessage = [...messages]
+    .reverse()
+    .find((m) => m.role === "assistant" && m.topicTitle);
+  const currentTopic = lastTopicMessage?.topicTitle ?? null;
+
+  return { percentage, currentTopic, showSkip: true };
+}


### PR DESCRIPTION
## Summary
- `useMemo` 内のインタビュー進捗計算ロジックを `calcInterviewProgress` 純粋関数として `utils/` に切り出し
- コンポーネント側は `useMemo` から関数を呼ぶだけに簡素化
- 11件のユニットテストを追加（各ステージ、境界値、重複IDの扱い等をカバー）

## Test plan
- [x] `pnpm --filter web test` で全テスト通過を確認
- [x] `pnpm --filter web typecheck` で型チェック通過を確認
- [ ] `pnpm dev` でインタビュー画面のプログレスバーが従来通り動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)