### PR TITLE
worktree作成手順に.envコピーを追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,10 @@ git worktree add ../mirai-gikai-<branch-name> -b <branch-name>
 mkdir -p ../mirai-gikai-<branch-name>/.claude
 cp .claude/settings.local.json ../mirai-gikai-<branch-name>/.claude/
 
-# 3. 依存パッケージをインストール
+# 3. .envをコピー（環境変数の引き継ぎ）
+cp .env ../mirai-gikai-<branch-name>/
+
+# 4. 依存パッケージをインストール
 cd ../mirai-gikai-<branch-name> && pnpm install --frozen-lockfile
 ```
 


### PR DESCRIPTION
## Summary
- worktree作成手順のステップ3に `.env` のコピーを追加
- worktree環境で環境変数が引き継がれるようにする

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup and initialization documentation. The sequence has been reordered to copy environment variables before dependency installation, ensuring proper configuration is available during the build process. This change establishes the correct control flow for project initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->