### PR TITLE
refactor: interview-report featureにrepositoryレイヤーを追加

### DIFF
--- a/web/src/features/interview-report/server/actions/update-public-setting.ts
+++ b/web/src/features/interview-report/server/actions/update-public-setting.ts
@@ -1,7 +1,7 @@
 "use server";
 
-import { createAdminClient } from "@mirai-gikai/supabase";
 import { verifySessionOwnership } from "@/features/interview-session/server/utils/verify-session-ownership";
+import { updateSessionPublicSetting } from "../repositories/interview-report-repository";
 
 interface UpdatePublicSettingResult {
   success: boolean;
@@ -21,17 +21,10 @@ export async function updatePublicSetting(
     return { success: false, error: ownershipResult.error };
   }
 
-  const supabase = createAdminClient();
-
-  const { error: updateError } = await supabase
-    .from("interview_sessions")
-    .update({ is_public_by_user: isPublic })
-    .eq("id", sessionId);
-
-  if (updateError) {
-    console.error("Failed to update public setting:", updateError);
+  try {
+    await updateSessionPublicSetting(sessionId, isPublic);
+    return { success: true };
+  } catch {
     return { success: false, error: "公開設定の更新に失敗しました" };
   }
-
-  return { success: true };
 }

--- a/web/src/features/interview-report/server/loaders/get-interview-report.ts
+++ b/web/src/features/interview-report/server/loaders/get-interview-report.ts
@@ -1,8 +1,8 @@
 import "server-only";
 
-import { createAdminClient } from "@mirai-gikai/supabase";
 import { verifySessionOwnership } from "@/features/interview-session/server/utils/verify-session-ownership";
 import type { InterviewReport } from "../../shared/types";
+import { findReportBySessionId } from "../repositories/interview-report-repository";
 
 /**
  * セッションIDからインタビューレポートを取得
@@ -21,19 +21,10 @@ export async function getInterviewReport(
     return null;
   }
 
-  const supabase = createAdminClient();
-
-  // レポートを取得
-  const { data: report, error: reportError } = await supabase
-    .from("interview_report")
-    .select("*")
-    .eq("interview_session_id", sessionId)
-    .single();
-
-  if (reportError) {
-    console.error("Failed to fetch interview report:", reportError);
+  try {
+    return await findReportBySessionId(sessionId);
+  } catch (error) {
+    console.error("Failed to fetch interview report:", error);
     return null;
   }
-
-  return report;
 }

--- a/web/src/features/interview-report/server/repositories/interview-report-repository.ts
+++ b/web/src/features/interview-report/server/repositories/interview-report-repository.ts
@@ -1,0 +1,95 @@
+import "server-only";
+
+import { createAdminClient } from "@mirai-gikai/supabase";
+
+/**
+ * レポートIDからインタビューレポートとセッション情報を結合取得
+ */
+export async function findReportWithSessionById(reportId: string) {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("interview_report")
+    .select(
+      "*, interview_sessions(user_id, started_at, completed_at, is_public_by_user, interview_configs(bill_id))"
+    )
+    .eq("id", reportId)
+    .single();
+
+  if (error) {
+    throw new Error(`Failed to fetch interview report: ${error.message}`);
+  }
+
+  return data;
+}
+
+/**
+ * セッションIDからインタビューレポートを取得
+ */
+export async function findReportBySessionId(sessionId: string) {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("interview_report")
+    .select("*")
+    .eq("interview_session_id", sessionId)
+    .single();
+
+  if (error) {
+    throw new Error(`Failed to fetch interview report: ${error.message}`);
+  }
+
+  return data;
+}
+
+/**
+ * セッションIDからインタビューメッセージ一覧を取得（作成日時昇順）
+ */
+export async function findMessagesBySessionId(sessionId: string) {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("interview_messages")
+    .select("*")
+    .eq("interview_session_id", sessionId)
+    .order("created_at", { ascending: true });
+
+  if (error) {
+    throw new Error(`Failed to fetch interview messages: ${error.message}`);
+  }
+
+  return data;
+}
+
+/**
+ * 議案IDから議案情報を取得（bill_contentsを結合）
+ */
+export async function findBillWithContentById(billId: string) {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("bills")
+    .select("id, name, thumbnail_url, bill_contents(title)")
+    .eq("id", billId)
+    .single();
+
+  if (error) {
+    throw new Error(`Failed to fetch bill: ${error.message}`);
+  }
+
+  return data;
+}
+
+/**
+ * セッションの公開設定を更新
+ */
+export async function updateSessionPublicSetting(
+  sessionId: string,
+  isPublic: boolean
+) {
+  const supabase = createAdminClient();
+  const { error } = await supabase
+    .from("interview_sessions")
+    .update({ is_public_by_user: isPublic })
+    .eq("id", sessionId);
+
+  if (error) {
+    throw new Error(`Failed to update public setting: ${error.message}`);
+  }
+}


### PR DESCRIPTION
## Summary
- interview-report featureにrepositoryレイヤー（`server/repositories/interview-report-repository.ts`）を追加
- loaders/actionsのSupabase直接呼び出しをrepository関数に集約

## Test plan
- [x] pnpm typecheck 通過
- [x] pnpm lint 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)