### PR TITLE
管理者一覧・招待・削除機能を追加

### DIFF
--- a/admin/src/app/(protected)/admins/page.tsx
+++ b/admin/src/app/(protected)/admins/page.tsx
@@ -1,0 +1,32 @@
+import { redirect } from "next/navigation";
+import { getCurrentAdmin } from "@/features/auth/lib/auth-server";
+import { AdminList } from "@/features/admins/components/admin-list";
+import { InviteAdminForm } from "@/features/admins/components/invite-admin-form";
+import { loadAdmins } from "@/features/admins/loaders/load-admins";
+
+export default async function AdminsPage() {
+  const currentAdmin = await getCurrentAdmin();
+
+  if (!currentAdmin) {
+    redirect("/login");
+  }
+
+  const admins = await loadAdmins();
+
+  return (
+    <div className="container mx-auto py-8">
+      <h1 className="text-2xl font-bold mb-8">管理者管理</h1>
+
+      {/* 管理者招待セクション */}
+      <section className="mb-8 rounded-lg border bg-white p-6">
+        <h2 className="text-lg font-semibold mb-4">管理者を招待</h2>
+        <InviteAdminForm />
+      </section>
+
+      {/* 管理者一覧セクション */}
+      <section className="rounded-lg border bg-white p-6">
+        <AdminList admins={admins} currentAdminId={currentAdmin.id} />
+      </section>
+    </div>
+  );
+}

--- a/admin/src/app/(protected)/layout/navigation-links.tsx
+++ b/admin/src/app/(protected)/layout/navigation-links.tsx
@@ -8,6 +8,7 @@ const navigationLinks = [
   { href: "/bills", label: "議案管理" },
   { href: "/diet-sessions", label: "国会会期管理" },
   { href: "/tags", label: "タグ管理" },
+  { href: "/admins", label: "管理者" },
 ];
 
 export function NavigationLinks() {

--- a/admin/src/features/admins/actions/delete-admin.ts
+++ b/admin/src/features/admins/actions/delete-admin.ts
@@ -1,0 +1,33 @@
+"use server";
+
+import { createAdminClient } from "@mirai-gikai/supabase";
+import { revalidatePath } from "next/cache";
+import { requireAdmin } from "@/features/auth/lib/auth-server";
+import type { DeleteAdminInput } from "../types";
+
+export async function deleteAdmin(input: DeleteAdminInput) {
+  try {
+    const currentAdmin = await requireAdmin();
+
+    if (currentAdmin.id === input.id) {
+      return { error: "自分自身を削除することはできません" };
+    }
+
+    const supabase = createAdminClient();
+
+    const { error } = await supabase.auth.admin.deleteUser(input.id);
+
+    if (error) {
+      return { error: `管理者の削除に失敗しました: ${error.message}` };
+    }
+
+    revalidatePath("/admins");
+    return { success: true };
+  } catch (error) {
+    console.error("Delete admin error:", error);
+    if (error instanceof Error) {
+      return { error: error.message };
+    }
+    return { error: "管理者の削除中にエラーが発生しました" };
+  }
+}

--- a/admin/src/features/admins/actions/invite-admin.ts
+++ b/admin/src/features/admins/actions/invite-admin.ts
@@ -1,0 +1,89 @@
+"use server";
+
+import { createAdminClient } from "@mirai-gikai/supabase";
+import { revalidatePath } from "next/cache";
+import { requireAdmin } from "@/features/auth/lib/auth-server";
+import type { InviteAdminInput } from "../types";
+
+export async function inviteAdmin(input: InviteAdminInput) {
+  try {
+    await requireAdmin();
+
+    const supabase = createAdminClient();
+
+    const email = input.email.trim().toLowerCase();
+    if (!email) {
+      return { error: "メールアドレスを入力してください" };
+    }
+
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(email)) {
+      return { error: "有効なメールアドレスを入力してください" };
+    }
+
+    // 既存ユーザーチェック
+    const { data: existingUsers } = await supabase.auth.admin.listUsers({
+      page: 1,
+      perPage: 1000,
+    });
+
+    const existingUser = existingUsers?.users?.find(
+      (u) => u.email?.toLowerCase() === email
+    );
+
+    if (existingUser) {
+      const roles = existingUser.app_metadata?.roles || [];
+      if (roles.includes("admin")) {
+        return {
+          error: "このメールアドレスは既に管理者として登録されています",
+        };
+      }
+
+      // 既存ユーザーにadmin権限を付与
+      const { error: updateError } = await supabase.auth.admin.updateUserById(
+        existingUser.id,
+        {
+          app_metadata: { roles: ["admin"] },
+        }
+      );
+
+      if (updateError) {
+        return {
+          error: `管理者権限の付与に失敗しました: ${updateError.message}`,
+        };
+      }
+
+      revalidatePath("/admins");
+      return { success: true };
+    }
+
+    // 新規ユーザー: 招待メール送信
+    const { data: inviteData, error: inviteError } =
+      await supabase.auth.admin.inviteUserByEmail(email);
+
+    if (inviteError) {
+      if (inviteError.message.includes("already been registered")) {
+        return { error: "このメールアドレスは既に登録されています" };
+      }
+      return {
+        error: `招待メールの送信に失敗しました: ${inviteError.message}`,
+      };
+    }
+
+    // app_metadataにadminロールを設定
+    if (inviteData?.user) {
+      await supabase.auth.admin.updateUserById(inviteData.user.id, {
+        app_metadata: { roles: ["admin"] },
+      });
+    }
+
+    revalidatePath("/admins");
+    return { success: true };
+  } catch (error) {
+    console.error("Invite admin error:", error);
+    if (error instanceof Error) {
+      return { error: error.message };
+    }
+    return { error: "管理者の招待中にエラーが発生しました" };
+  }
+}

--- a/admin/src/features/admins/components/admin-item.tsx
+++ b/admin/src/features/admins/components/admin-item.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { Trash2 } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { TableCell, TableRow } from "@/components/ui/table";
+import { deleteAdmin } from "../actions/delete-admin";
+import type { Admin } from "../types";
+
+type AdminItemProps = {
+  admin: Admin;
+  isCurrentUser: boolean;
+};
+
+export function AdminItem({ admin, isCurrentUser }: AdminItemProps) {
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const handleDelete = async () => {
+    setIsDeleting(true);
+
+    try {
+      const result = await deleteAdmin({ id: admin.id });
+
+      if (result.error) {
+        toast.error(result.error);
+      } else {
+        toast.success("管理者を削除しました");
+      }
+    } catch (error) {
+      console.error("Delete admin error:", error);
+      toast.error("管理者の削除に失敗しました");
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  const formatDate = (dateString: string | null) => {
+    if (!dateString) return "-";
+    return new Date(dateString).toLocaleDateString("ja-JP", {
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  };
+
+  return (
+    <TableRow>
+      <TableCell>
+        <div className="flex items-center gap-2">
+          <span className="font-medium">{admin.email}</span>
+          {isCurrentUser && <Badge variant="secondary">自分</Badge>}
+        </div>
+      </TableCell>
+      <TableCell className="text-gray-600">
+        {formatDate(admin.created_at)}
+      </TableCell>
+      <TableCell className="text-gray-600">
+        {formatDate(admin.last_sign_in_at)}
+      </TableCell>
+      <TableCell>
+        {isCurrentUser ? (
+          <Button variant="ghost" size="sm" disabled className="text-gray-400">
+            <Trash2 className="h-4 w-4" />
+          </Button>
+        ) : (
+          <AlertDialog>
+            <AlertDialogTrigger asChild>
+              <Button
+                variant="ghost"
+                size="sm"
+                disabled={isDeleting}
+                className="text-red-600 hover:text-red-800 hover:bg-red-50"
+              >
+                <Trash2 className="h-4 w-4" />
+              </Button>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>管理者の削除</AlertDialogTitle>
+                <AlertDialogDescription>
+                  「{admin.email}
+                  」を管理者から削除しますか？この操作は取り消せません。
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>キャンセル</AlertDialogCancel>
+                <AlertDialogAction
+                  onClick={handleDelete}
+                  disabled={isDeleting}
+                  className="bg-red-600 hover:bg-red-700"
+                >
+                  {isDeleting ? "削除中..." : "削除"}
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        )}
+      </TableCell>
+    </TableRow>
+  );
+}

--- a/admin/src/features/admins/components/admin-list.tsx
+++ b/admin/src/features/admins/components/admin-list.tsx
@@ -1,0 +1,50 @@
+import {
+  Table,
+  TableBody,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import type { Admin } from "../types";
+import { AdminItem } from "./admin-item";
+
+type AdminListProps = {
+  admins: Admin[];
+  currentAdminId: string;
+};
+
+export function AdminList({ admins, currentAdminId }: AdminListProps) {
+  return (
+    <div>
+      <h2 className="text-lg font-semibold mb-4">
+        管理者一覧 ({admins.length}件)
+      </h2>
+
+      {admins.length === 0 ? (
+        <p className="text-gray-500">管理者がいません</p>
+      ) : (
+        <div className="rounded-md border bg-white">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>メールアドレス</TableHead>
+                <TableHead>作成日</TableHead>
+                <TableHead>最終ログイン</TableHead>
+                <TableHead className="w-[100px]" />
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {admins.map((admin) => (
+                <AdminItem
+                  key={admin.id}
+                  admin={admin}
+                  isCurrentUser={admin.id === currentAdminId}
+                />
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/admin/src/features/admins/components/invite-admin-form.tsx
+++ b/admin/src/features/admins/components/invite-admin-form.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import type { FormEvent } from "react";
+import { useId, useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { inviteAdmin } from "../actions/invite-admin";
+
+export function InviteAdminForm() {
+  const emailId = useId();
+  const [email, setEmail] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+
+    if (!email.trim()) {
+      toast.error("メールアドレスを入力してください");
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      const result = await inviteAdmin({ email });
+
+      if (result.error) {
+        toast.error(result.error);
+      } else {
+        toast.success("招待メールを送信しました");
+        setEmail("");
+      }
+    } catch (error) {
+      console.error("Invite admin error:", error);
+      toast.error("招待メールの送信に失敗しました");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="flex gap-4">
+        <div className="flex-1 space-y-2">
+          <Label htmlFor={emailId}>メールアドレス</Label>
+          <Input
+            id={emailId}
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="admin@example.com"
+            disabled={isSubmitting}
+          />
+        </div>
+        <div className="flex items-end">
+          <Button type="submit" disabled={isSubmitting}>
+            {isSubmitting ? "招待中..." : "招待"}
+          </Button>
+        </div>
+      </div>
+    </form>
+  );
+}

--- a/admin/src/features/admins/loaders/load-admins.ts
+++ b/admin/src/features/admins/loaders/load-admins.ts
@@ -1,0 +1,33 @@
+import { createAdminClient } from "@mirai-gikai/supabase";
+import type { Admin } from "../types";
+
+export async function loadAdmins(): Promise<Admin[]> {
+  const supabase = createAdminClient();
+
+  const { data, error } = await supabase.auth.admin.listUsers({
+    page: 1,
+    perPage: 1000,
+  });
+
+  if (error) {
+    throw new Error(`管理者一覧の取得に失敗しました: ${error.message}`);
+  }
+
+  const admins: Admin[] = (data?.users ?? [])
+    .filter((user) => {
+      const roles = user.app_metadata?.roles || [];
+      return roles.includes("admin");
+    })
+    .map((user) => ({
+      id: user.id,
+      email: user.email ?? "",
+      created_at: user.created_at,
+      last_sign_in_at: user.last_sign_in_at ?? null,
+    }))
+    .sort(
+      (a, b) =>
+        new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+    );
+
+  return admins;
+}

--- a/admin/src/features/admins/types/index.ts
+++ b/admin/src/features/admins/types/index.ts
@@ -1,0 +1,14 @@
+export type Admin = {
+  id: string;
+  email: string;
+  created_at: string;
+  last_sign_in_at: string | null;
+};
+
+export type InviteAdminInput = {
+  email: string;
+};
+
+export type DeleteAdminInput = {
+  id: string;
+};


### PR DESCRIPTION
## Summary
- `/admins` ページに管理者一覧テーブルと管理者招待フォームを追加
- Supabase Auth Admin API を使用してメール招待（`inviteUserByEmail`）とユーザー削除（`deleteUser`）を実装
- 自分自身の削除を防止するガードを実装（サーバーサイド + UI の両方で制御）
- ナビゲーションに「管理者」リンクを追加

## 機能詳細
- **管理者一覧**: メールアドレス、作成日、最終ログイン日時をテーブル表示。現在のユーザーには「自分」バッジを表示
- **管理者招待**: メールアドレスを入力して招待メールを送信。既存ユーザーの場合は admin 権限を付与
- **管理者削除**: AlertDialog で確認後に削除。自分自身の削除は不可

## 技術的な注意点
- 招待メールの送信には Supabase の SMTP 設定が必要です
- `inviteUserByEmail` は `user_metadata` のみ設定可能なため、招待後に `updateUserById` で `app_metadata.roles` を設定する 2 段階方式を採用

## Test plan
- [ ] `pnpm typecheck` でエラーなし
- [ ] `pnpm lint` でエラーなし
- [ ] `http://localhost:3001/admins` で管理者一覧が表示される
- [ ] 現在のユーザーに「自分」バッジが表示される
- [ ] 自分の削除ボタンが無効化されている
- [ ] メールアドレスを入力して招待が成功する
- [ ] 他の管理者を削除できる（確認ダイアログ付き）

🤖 Generated with [Claude Code](https://claude.com/claude-code)