### PR TITLE
refactor: diet-sessions featureにrepositoryレイヤーを追加

### DIFF
--- a/web/src/features/diet-sessions/server/loaders/get-active-diet-session.ts
+++ b/web/src/features/diet-sessions/server/loaders/get-active-diet-session.ts
@@ -1,7 +1,7 @@
-import { createAdminClient } from "@mirai-gikai/supabase";
 import { unstable_cache } from "next/cache";
 import { CACHE_TAGS } from "@/lib/cache-tags";
 import type { DietSession } from "../../shared/types";
+import { findActiveDietSession } from "../repositories/diet-session-repository";
 
 /**
  * アクティブな国会会期を取得
@@ -14,20 +14,7 @@ export async function getActiveDietSession(): Promise<DietSession | null> {
 
 const _getCachedActiveDietSession = unstable_cache(
   async (): Promise<DietSession | null> => {
-    const supabase = createAdminClient();
-
-    const { data: activeSession, error: activeError } = await supabase
-      .from("diet_sessions")
-      .select("*")
-      .eq("is_active", true)
-      .maybeSingle();
-
-    if (activeError) {
-      console.error("Failed to fetch active diet session:", activeError);
-      return null;
-    }
-
-    return activeSession;
+    return findActiveDietSession();
   },
   ["active-diet-session"],
   {

--- a/web/src/features/diet-sessions/server/loaders/get-current-diet-session.ts
+++ b/web/src/features/diet-sessions/server/loaders/get-current-diet-session.ts
@@ -1,7 +1,7 @@
-import { createAdminClient } from "@mirai-gikai/supabase";
 import { unstable_cache } from "next/cache";
 import { CACHE_TAGS } from "@/lib/cache-tags";
 import type { DietSession } from "../../shared/types";
+import { findCurrentDietSession } from "../repositories/diet-session-repository";
 
 /**
  * 指定日時点で開催中の国会会期を取得
@@ -21,23 +21,7 @@ export async function getCurrentDietSession(
 
 const _getCachedCurrentDietSession = unstable_cache(
   async (targetDate: string): Promise<DietSession | null> => {
-    const supabase = createAdminClient();
-
-    const { data, error } = await supabase
-      .from("diet_sessions")
-      .select("*")
-      .lte("start_date", targetDate)
-      .gte("end_date", targetDate)
-      .order("start_date", { ascending: false })
-      .limit(1)
-      .maybeSingle();
-
-    if (error) {
-      console.error("Failed to fetch current diet session:", error);
-      return null;
-    }
-
-    return data;
+    return findCurrentDietSession(targetDate);
   },
   ["current-diet-session"],
   {

--- a/web/src/features/diet-sessions/server/loaders/get-diet-session-by-slug.ts
+++ b/web/src/features/diet-sessions/server/loaders/get-diet-session-by-slug.ts
@@ -1,7 +1,7 @@
-import { createAdminClient } from "@mirai-gikai/supabase";
 import { unstable_cache } from "next/cache";
 import { CACHE_TAGS } from "@/lib/cache-tags";
 import type { DietSession } from "../../shared/types";
+import { findDietSessionBySlug } from "../repositories/diet-session-repository";
 
 /**
  * slugで国会会期を取得
@@ -14,20 +14,7 @@ export async function getDietSessionBySlug(
 
 const _getCachedDietSessionBySlug = unstable_cache(
   async (slug: string): Promise<DietSession | null> => {
-    const supabase = createAdminClient();
-
-    const { data, error } = await supabase
-      .from("diet_sessions")
-      .select("*")
-      .eq("slug", slug)
-      .maybeSingle();
-
-    if (error) {
-      console.error("Failed to fetch diet session by slug:", error);
-      return null;
-    }
-
-    return data;
+    return findDietSessionBySlug(slug);
   },
   ["diet-session-by-slug"],
   {

--- a/web/src/features/diet-sessions/server/loaders/get-previous-diet-session.ts
+++ b/web/src/features/diet-sessions/server/loaders/get-previous-diet-session.ts
@@ -1,7 +1,7 @@
-import { createAdminClient } from "@mirai-gikai/supabase";
 import { unstable_cache } from "next/cache";
 import { CACHE_TAGS } from "@/lib/cache-tags";
 import type { DietSession } from "../../shared/types";
+import { findPreviousDietSession } from "../repositories/diet-session-repository";
 import { getActiveDietSession } from "./get-active-diet-session";
 
 /**
@@ -22,23 +22,7 @@ export async function getPreviousDietSession(): Promise<DietSession | null> {
 
 const _getCachedPreviousDietSession = unstable_cache(
   async (activeStartDate: string): Promise<DietSession | null> => {
-    const supabase = createAdminClient();
-
-    // アクティブなセッションより古いセッションを取得（start_dateで比較）
-    const { data: previousSession, error: previousError } = await supabase
-      .from("diet_sessions")
-      .select("*")
-      .lt("start_date", activeStartDate)
-      .order("start_date", { ascending: false })
-      .limit(1)
-      .maybeSingle();
-
-    if (previousError) {
-      console.error("Failed to fetch previous diet session:", previousError);
-      return null;
-    }
-
-    return previousSession;
+    return findPreviousDietSession(activeStartDate);
   },
   ["previous-diet-session"],
   {

--- a/web/src/features/diet-sessions/server/repositories/diet-session-repository.ts
+++ b/web/src/features/diet-sessions/server/repositories/diet-session-repository.ts
@@ -1,0 +1,94 @@
+import "server-only";
+import { createAdminClient } from "@mirai-gikai/supabase";
+import type { DietSession } from "../../shared/types";
+
+/**
+ * アクティブな国会会期を取得
+ */
+export async function findActiveDietSession(): Promise<DietSession | null> {
+  const supabase = createAdminClient();
+
+  const { data, error } = await supabase
+    .from("diet_sessions")
+    .select("*")
+    .eq("is_active", true)
+    .maybeSingle();
+
+  if (error) {
+    console.error("Failed to fetch active diet session:", error);
+    return null;
+  }
+
+  return data;
+}
+
+/**
+ * 指定日時点で開催中の国会会期を取得
+ */
+export async function findCurrentDietSession(
+  targetDate: string
+): Promise<DietSession | null> {
+  const supabase = createAdminClient();
+
+  const { data, error } = await supabase
+    .from("diet_sessions")
+    .select("*")
+    .lte("start_date", targetDate)
+    .gte("end_date", targetDate)
+    .order("start_date", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    console.error("Failed to fetch current diet session:", error);
+    return null;
+  }
+
+  return data;
+}
+
+/**
+ * slugで国会会期を取得
+ */
+export async function findDietSessionBySlug(
+  slug: string
+): Promise<DietSession | null> {
+  const supabase = createAdminClient();
+
+  const { data, error } = await supabase
+    .from("diet_sessions")
+    .select("*")
+    .eq("slug", slug)
+    .maybeSingle();
+
+  if (error) {
+    console.error("Failed to fetch diet session by slug:", error);
+    return null;
+  }
+
+  return data;
+}
+
+/**
+ * 指定日より前の直近の国会会期を取得
+ */
+export async function findPreviousDietSession(
+  beforeStartDate: string
+): Promise<DietSession | null> {
+  const supabase = createAdminClient();
+
+  const { data, error } = await supabase
+    .from("diet_sessions")
+    .select("*")
+    .lt("start_date", beforeStartDate)
+    .order("start_date", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    console.error("Failed to fetch previous diet session:", error);
+    return null;
+  }
+
+  return data;
+}


### PR DESCRIPTION
## Summary
- diet-sessions featureにrepositoryレイヤー（`server/repositories/diet-session-repository.ts`）を追加
- loadersのSupabase直接呼び出しをrepository関数に集約
- データアクセス層の分離により、テスタビリティと保守性を向上

## 変更内容
- 新規: `diet-session-repository.ts` - 全Supabaseクエリを集約
- 更新: 各loaderファイルからSupabase直接呼び出しを削除し、repository関数を利用

## Test plan
- [x] pnpm typecheck 通過
- [x] pnpm lint 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)