### PR TITLE
refactor: interview-session featureにrepositoryレイヤーを追加

### DIFF
--- a/web/src/features/interview-session/server/actions/archive-interview-session.ts
+++ b/web/src/features/interview-session/server/actions/archive-interview-session.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { createAdminClient } from "@mirai-gikai/supabase";
+import { updateInterviewSessionArchived } from "../repositories/interview-session-repository";
 import { verifySessionOwnership } from "../utils/verify-session-ownership";
 
 interface ArchiveInterviewSessionResult {
@@ -21,16 +21,10 @@ export async function archiveInterviewSession(
     return { success: false, error: ownershipResult.error };
   }
 
-  const supabase = createAdminClient();
-
-  // アーカイブ実行
-  const { error: updateError } = await supabase
-    .from("interview_sessions")
-    .update({ archived_at: new Date().toISOString() })
-    .eq("id", sessionId);
-
-  if (updateError) {
-    console.error("Failed to archive interview session:", updateError);
+  try {
+    await updateInterviewSessionArchived(sessionId);
+  } catch (error) {
+    console.error("Failed to archive interview session:", error);
     return { success: false, error: "アーカイブに失敗しました" };
   }
 

--- a/web/src/features/interview-session/server/actions/create-interview-session.ts
+++ b/web/src/features/interview-session/server/actions/create-interview-session.ts
@@ -1,8 +1,8 @@
 "use server";
 
-import { createAdminClient } from "@mirai-gikai/supabase";
 import { getChatSupabaseUser } from "@/features/chat/server/utils/supabase-server";
 import type { InterviewSession } from "../../shared/types";
+import { createInterviewSessionRecord } from "../repositories/interview-session-repository";
 
 export async function createInterviewSession({
   interviewConfigId,
@@ -21,21 +21,8 @@ export async function createInterviewSession({
     );
   }
 
-  const supabase = createAdminClient();
-
-  const { data, error } = await supabase
-    .from("interview_sessions")
-    .insert({
-      interview_config_id: interviewConfigId,
-      user_id: user.id,
-      started_at: new Date().toISOString(),
-    })
-    .select()
-    .single();
-
-  if (error) {
-    throw new Error(`Failed to create interview session: ${error.message}`);
-  }
-
-  return data;
+  return await createInterviewSessionRecord({
+    interviewConfigId,
+    userId: user.id,
+  });
 }

--- a/web/src/features/interview-session/server/loaders/get-interview-messages.ts
+++ b/web/src/features/interview-session/server/loaders/get-interview-messages.ts
@@ -1,7 +1,7 @@
 import "server-only";
 
-import { createAdminClient } from "@mirai-gikai/supabase";
 import type { InterviewMessage } from "../../shared/types";
+import { findInterviewMessagesBySessionId } from "../repositories/interview-session-repository";
 import { verifySessionOwnership } from "../utils/verify-session-ownership";
 
 export async function getInterviewMessages(
@@ -17,19 +17,10 @@ export async function getInterviewMessages(
     return [];
   }
 
-  const supabase = createAdminClient();
-
-  // メッセージを取得
-  const { data, error } = await supabase
-    .from("interview_messages")
-    .select("*")
-    .eq("interview_session_id", sessionId)
-    .order("created_at", { ascending: true });
-
-  if (error) {
+  try {
+    return await findInterviewMessagesBySessionId(sessionId);
+  } catch (error) {
     console.error("Failed to fetch interview messages:", error);
     return [];
   }
-
-  return data || [];
 }

--- a/web/src/features/interview-session/server/loaders/get-interview-session-by-id.ts
+++ b/web/src/features/interview-session/server/loaders/get-interview-session-by-id.ts
@@ -1,7 +1,7 @@
 import "server-only";
 
-import { createAdminClient } from "@mirai-gikai/supabase";
 import type { InterviewSession } from "../../shared/types";
+import { findInterviewSessionWithConfigById } from "../repositories/interview-session-repository";
 import {
   getAuthenticatedUser,
   isSessionOwner,
@@ -26,17 +26,12 @@ export async function getInterviewSessionById(
   }
 
   const { userId } = authResult;
-  const supabase = createAdminClient();
 
-  // セッションとinterview_configを結合して取得
-  const { data: session, error: sessionError } = await supabase
-    .from("interview_sessions")
-    .select("*, interview_configs(bill_id)")
-    .eq("id", sessionId)
-    .single();
-
-  if (sessionError || !session) {
-    console.error("Failed to fetch interview session:", sessionError);
+  let session: Awaited<ReturnType<typeof findInterviewSessionWithConfigById>>;
+  try {
+    session = await findInterviewSessionWithConfigById(sessionId);
+  } catch (error) {
+    console.error("Failed to fetch interview session:", error);
     return null;
   }
 

--- a/web/src/features/interview-session/server/loaders/get-interview-session.ts
+++ b/web/src/features/interview-session/server/loaders/get-interview-session.ts
@@ -1,8 +1,8 @@
 import "server-only";
 
-import { createAdminClient } from "@mirai-gikai/supabase";
 import { getChatSupabaseUser } from "@/features/chat/server/utils/supabase-server";
 import type { InterviewSession } from "../../shared/types";
+import { findActiveInterviewSession } from "../repositories/interview-session-repository";
 
 export async function getInterviewSession(
   interviewConfigId: string
@@ -18,23 +18,10 @@ export async function getInterviewSession(
     return null;
   }
 
-  const supabase = createAdminClient();
-
-  const { data, error } = await supabase
-    .from("interview_sessions")
-    .select("*")
-    .eq("interview_config_id", interviewConfigId)
-    .eq("user_id", user.id)
-    .is("completed_at", null) // 未完了のセッションのみ
-    .is("archived_at", null) // アーカイブされていないセッションのみ
-    .order("created_at", { ascending: false })
-    .limit(1)
-    .maybeSingle();
-
-  if (error) {
+  try {
+    return await findActiveInterviewSession(interviewConfigId, user.id);
+  } catch (error) {
     console.error("Failed to fetch interview session:", error);
     return null;
   }
-
-  return data;
 }

--- a/web/src/features/interview-session/server/repositories/interview-session-repository.ts
+++ b/web/src/features/interview-session/server/repositories/interview-session-repository.ts
@@ -1,0 +1,257 @@
+import "server-only";
+
+import { createAdminClient } from "@mirai-gikai/supabase";
+import type {
+  InterviewMessage,
+  InterviewReport,
+  InterviewReportInsert,
+  InterviewSession,
+} from "../../shared/types";
+
+// ========================================
+// Interview Sessions
+// ========================================
+
+/**
+ * アクティブ（未完了・未アーカイブ）なインタビューセッションを取得
+ */
+export async function findActiveInterviewSession(
+  interviewConfigId: string,
+  userId: string
+): Promise<InterviewSession | null> {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("interview_sessions")
+    .select("*")
+    .eq("interview_config_id", interviewConfigId)
+    .eq("user_id", userId)
+    .is("completed_at", null)
+    .is("archived_at", null)
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(
+      `Failed to fetch active interview session: ${error.message}`
+    );
+  }
+
+  return data;
+}
+
+/**
+ * セッションIDからインタビューセッション（interview_configs付き）を取得
+ */
+export async function findInterviewSessionWithConfigById(sessionId: string) {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("interview_sessions")
+    .select("*, interview_configs(bill_id)")
+    .eq("id", sessionId)
+    .single();
+
+  if (error) {
+    throw new Error(`Failed to fetch interview session: ${error.message}`);
+  }
+
+  return data;
+}
+
+/**
+ * 最新の未アーカイブセッション（完了済みも含む）を取得
+ */
+export async function findLatestNonArchivedSession(
+  interviewConfigId: string,
+  userId: string
+) {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("interview_sessions")
+    .select("id, completed_at, interview_report(id)")
+    .eq("interview_config_id", interviewConfigId)
+    .eq("user_id", userId)
+    .is("archived_at", null)
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(
+      `Failed to fetch latest interview session: ${error.message}`
+    );
+  }
+
+  return data;
+}
+
+/**
+ * セッションの所有者情報（user_id）を取得
+ */
+export async function findSessionOwnerById(sessionId: string) {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("interview_sessions")
+    .select("user_id")
+    .eq("id", sessionId)
+    .single();
+
+  if (error) {
+    throw new Error(`Failed to fetch session owner: ${error.message}`);
+  }
+
+  return data;
+}
+
+/**
+ * 新しいインタビューセッションを作成
+ */
+export async function createInterviewSessionRecord(params: {
+  interviewConfigId: string;
+  userId: string;
+}): Promise<InterviewSession> {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("interview_sessions")
+    .insert({
+      interview_config_id: params.interviewConfigId,
+      user_id: params.userId,
+      started_at: new Date().toISOString(),
+    })
+    .select()
+    .single();
+
+  if (error) {
+    throw new Error(`Failed to create interview session: ${error.message}`);
+  }
+
+  return data;
+}
+
+/**
+ * セッションをアーカイブ
+ */
+export async function updateInterviewSessionArchived(
+  sessionId: string
+): Promise<void> {
+  const supabase = createAdminClient();
+  const { error } = await supabase
+    .from("interview_sessions")
+    .update({ archived_at: new Date().toISOString() })
+    .eq("id", sessionId);
+
+  if (error) {
+    throw new Error(`Failed to archive interview session: ${error.message}`);
+  }
+}
+
+/**
+ * セッションを完了
+ */
+export async function updateInterviewSessionCompleted(
+  sessionId: string
+): Promise<void> {
+  const supabase = createAdminClient();
+  const { error } = await supabase
+    .from("interview_sessions")
+    .update({ completed_at: new Date().toISOString() })
+    .eq("id", sessionId);
+
+  if (error) {
+    throw new Error(`Failed to complete interview session: ${error.message}`);
+  }
+}
+
+// ========================================
+// Interview Messages
+// ========================================
+
+/**
+ * セッションのメッセージを時系列順で取得
+ */
+export async function findInterviewMessagesBySessionId(
+  sessionId: string
+): Promise<InterviewMessage[]> {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("interview_messages")
+    .select("*")
+    .eq("interview_session_id", sessionId)
+    .order("created_at", { ascending: true });
+
+  if (error) {
+    throw new Error(`Failed to fetch interview messages: ${error.message}`);
+  }
+
+  return data || [];
+}
+
+/**
+ * セッションのメッセージを新しい順で取得
+ */
+export async function findInterviewMessagesBySessionIdDesc(
+  sessionId: string
+): Promise<InterviewMessage[]> {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("interview_messages")
+    .select("*")
+    .eq("interview_session_id", sessionId)
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    throw new Error(`Failed to fetch interview messages: ${error.message}`);
+  }
+
+  return data || [];
+}
+
+/**
+ * インタビューメッセージを保存
+ */
+export async function createInterviewMessage(params: {
+  sessionId: string;
+  role: "assistant" | "user";
+  content: string;
+}): Promise<InterviewMessage> {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("interview_messages")
+    .insert({
+      interview_session_id: params.sessionId,
+      role: params.role,
+      content: params.content,
+    })
+    .select()
+    .single();
+
+  if (error) {
+    throw new Error(`Failed to save interview message: ${error.message}`);
+  }
+
+  return data;
+}
+
+// ========================================
+// Interview Reports
+// ========================================
+
+/**
+ * インタビューレポートをUPSERT
+ */
+export async function upsertInterviewReport(
+  params: InterviewReportInsert
+): Promise<InterviewReport> {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("interview_report")
+    .upsert(params, { onConflict: "interview_session_id" })
+    .select()
+    .single();
+
+  if (error) {
+    throw new Error(`Failed to save interview report: ${error.message}`);
+  }
+
+  return data;
+}

--- a/web/src/features/interview-session/server/services/complete-interview-session.ts
+++ b/web/src/features/interview-session/server/services/complete-interview-session.ts
@@ -1,11 +1,15 @@
 import "server-only";
 
-import { createAdminClient } from "@mirai-gikai/supabase";
 import {
   type InterviewReportData,
   interviewChatWithReportSchema,
 } from "../../shared/schemas";
 import type { InterviewReport } from "../../shared/types";
+import {
+  findInterviewMessagesBySessionIdDesc,
+  updateInterviewSessionCompleted,
+  upsertInterviewReport,
+} from "../repositories/interview-session-repository";
 
 type CompleteInterviewSessionParams = {
   sessionId: string;
@@ -34,20 +38,8 @@ function extractReportFromMessage(content: string): InterviewReportData | null {
 export async function completeInterviewSession({
   sessionId,
 }: CompleteInterviewSessionParams): Promise<InterviewReport> {
-  const supabase = createAdminClient();
-
   // メッセージ履歴を取得（新しい順）
-  const { data: messages, error: messagesError } = await supabase
-    .from("interview_messages")
-    .select("*")
-    .eq("interview_session_id", sessionId)
-    .order("created_at", { ascending: false });
-
-  if (messagesError || !messages) {
-    throw new Error(
-      `Failed to fetch interview messages: ${messagesError?.message ?? "unknown"}`
-    );
-  }
+  const messages = await findInterviewMessagesBySessionIdDesc(sessionId);
 
   // 最新のアシスタントメッセージからレポートを抽出
   let reportData: InterviewReportData | null = null;
@@ -66,41 +58,19 @@ export async function completeInterviewSession({
 
   // レポートを保存（UPSERT）
   // scoresはZodスキーマでバリデーション済み（totalは0-100の整数）
-  const { data: report, error: upsertError } = await supabase
-    .from("interview_report")
-    .upsert(
-      {
-        interview_session_id: sessionId,
-        summary: reportData.summary,
-        stance: reportData.stance,
-        role: reportData.role,
-        role_description: reportData.role_description,
-        role_title: reportData.role_title,
-        opinions: reportData.opinions,
-        scores: reportData.scores,
-      },
-      { onConflict: "interview_session_id" }
-    )
-    .select()
-    .single();
-
-  if (upsertError || !report) {
-    throw new Error(
-      `Failed to save interview report: ${upsertError?.message ?? "unknown"}`
-    );
-  }
+  const report = await upsertInterviewReport({
+    interview_session_id: sessionId,
+    summary: reportData.summary,
+    stance: reportData.stance,
+    role: reportData.role,
+    role_description: reportData.role_description,
+    role_title: reportData.role_title,
+    opinions: reportData.opinions,
+    scores: reportData.scores,
+  });
 
   // セッションを完了
-  const { error: sessionUpdateError } = await supabase
-    .from("interview_sessions")
-    .update({ completed_at: new Date().toISOString() })
-    .eq("id", sessionId);
-
-  if (sessionUpdateError) {
-    throw new Error(
-      `Failed to complete interview session: ${sessionUpdateError?.message ?? "unknown"}`
-    );
-  }
+  await updateInterviewSessionCompleted(sessionId);
 
   return report;
 }

--- a/web/src/features/interview-session/server/services/save-interview-message.ts
+++ b/web/src/features/interview-session/server/services/save-interview-message.ts
@@ -1,7 +1,7 @@
 import "server-only";
 
-import { createAdminClient } from "@mirai-gikai/supabase";
 import { logger } from "@/lib/logger";
+import { createInterviewMessage } from "../repositories/interview-session-repository";
 
 interface SaveInterviewMessageParams {
   sessionId: string;
@@ -25,16 +25,5 @@ export async function saveInterviewMessage({
     return;
   }
 
-  const supabase = createAdminClient();
-
-  const { error } = await supabase.from("interview_messages").insert({
-    interview_session_id: sessionId,
-    role,
-    content,
-  });
-
-  if (error) {
-    console.error("Failed to save interview message:", error);
-    throw new Error(`Failed to save interview message: ${error.message}`);
-  }
+  await createInterviewMessage({ sessionId, role, content });
 }

--- a/web/src/features/interview-session/server/utils/verify-session-ownership.ts
+++ b/web/src/features/interview-session/server/utils/verify-session-ownership.ts
@@ -1,7 +1,7 @@
 import "server-only";
 
-import { createAdminClient } from "@mirai-gikai/supabase";
 import { getChatSupabaseUser } from "@/features/chat/server/utils/supabase-server";
+import { findSessionOwnerById } from "../repositories/interview-session-repository";
 
 export type AuthenticatedUserResult =
   | {
@@ -54,16 +54,15 @@ export async function verifySessionOwnership(
   }
 
   const { userId } = authResult;
-  const supabase = createAdminClient();
 
-  const { data: session, error: sessionError } = await supabase
-    .from("interview_sessions")
-    .select("user_id")
-    .eq("id", sessionId)
-    .single();
-
-  if (sessionError || !session) {
-    return { authorized: false, error: "セッションが見つかりません" };
+  let session: { user_id: string };
+  try {
+    session = await findSessionOwnerById(sessionId);
+  } catch {
+    return {
+      authorized: false,
+      error: "セッションが見つかりません",
+    };
   }
 
   if (session.user_id !== userId) {


### PR DESCRIPTION
## Summary
- interview-session featureにrepositoryレイヤー（`server/repositories/interview-session-repository.ts`）を追加
- loaders/actions/services/utilsのSupabase直接呼び出しをrepository関数に集約
- データアクセス層の分離により、テスタビリティと保守性を向上

## 変更内容
- 新規: `interview-session-repository.ts` - 全Supabaseクエリを集約
- 更新: 各loader/action/service/utilsファイルからSupabase直接呼び出しを削除し、repository関数を利用

## Test plan
- [x] pnpm typecheck 通過
- [x] pnpm lint 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)