### PR TITLE
refactor: interview-config featureにrepositoryレイヤーを追加

### DIFF
--- a/web/src/features/interview-config/server/loaders/get-interview-config.ts
+++ b/web/src/features/interview-config/server/loaders/get-interview-config.ts
@@ -1,7 +1,7 @@
 import type { Database } from "@mirai-gikai/supabase";
-import { createAdminClient } from "@mirai-gikai/supabase";
 import { unstable_cache } from "next/cache";
 import { CACHE_TAGS } from "@/lib/cache-tags";
+import { findPublicInterviewConfigByBillId } from "../repositories/interview-config-repository";
 
 export type InterviewConfig =
   Database["public"]["Tables"]["interview_configs"]["Row"];
@@ -14,14 +14,7 @@ export async function getInterviewConfig(
 
 const _getCachedInterviewConfig = unstable_cache(
   async (billId: string): Promise<InterviewConfig | null> => {
-    const supabase = createAdminClient();
-
-    const { data, error } = await supabase
-      .from("interview_configs")
-      .select("*")
-      .eq("bill_id", billId)
-      .eq("status", "public") // 公開ステータスのみ
-      .single();
+    const { data, error } = await findPublicInterviewConfigByBillId(billId);
 
     if (error) {
       // レコードが存在しない場合はnullを返す（エラーではない）

--- a/web/src/features/interview-config/server/loaders/get-interview-questions.ts
+++ b/web/src/features/interview-config/server/loaders/get-interview-questions.ts
@@ -1,21 +1,14 @@
-import { createAdminClient } from "@mirai-gikai/supabase";
 import type { InterviewQuestion } from "@/features/interview-session/shared/types";
+import { findInterviewQuestionsByConfigId } from "../repositories/interview-config-repository";
 
 export async function getInterviewQuestions(
   interviewConfigId: string
 ): Promise<InterviewQuestion[]> {
-  const supabase = createAdminClient();
-
-  const { data, error } = await supabase
-    .from("interview_questions")
-    .select("*")
-    .eq("interview_config_id", interviewConfigId)
-    .order("question_order", { ascending: true });
-
-  if (error) {
+  try {
+    const data = await findInterviewQuestionsByConfigId(interviewConfigId);
+    return data || [];
+  } catch (error) {
     console.error("Failed to fetch interview questions:", error);
     return [];
   }
-
-  return data || [];
 }

--- a/web/src/features/interview-config/server/repositories/interview-config-repository.ts
+++ b/web/src/features/interview-config/server/repositories/interview-config-repository.ts
@@ -1,0 +1,54 @@
+import "server-only";
+
+import { createAdminClient } from "@mirai-gikai/supabase";
+
+/**
+ * bill_idから公開ステータスのインタビュー設定を取得
+ */
+export async function findPublicInterviewConfigByBillId(billId: string) {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("interview_configs")
+    .select("*")
+    .eq("bill_id", billId)
+    .eq("status", "public")
+    .single();
+
+  return { data, error };
+}
+
+/**
+ * bill_idから最新のインタビュー設定を取得（ステータス問わず）
+ */
+export async function findLatestInterviewConfigByBillId(billId: string) {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("interview_configs")
+    .select("*")
+    .eq("bill_id", billId)
+    .order("updated_at", { ascending: false })
+    .limit(1)
+    .single();
+
+  return { data, error };
+}
+
+/**
+ * interview_config_idからインタビュー質問一覧を取得（question_order昇順）
+ */
+export async function findInterviewQuestionsByConfigId(
+  interviewConfigId: string
+) {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("interview_questions")
+    .select("*")
+    .eq("interview_config_id", interviewConfigId)
+    .order("question_order", { ascending: true });
+
+  if (error) {
+    throw new Error(`Failed to fetch interview questions: ${error.message}`);
+  }
+
+  return data;
+}


### PR DESCRIPTION
## Summary
- interview-config featureにrepositoryレイヤー（`server/repositories/interview-config-repository.ts`）を追加
- loadersのSupabase直接呼び出しをrepository関数に集約

## Test plan
- [x] pnpm typecheck 通過
- [x] pnpm lint 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)