### PR TITLE
管理者追加をメール招待からパスワード指定方式に変更

### DIFF
--- a/admin/src/app/(protected)/admins/page.tsx
+++ b/admin/src/app/(protected)/admins/page.tsx
@@ -17,9 +17,9 @@ export default async function AdminsPage() {
     <div className="container mx-auto py-8">
       <h1 className="text-2xl font-bold mb-8">管理者管理</h1>
 
-      {/* 管理者招待セクション */}
+      {/* 管理者追加セクション */}
       <section className="mb-8 rounded-lg border bg-white p-6">
-        <h2 className="text-lg font-semibold mb-4">管理者を招待</h2>
+        <h2 className="text-lg font-semibold mb-4">管理者を追加</h2>
         <InviteAdminForm />
       </section>
 

--- a/admin/src/features/admins/components/invite-admin-form.tsx
+++ b/admin/src/features/admins/components/invite-admin-form.tsx
@@ -6,11 +6,13 @@ import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { inviteAdmin } from "../actions/invite-admin";
+import { createAdmin } from "../actions/invite-admin";
 
 export function InviteAdminForm() {
   const emailId = useId();
+  const passwordId = useId();
   const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const handleSubmit = async (e: FormEvent) => {
@@ -21,20 +23,26 @@ export function InviteAdminForm() {
       return;
     }
 
+    if (!password || password.length < 6) {
+      toast.error("パスワードは6文字以上で入力してください");
+      return;
+    }
+
     setIsSubmitting(true);
 
     try {
-      const result = await inviteAdmin({ email });
+      const result = await createAdmin({ email, password });
 
       if (result.error) {
         toast.error(result.error);
       } else {
-        toast.success("招待メールを送信しました");
+        toast.success("管理者を作成しました");
         setEmail("");
+        setPassword("");
       }
     } catch (error) {
-      console.error("Invite admin error:", error);
-      toast.error("招待メールの送信に失敗しました");
+      console.error("Create admin error:", error);
+      toast.error("管理者の作成に失敗しました");
     } finally {
       setIsSubmitting(false);
     }
@@ -54,9 +62,20 @@ export function InviteAdminForm() {
             disabled={isSubmitting}
           />
         </div>
+        <div className="flex-1 space-y-2">
+          <Label htmlFor={passwordId}>パスワード</Label>
+          <Input
+            id={passwordId}
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="6文字以上"
+            disabled={isSubmitting}
+          />
+        </div>
         <div className="flex items-end">
           <Button type="submit" disabled={isSubmitting}>
-            {isSubmitting ? "招待中..." : "招待"}
+            {isSubmitting ? "作成中..." : "作成"}
           </Button>
         </div>
       </div>

--- a/admin/src/features/admins/types/index.ts
+++ b/admin/src/features/admins/types/index.ts
@@ -5,8 +5,9 @@ export type Admin = {
   last_sign_in_at: string | null;
 };
 
-export type InviteAdminInput = {
+export type CreateAdminInput = {
   email: string;
+  password: string;
 };
 
 export type DeleteAdminInput = {


### PR DESCRIPTION
## Summary
- 管理者追加の方式をメール招待（`inviteUserByEmail`）からパスワード指定（`createUser`）に変更
- フォームにパスワード入力欄を追加（6文字以上のバリデーション付き）
- `email_confirm: true` で即座にログイン可能な状態で作成

## 変更内容
- `invite-admin.ts`: `inviteUserByEmail` → `createUser` に変更、`app_metadata.roles` を直接設定
- `invite-admin-form.tsx`: パスワード入力欄を追加
- `types/index.ts`: `InviteAdminInput` → `CreateAdminInput` にリネーム、`password` フィールド追加
- `admins/page.tsx`: セクション見出しを「管理者を追加」に変更

## Test plan
- [ ] `pnpm typecheck` でエラーなし
- [ ] `pnpm lint` でエラーなし
- [ ] メールアドレスとパスワードを入力して管理者を作成できる
- [ ] 作成した管理者でログインできる
- [ ] 既存メールアドレスの重複チェックが動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Admin creation now supports direct account setup with password instead of email invitations.
  * Added password field to admin creation form with minimum 6-character validation.

* **UI Updates**
  * Updated admin management interface labels from "invite" to "add" terminology.
  * Revised success and error messages to reflect the new account creation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->