### PR TITLE
refactor: chat featureにrepositoryレイヤーを追加

### DIFF
--- a/web/src/features/chat/server/repositories/chat-usage-repository.ts
+++ b/web/src/features/chat/server/repositories/chat-usage-repository.ts
@@ -1,0 +1,43 @@
+import "server-only";
+
+import type { Database } from "@mirai-gikai/supabase";
+import { createAdminClient } from "@mirai-gikai/supabase";
+
+type ChatUsageInsert =
+  Database["public"]["Tables"]["chat_usage_events"]["Insert"];
+
+type ChatUsageRow = Database["public"]["Tables"]["chat_usage_events"]["Row"];
+
+export type { ChatUsageInsert, ChatUsageRow };
+
+export async function insertChatUsageEvent(payload: ChatUsageInsert) {
+  const supabase = createAdminClient();
+  const { error } = await supabase.from("chat_usage_events").insert(payload);
+  if (error) {
+    throw new Error(`Failed to record chat usage: ${error.message}`, {
+      cause: error,
+    });
+  }
+}
+
+export async function findChatUsageEvents(
+  userId: string,
+  fromIso: string,
+  toIso: string
+): Promise<Pick<ChatUsageRow, "cost_usd" | "occurred_at">[]> {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("chat_usage_events")
+    .select("cost_usd, occurred_at")
+    .eq("user_id", userId)
+    .gte("occurred_at", fromIso)
+    .lt("occurred_at", toIso);
+
+  if (error) {
+    throw new Error(`Failed to fetch chat usage: ${error.message}`, {
+      cause: error,
+    });
+  }
+
+  return data ?? [];
+}


### PR DESCRIPTION
## Summary
- chat featureにrepositoryレイヤー（`server/repositories/chat-usage-repository.ts`）を追加
- cost-tracker.tsのSupabase直接呼び出しをrepository関数に集約
- データアクセス層の分離により、テスタビリティと保守性を向上

## 変更内容
- 新規: `chat-usage-repository.ts` - chat_usage_eventsテーブルへのクエリを集約
- 更新: `cost-tracker.ts` からSupabase直接呼び出しを削除し、repository関数を利用

## Test plan
- [x] pnpm typecheck 通過
- [x] pnpm lint 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)