### PR TITLE
過去国会の議案一覧で成立法案を先頭に表示

### DIFF
--- a/web/src/features/bills/server/loaders/get-bills-by-diet-session.ts
+++ b/web/src/features/bills/server/loaders/get-bills-by-diet-session.ts
@@ -44,6 +44,7 @@ const _getCachedBillsByDietSession = unstable_cache(
       .eq("diet_session_id", dietSessionId)
       .eq("publish_status", "published")
       .eq("bill_contents.difficulty_level", difficultyLevel)
+      .order("status", { ascending: true })
       .order("published_at", { ascending: false });
 
     if (error) {
@@ -69,13 +70,6 @@ const _getCachedBillsByDietSession = unstable_cache(
           : undefined,
         tags: tagsByBillId.get(item.id) ?? [],
       };
-    });
-
-    // 成立法案を先頭に、それ以外はpublished_at降順
-    billsWithContent.sort((a, b) => {
-      if (a.status === "enacted" && b.status !== "enacted") return -1;
-      if (a.status !== "enacted" && b.status === "enacted") return 1;
-      return 0;
     });
 
     return billsWithContent;


### PR DESCRIPTION
## Summary
- 過去国会の議案一覧ページ（`/kokkai/[slug]/bills`）で、成立法案を一覧の先頭に表示するようソートを追加
- 成立法案同士は `published_at` 降順（新しい順）を維持

## Test plan
- [ ] `/kokkai/219-rinji/bills` にアクセスし、成立法案が先頭に並んでいることを確認
- [ ] フィルター切り替えが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)