### PR TITLE
parallel-prスキルのnameをフォルダ名と一致させる

### DIFF
--- a/.claude/skills/parallel-pr/SKILL.md
+++ b/.claude/skills/parallel-pr/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Parallel PR
+name: parallel-pr
 description: 複数の独立PRをチーム×worktreeで並列作成する。タスク一覧を受け取り、worktree準備→チーム組成→エージェント起動→CI確認→クリーンアップまで一気に実行する。
 ---
 


### PR DESCRIPTION
## Summary
- parallel-prスキルのSKILL.md frontmatterの `name` を `Parallel PR` から `parallel-pr` に修正
- フォルダ名とスキル名の不一致による警告を解消

🤖 Generated with [Claude Code](https://claude.com/claude-code)