### PR TITLE
refactor: bills featureにrepositoryレイヤーを追加

### DIFF
--- a/web/src/features/bills/server/loaders/get-bills-by-diet-session.ts
+++ b/web/src/features/bills/server/loaders/get-bills-by-diet-session.ts
@@ -1,10 +1,12 @@
-import { createAdminClient } from "@mirai-gikai/supabase";
 import { unstable_cache } from "next/cache";
 import { getDifficultyLevel } from "@/features/bill-difficulty/server/loaders/get-difficulty-level";
 import type { DifficultyLevelEnum } from "@/features/bill-difficulty/shared/types";
 import { CACHE_TAGS } from "@/lib/cache-tags";
 import type { BillWithContent } from "../../shared/types";
-import { fetchTagsByBillIds } from "./helpers/get-bill-tags";
+import {
+  findPublishedBillsByDietSession,
+  findTagsByBillIds,
+} from "../repositories/bill-repository";
 
 /**
  * 国会会期IDに紐づく議案一覧を取得
@@ -21,37 +23,10 @@ const _getCachedBillsByDietSession = unstable_cache(
     dietSessionId: string,
     difficultyLevel: DifficultyLevelEnum
   ): Promise<BillWithContent[]> => {
-    const supabase = createAdminClient();
-
-    // 会期IDに紐づく公開済み議案を取得
-    const { data, error } = await supabase
-      .from("bills")
-      .select(
-        `
-        *,
-        bill_contents!inner (
-          id,
-          bill_id,
-          title,
-          summary,
-          content,
-          difficulty_level,
-          created_at,
-          updated_at
-        )
-      `
-      )
-      .eq("diet_session_id", dietSessionId)
-      .eq("publish_status", "published")
-      .eq("bill_contents.difficulty_level", difficultyLevel)
-      .order("status", { ascending: true })
-      .order("published_at", { ascending: false });
-
-    if (error) {
-      throw new Error(
-        `Failed to fetch bills by diet session: ${error.message}`
-      );
-    }
+    const data = await findPublishedBillsByDietSession(
+      dietSessionId,
+      difficultyLevel
+    );
 
     if (!data || data.length === 0) {
       return [];
@@ -59,7 +34,7 @@ const _getCachedBillsByDietSession = unstable_cache(
 
     // タグ情報を一括取得
     const billIds = data.map((item) => item.id);
-    const tagsByBillId = await fetchTagsByBillIds(supabase, billIds);
+    const tagsByBillId = await findTagsByBillIds(billIds);
 
     const billsWithContent: BillWithContent[] = data.map((item) => {
       const { bill_contents, ...bill } = item;

--- a/web/src/features/bills/server/loaders/get-bills.ts
+++ b/web/src/features/bills/server/loaders/get-bills.ts
@@ -1,10 +1,12 @@
-import { createAdminClient } from "@mirai-gikai/supabase";
 import { unstable_cache } from "next/cache";
 import { getDifficultyLevel } from "@/features/bill-difficulty/server/loaders/get-difficulty-level";
 import type { DifficultyLevelEnum } from "@/features/bill-difficulty/shared/types";
 import { CACHE_TAGS } from "@/lib/cache-tags";
 import type { BillWithContent } from "../../shared/types";
-import { fetchTagsByBillIds } from "./helpers/get-bill-tags";
+import {
+  findPublishedBillsWithContents,
+  findTagsByBillIds,
+} from "../repositories/bill-repository";
 
 export async function getBills(): Promise<BillWithContent[]> {
   // キャッシュ外でcookiesにアクセス
@@ -14,38 +16,11 @@ export async function getBills(): Promise<BillWithContent[]> {
 
 const _getCachedBills = unstable_cache(
   async (difficultyLevel: DifficultyLevelEnum): Promise<BillWithContent[]> => {
-    const supabase = createAdminClient();
-
-    // JOINを使用して一度のクエリでbill_contentsも取得
-    // 公開ステータスの議案のみを取得
-    const { data, error } = await supabase
-      .from("bills")
-      .select(
-        `
-        *,
-        bill_contents!inner (
-          id,
-          bill_id,
-          title,
-          summary,
-          content,
-          difficulty_level,
-          created_at,
-          updated_at
-        )
-      `
-      )
-      .eq("publish_status", "published") // 公開済み議案のみ
-      .eq("bill_contents.difficulty_level", difficultyLevel)
-      .order("published_at", { ascending: false });
-
-    if (error) {
-      throw new Error(`Failed to fetch bills: ${error.message}`);
-    }
+    const data = await findPublishedBillsWithContents(difficultyLevel);
 
     // タグ情報を一括取得
     const billIds = data.map((item) => item.id);
-    const tagsByBillId = await fetchTagsByBillIds(supabase, billIds);
+    const tagsByBillId = await findTagsByBillIds(billIds);
 
     const billsWithContent: BillWithContent[] = data.map((item) => {
       const { bill_contents, ...bill } = item;

--- a/web/src/features/bills/server/loaders/get-previous-session-bills.ts
+++ b/web/src/features/bills/server/loaders/get-previous-session-bills.ts
@@ -1,4 +1,3 @@
-import { createAdminClient } from "@mirai-gikai/supabase";
 import { unstable_cache } from "next/cache";
 import { getDifficultyLevel } from "@/features/bill-difficulty/server/loaders/get-difficulty-level";
 import type { DifficultyLevelEnum } from "@/features/bill-difficulty/shared/types";
@@ -6,7 +5,11 @@ import { getPreviousDietSession } from "@/features/diet-sessions/server/loaders/
 import type { DietSession } from "@/features/diet-sessions/shared/types";
 import { CACHE_TAGS } from "@/lib/cache-tags";
 import type { BillWithContent } from "../../shared/types";
-import { fetchTagsByBillIds } from "./helpers/get-bill-tags";
+import {
+  findPreviousSessionBills,
+  findTagsByBillIds,
+  countPublishedBillsByDietSession,
+} from "../repositories/bill-repository";
 
 const MAX_PREVIEW_BILLS = 5;
 
@@ -44,44 +47,19 @@ const _getCachedPreviousSessionBills = unstable_cache(
     dietSessionId: string,
     difficultyLevel: DifficultyLevelEnum
   ): Promise<BillWithContent[]> => {
-    const supabase = createAdminClient();
+    const data = await findPreviousSessionBills(
+      dietSessionId,
+      difficultyLevel,
+      MAX_PREVIEW_BILLS
+    );
 
-    // 会期IDに紐づく公開済み議案を取得（最大5件）
-    const { data, error } = await supabase
-      .from("bills")
-      .select(
-        `
-        *,
-        bill_contents!inner (
-          id,
-          bill_id,
-          title,
-          summary,
-          content,
-          difficulty_level,
-          created_at,
-          updated_at
-        )
-      `
-      )
-      .eq("diet_session_id", dietSessionId)
-      .eq("publish_status", "published")
-      .eq("bill_contents.difficulty_level", difficultyLevel)
-      .order("published_at", { ascending: false })
-      .limit(MAX_PREVIEW_BILLS);
-
-    if (error) {
-      console.error("Failed to fetch previous session bills:", error);
-      return [];
-    }
-
-    if (!data || data.length === 0) {
+    if (data.length === 0) {
       return [];
     }
 
     // タグ情報を取得
     const billIds = data.map((item) => item.id);
-    const tagsByBillId = await fetchTagsByBillIds(supabase, billIds);
+    const tagsByBillId = await findTagsByBillIds(billIds);
 
     const billsWithContent: BillWithContent[] = data.map((item) => {
       const { bill_contents, ...bill } = item;
@@ -108,24 +86,7 @@ const _getCachedPreviousSessionBillCount = unstable_cache(
     dietSessionId: string,
     difficultyLevel: DifficultyLevelEnum
   ): Promise<number> => {
-    const supabase = createAdminClient();
-
-    const { count, error } = await supabase
-      .from("bills")
-      .select("*, bill_contents!inner(difficulty_level)", {
-        count: "exact",
-        head: true,
-      })
-      .eq("diet_session_id", dietSessionId)
-      .eq("publish_status", "published")
-      .eq("bill_contents.difficulty_level", difficultyLevel);
-
-    if (error) {
-      console.error("Failed to count previous session bills:", error);
-      return 0;
-    }
-
-    return count ?? 0;
+    return countPublishedBillsByDietSession(dietSessionId, difficultyLevel);
   },
   ["previous-session-bill-count"],
   {

--- a/web/src/features/bills/server/loaders/helpers/get-bill-content.ts
+++ b/web/src/features/bills/server/loaders/helpers/get-bill-content.ts
@@ -1,5 +1,5 @@
-import { createAdminClient } from "@mirai-gikai/supabase";
 import type { DifficultyLevelEnum } from "@/features/bill-difficulty/shared/types";
+import { findBillContentByDifficulty } from "../../repositories/bill-repository";
 
 /**
  * 指定された難易度の議案コンテンツを取得
@@ -10,20 +10,5 @@ export async function getBillContentWithDifficulty(
   billId: string,
   difficultyLevel: DifficultyLevelEnum
 ) {
-  const supabase = createAdminClient();
-
-  // 選択された難易度のコンテンツを取得
-  const { data: billContent, error } = await supabase
-    .from("bill_contents")
-    .select("*")
-    .eq("bill_id", billId)
-    .eq("difficulty_level", difficultyLevel)
-    .single();
-
-  if (error) {
-    console.error(`Failed to fetch bill content: ${error.message}`);
-    return null;
-  }
-
-  return billContent;
+  return findBillContentByDifficulty(billId, difficultyLevel);
 }

--- a/web/src/features/bills/server/loaders/helpers/get-bill-tags.ts
+++ b/web/src/features/bills/server/loaders/helpers/get-bill-tags.ts
@@ -1,47 +1,14 @@
-import type { createAdminClient } from "@mirai-gikai/supabase";
-
-type SupabaseClient = ReturnType<typeof createAdminClient>;
-
-type BillTag = {
-  bill_id: string;
-  tags: { id: string; label: string } | null;
-};
-
-/**
- * bill_idごとにタグをグループ化する
- */
-function groupTagsByBillId(
-  billTags: BillTag[]
-): Map<string, Array<{ id: string; label: string }>> {
-  return billTags.reduce((acc, bt) => {
-    if (bt.tags) {
-      const existing = acc.get(bt.bill_id) ?? [];
-      acc.set(bt.bill_id, [...existing, bt.tags]);
-    }
-    return acc;
-  }, new Map<string, Array<{ id: string; label: string }>>());
-}
+import { findTagsByBillIds } from "../../repositories/bill-repository";
 
 /**
  * 複数のbill_idに紐づくタグを一括取得し、bill_idごとにグループ化して返す
  * N+1問題を回避するためのヘルパー
+ *
+ * @deprecated repository関数 findTagsByBillIds を直接使用してください
  */
 export async function fetchTagsByBillIds(
-  supabase: SupabaseClient,
+  _supabase: unknown,
   billIds: string[]
 ): Promise<Map<string, Array<{ id: string; label: string }>>> {
-  if (billIds.length === 0) {
-    return new Map();
-  }
-
-  const { data: allBillTags, error } = await supabase
-    .from("bills_tags")
-    .select("bill_id, tags(id, label)")
-    .in("bill_id", billIds);
-
-  if (error) {
-    throw new Error(`Failed to fetch tags: ${error.message}`);
-  }
-
-  return groupTagsByBillId(allBillTags ?? []);
+  return findTagsByBillIds(billIds);
 }

--- a/web/src/features/bills/server/loaders/validate-preview-token.ts
+++ b/web/src/features/bills/server/loaders/validate-preview-token.ts
@@ -1,4 +1,4 @@
-import { createAdminClient } from "@mirai-gikai/supabase";
+import { findPreviewToken } from "../repositories/bill-repository";
 
 export async function validatePreviewToken(
   billId: string,
@@ -9,16 +9,9 @@ export async function validatePreviewToken(
   }
 
   try {
-    const supabase = createAdminClient();
+    const data = await findPreviewToken(billId, token);
 
-    const { data, error } = await supabase
-      .from("preview_tokens")
-      .select("expires_at")
-      .eq("bill_id", billId)
-      .eq("token", token)
-      .single();
-
-    if (error || !data) {
+    if (!data) {
       return false;
     }
 

--- a/web/src/features/bills/server/repositories/bill-repository.ts
+++ b/web/src/features/bills/server/repositories/bill-repository.ts
@@ -1,0 +1,481 @@
+import "server-only";
+import { createAdminClient } from "@mirai-gikai/supabase";
+import type { DifficultyLevelEnum } from "@/features/bill-difficulty/shared/types";
+
+// ============================================================
+// Bills
+// ============================================================
+
+/**
+ * 公開済み議案を難易度コンテンツ付きで取得
+ */
+export async function findPublishedBillsWithContents(
+  difficultyLevel: DifficultyLevelEnum
+) {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("bills")
+    .select(
+      `
+      *,
+      bill_contents!inner (
+        id,
+        bill_id,
+        title,
+        summary,
+        content,
+        difficulty_level,
+        created_at,
+        updated_at
+      )
+    `
+    )
+    .eq("publish_status", "published")
+    .eq("bill_contents.difficulty_level", difficultyLevel)
+    .order("published_at", { ascending: false });
+
+  if (error) {
+    throw new Error(`Failed to fetch bills: ${error.message}`);
+  }
+
+  return data;
+}
+
+/**
+ * 公開済み議案を1件取得
+ */
+export async function findPublishedBillById(id: string) {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("bills")
+    .select("*")
+    .eq("id", id)
+    .eq("publish_status", "published")
+    .single();
+
+  if (error) {
+    return null;
+  }
+
+  return data;
+}
+
+/**
+ * 管理者用: ステータス問わず議案を1件取得
+ */
+export async function findBillById(id: string) {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("bills")
+    .select("*")
+    .eq("id", id)
+    .single();
+
+  if (error) {
+    return null;
+  }
+
+  return data;
+}
+
+/**
+ * 議案のmirai_stanceを取得
+ */
+export async function findMiraiStanceByBillId(billId: string) {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("mirai_stances")
+    .select("*")
+    .eq("bill_id", billId)
+    .single();
+
+  if (error) {
+    return null;
+  }
+
+  return data;
+}
+
+/**
+ * 議案のタグを取得
+ */
+export async function findTagsByBillId(billId: string) {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("bills_tags")
+    .select("tags(id, label)")
+    .eq("bill_id", billId);
+
+  if (error) {
+    return null;
+  }
+
+  return data;
+}
+
+// ============================================================
+// Bill Contents
+// ============================================================
+
+/**
+ * 指定された難易度の議案コンテンツを取得
+ */
+export async function findBillContentByDifficulty(
+  billId: string,
+  difficultyLevel: DifficultyLevelEnum
+) {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("bill_contents")
+    .select("*")
+    .eq("bill_id", billId)
+    .eq("difficulty_level", difficultyLevel)
+    .single();
+
+  if (error) {
+    console.error(`Failed to fetch bill content: ${error.message}`);
+    return null;
+  }
+
+  return data;
+}
+
+// ============================================================
+// Tags (bulk)
+// ============================================================
+
+type BillTag = {
+  bill_id: string;
+  tags: { id: string; label: string } | null;
+};
+
+function groupTagsByBillId(
+  billTags: BillTag[]
+): Map<string, Array<{ id: string; label: string }>> {
+  return billTags.reduce((acc, bt) => {
+    if (bt.tags) {
+      const existing = acc.get(bt.bill_id) ?? [];
+      acc.set(bt.bill_id, [...existing, bt.tags]);
+    }
+    return acc;
+  }, new Map<string, Array<{ id: string; label: string }>>());
+}
+
+/**
+ * 複数のbill_idに紐づくタグを一括取得し、bill_idごとにグループ化して返す
+ */
+export async function findTagsByBillIds(
+  billIds: string[]
+): Promise<Map<string, Array<{ id: string; label: string }>>> {
+  if (billIds.length === 0) {
+    return new Map();
+  }
+
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("bills_tags")
+    .select("bill_id, tags(id, label)")
+    .in("bill_id", billIds);
+
+  if (error) {
+    throw new Error(`Failed to fetch tags: ${error.message}`);
+  }
+
+  return groupTagsByBillId(data ?? []);
+}
+
+// ============================================================
+// Diet Session Bills
+// ============================================================
+
+/**
+ * 国会会期IDに紐づく公開済み議案を取得
+ */
+export async function findPublishedBillsByDietSession(
+  dietSessionId: string,
+  difficultyLevel: DifficultyLevelEnum
+) {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("bills")
+    .select(
+      `
+      *,
+      bill_contents!inner (
+        id,
+        bill_id,
+        title,
+        summary,
+        content,
+        difficulty_level,
+        created_at,
+        updated_at
+      )
+    `
+    )
+    .eq("diet_session_id", dietSessionId)
+    .eq("publish_status", "published")
+    .eq("bill_contents.difficulty_level", difficultyLevel)
+    .order("status", { ascending: true })
+    .order("published_at", { ascending: false });
+
+  if (error) {
+    throw new Error(`Failed to fetch bills by diet session: ${error.message}`);
+  }
+
+  return data;
+}
+
+/**
+ * 前回の国会会期の公開済み議案を取得（件数制限あり）
+ */
+export async function findPreviousSessionBills(
+  dietSessionId: string,
+  difficultyLevel: DifficultyLevelEnum,
+  limit: number
+) {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("bills")
+    .select(
+      `
+      *,
+      bill_contents!inner (
+        id,
+        bill_id,
+        title,
+        summary,
+        content,
+        difficulty_level,
+        created_at,
+        updated_at
+      )
+    `
+    )
+    .eq("diet_session_id", dietSessionId)
+    .eq("publish_status", "published")
+    .eq("bill_contents.difficulty_level", difficultyLevel)
+    .order("published_at", { ascending: false })
+    .limit(limit);
+
+  if (error) {
+    console.error("Failed to fetch previous session bills:", error);
+    return [];
+  }
+
+  return data ?? [];
+}
+
+/**
+ * 前回の国会会期の公開済み議案数を取得
+ */
+export async function countPublishedBillsByDietSession(
+  dietSessionId: string,
+  difficultyLevel: DifficultyLevelEnum
+): Promise<number> {
+  const supabase = createAdminClient();
+  const { count, error } = await supabase
+    .from("bills")
+    .select("*, bill_contents!inner(difficulty_level)", {
+      count: "exact",
+      head: true,
+    })
+    .eq("diet_session_id", dietSessionId)
+    .eq("publish_status", "published")
+    .eq("bill_contents.difficulty_level", difficultyLevel);
+
+  if (error) {
+    console.error("Failed to count previous session bills:", error);
+    return 0;
+  }
+
+  return count ?? 0;
+}
+
+// ============================================================
+// Featured
+// ============================================================
+
+/**
+ * featured_priorityが設定されているタグを取得
+ */
+export async function findFeaturedTags() {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("tags")
+    .select("id, label, description, featured_priority")
+    .not("featured_priority", "is", null)
+    .order("featured_priority", { ascending: true });
+
+  if (error) {
+    console.error("Failed to fetch featured tags:", error);
+    return [];
+  }
+
+  return data ?? [];
+}
+
+/**
+ * 特定タグに紐づく公開済み議案を取得（bill_contents + タグ付き）
+ */
+export async function findPublishedBillsByTag(
+  tagId: string,
+  difficultyLevel: DifficultyLevelEnum,
+  dietSessionId: string | null
+) {
+  const supabase = createAdminClient();
+  let query = supabase
+    .from("bills_tags")
+    .select(
+      `
+      bill_id,
+      bills!inner (
+        *,
+        bill_contents!inner (
+          id,
+          bill_id,
+          title,
+          summary,
+          content,
+          difficulty_level,
+          created_at,
+          updated_at
+        ),
+        bills_tags!inner (
+          tags (
+            id,
+            label
+          )
+        )
+      )
+    `
+    )
+    .eq("tag_id", tagId)
+    .eq("bills.publish_status", "published")
+    .eq("bills.bill_contents.difficulty_level", difficultyLevel);
+
+  if (dietSessionId) {
+    query = query.eq("bills.diet_session_id", dietSessionId);
+  }
+
+  const { data, error } = await query;
+
+  if (error) {
+    console.error(`Failed to fetch bills for tag:`, error);
+    return null;
+  }
+
+  return data;
+}
+
+/**
+ * 注目の議案を取得（is_featured = true）
+ */
+export async function findFeaturedBillsWithContents(
+  difficultyLevel: DifficultyLevelEnum,
+  dietSessionId: string | null
+) {
+  const supabase = createAdminClient();
+  let query = supabase
+    .from("bills")
+    .select(
+      `
+      *,
+      bill_contents!inner (
+        id,
+        bill_id,
+        title,
+        summary,
+        content,
+        difficulty_level,
+        created_at,
+        updated_at
+      ),
+      tags:bills_tags(
+        tag:tags(
+          id,
+          label
+        )
+      )
+    `
+    )
+    .eq("is_featured", true)
+    .eq("bill_contents.difficulty_level", difficultyLevel)
+    .order("published_at", { ascending: false });
+
+  if (dietSessionId) {
+    query = query.eq("diet_session_id", dietSessionId);
+  }
+
+  const { data, error } = await query;
+
+  if (error) {
+    console.error("Failed to fetch featured bills:", error);
+    return [];
+  }
+
+  return data ?? [];
+}
+
+// ============================================================
+// Coming Soon
+// ============================================================
+
+/**
+ * Coming Soon議案を取得
+ */
+export async function findComingSoonBills(dietSessionId: string | null) {
+  const supabase = createAdminClient();
+  let query = supabase
+    .from("bills")
+    .select(
+      `
+      id,
+      name,
+      originating_house,
+      shugiin_url,
+      bill_contents (
+        title,
+        difficulty_level
+      )
+    `
+    )
+    .eq("publish_status", "coming_soon")
+    .order("created_at", { ascending: false });
+
+  if (dietSessionId) {
+    query = query.eq("diet_session_id", dietSessionId);
+  }
+
+  const { data, error } = await query;
+
+  if (error) {
+    console.error("Failed to fetch coming soon bills:", error);
+    return [];
+  }
+
+  return data ?? [];
+}
+
+// ============================================================
+// Preview Tokens
+// ============================================================
+
+/**
+ * プレビュートークンを検証
+ */
+export async function findPreviewToken(billId: string, token: string) {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("preview_tokens")
+    .select("expires_at")
+    .eq("bill_id", billId)
+    .eq("token", token)
+    .single();
+
+  if (error || !data) {
+    return null;
+  }
+
+  return data;
+}


### PR DESCRIPTION
## Summary
- bills featureにrepositoryレイヤー（`server/repositories/bill-repository.ts`）を追加
- loaders/helpersのSupabase直接呼び出しをrepository関数に集約
- データアクセス層の分離により、テスタビリティと保守性を向上

## 変更内容
- 新規: `bill-repository.ts` - 全Supabaseクエリを集約（findPublishedBillsWithContents, findPublishedBillById, findBillById, findMiraiStanceByBillId, findTagsByBillId, findBillContentByDifficulty, findTagsByBillIds, findPublishedBillsByDietSession, findPreviousSessionBills, countPublishedBillsByDietSession, findFeaturedTags, findPublishedBillsByTag, findFeaturedBillsWithContents, findComingSoonBills, findPreviewToken）
- 更新: 各loaderファイルからSupabase直接呼び出しを削除し、repository関数を利用
- 更新: get-bill-content.ts / get-bill-tags.ts ヘルパーもrepository経由に変更

## Test plan
- [x] pnpm typecheck 通過
- [x] pnpm lint 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)