### PR TITLE
refactor: admin/bills-edit featureにrepositoryレイヤーを追加

### DIFF
--- a/admin/src/features/bills-edit/actions/create-bill.ts
+++ b/admin/src/features/bills-edit/actions/create-bill.ts
@@ -1,10 +1,10 @@
 "use server";
 
-import { createAdminClient } from "@mirai-gikai/supabase";
 import { redirect } from "next/navigation";
 import { requireAdmin } from "@/features/auth/lib/auth-server";
 import { invalidateWebCache } from "@/lib/utils/cache-invalidation";
 import { type BillCreateInput, billCreateSchema } from "../types";
+import { createBillRecord } from "../repositories/bill-edit-repository";
 
 export async function createBill(input: BillCreateInput) {
   try {
@@ -22,16 +22,7 @@ export async function createBill(input: BillCreateInput) {
     };
 
     // Supabaseに挿入
-    const supabase = createAdminClient();
-    const { error } = await supabase
-      .from("bills")
-      .insert(insertData)
-      .select("id")
-      .single();
-
-    if (error) {
-      throw new Error(`議案の作成に失敗しました: ${error.message}`);
-    }
+    await createBillRecord(insertData);
 
     // web側のキャッシュを無効化
     await invalidateWebCache();

--- a/admin/src/features/bills-edit/loaders/get-bill-by-id.ts
+++ b/admin/src/features/bills-edit/loaders/get-bill-by-id.ts
@@ -1,19 +1,11 @@
-import { createAdminClient } from "@mirai-gikai/supabase";
 import type { Bill } from "../types";
+import { findBillById } from "../repositories/bill-edit-repository";
 
 export async function getBillById(id: string): Promise<Bill | null> {
-  const supabase = createAdminClient();
-
-  const { data, error } = await supabase
-    .from("bills")
-    .select("*")
-    .eq("id", id)
-    .single();
-
-  if (error) {
+  try {
+    return await findBillById(id);
+  } catch (error) {
     console.error("Failed to fetch bill:", error);
     return null;
   }
-
-  return data;
 }

--- a/admin/src/features/bills-edit/loaders/get-bill-contents.ts
+++ b/admin/src/features/bills-edit/loaders/get-bill-contents.ts
@@ -1,25 +1,13 @@
-import { createAdminClient } from "@mirai-gikai/supabase";
 import { requireAdmin } from "@/features/auth/lib/auth-server";
 import type { BillContent } from "../types/bill-contents";
+import { findBillContentsByBillId } from "../repositories/bill-edit-repository";
 
 export async function getBillContents(billId: string): Promise<BillContent[]> {
   try {
     // 管理者権限チェック
     await requireAdmin();
 
-    // Supabaseから取得
-    const supabase = createAdminClient();
-    const { data, error } = await supabase
-      .from("bill_contents")
-      .select("*")
-      .eq("bill_id", billId)
-      .order("difficulty_level");
-
-    if (error) {
-      throw new Error(`議案コンテンツの取得に失敗しました: ${error.message}`);
-    }
-
-    return data || [];
+    return await findBillContentsByBillId(billId);
   } catch (error) {
     console.error("Get bill contents error:", error);
     throw error;

--- a/admin/src/features/bills-edit/loaders/get-bill-tag-ids.ts
+++ b/admin/src/features/bills-edit/loaders/get-bill-tag-ids.ts
@@ -1,19 +1,8 @@
-import { createAdminClient } from "@mirai-gikai/supabase";
+import { findBillTagIdsByBillId } from "../repositories/bill-edit-repository";
 
 /**
  * 議案に紐づくタグIDの配列を取得する
  */
 export async function getBillTagIds(billId: string): Promise<string[]> {
-  const supabase = createAdminClient();
-
-  const { data, error } = await supabase
-    .from("bills_tags")
-    .select("tag_id")
-    .eq("bill_id", billId);
-
-  if (error) {
-    throw new Error(`議案のタグ取得に失敗しました: ${error.message}`);
-  }
-
-  return data?.map((item) => item.tag_id) || [];
+  return findBillTagIdsByBillId(billId);
 }

--- a/admin/src/features/bills-edit/repositories/bill-edit-repository.ts
+++ b/admin/src/features/bills-edit/repositories/bill-edit-repository.ts
@@ -1,0 +1,147 @@
+import "server-only";
+
+import { createAdminClient } from "@mirai-gikai/supabase";
+import type { BillInsert } from "../types";
+import type { DifficultyLevel } from "../types/bill-contents";
+
+export async function findBillById(id: string) {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("bills")
+    .select("*")
+    .eq("id", id)
+    .single();
+
+  if (error) {
+    throw new Error(`Failed to fetch bill: ${error.message}`);
+  }
+
+  return data;
+}
+
+export async function findBillContentsByBillId(billId: string) {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("bill_contents")
+    .select("*")
+    .eq("bill_id", billId)
+    .order("difficulty_level");
+
+  if (error) {
+    throw new Error(`Failed to fetch bill contents: ${error.message}`);
+  }
+
+  return data ?? [];
+}
+
+export async function findBillTagIdsByBillId(billId: string) {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("bills_tags")
+    .select("tag_id")
+    .eq("bill_id", billId);
+
+  if (error) {
+    throw new Error(`Failed to fetch bill tag ids: ${error.message}`);
+  }
+
+  return data?.map((item) => item.tag_id) ?? [];
+}
+
+export async function createBillRecord(insertData: BillInsert) {
+  const supabase = createAdminClient();
+  const { error } = await supabase
+    .from("bills")
+    .insert(insertData)
+    .select("id")
+    .single();
+
+  if (error) {
+    throw new Error(`Failed to create bill: ${error.message}`);
+  }
+}
+
+export async function updateBillRecord(
+  id: string,
+  updateData: Record<string, unknown>
+) {
+  const supabase = createAdminClient();
+  const { error } = await supabase
+    .from("bills")
+    .update(updateData)
+    .eq("id", id);
+
+  if (error) {
+    throw new Error(`Failed to update bill: ${error.message}`);
+  }
+}
+
+export async function upsertBillContent(params: {
+  billId: string;
+  difficultyLevel: DifficultyLevel;
+  title: string;
+  summary: string;
+  content: string;
+}) {
+  const supabase = createAdminClient();
+  const { error } = await supabase.from("bill_contents").upsert(
+    {
+      bill_id: params.billId,
+      difficulty_level: params.difficultyLevel,
+      title: params.title,
+      summary: params.summary,
+      content: params.content,
+      updated_at: new Date().toISOString(),
+    },
+    {
+      onConflict: "bill_id,difficulty_level",
+    }
+  );
+
+  if (error) {
+    throw new Error(
+      `Failed to upsert bill content (${params.difficultyLevel}): ${error.message}`
+    );
+  }
+}
+
+export async function findBillsTagsByBillId(billId: string) {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("bills_tags")
+    .select("tag_id")
+    .eq("bill_id", billId);
+
+  if (error) {
+    throw new Error(`Failed to fetch bill tags: ${error.message}`);
+  }
+
+  return data?.map((t) => t.tag_id) ?? [];
+}
+
+export async function deleteBillsTags(billId: string, tagIds: string[]) {
+  const supabase = createAdminClient();
+  const { error } = await supabase
+    .from("bills_tags")
+    .delete()
+    .eq("bill_id", billId)
+    .in("tag_id", tagIds);
+
+  if (error) {
+    throw new Error(`Failed to delete bill tags: ${error.message}`);
+  }
+}
+
+export async function createBillsTags(billId: string, tagIds: string[]) {
+  const supabase = createAdminClient();
+  const billTags = tagIds.map((tagId) => ({
+    bill_id: billId,
+    tag_id: tagId,
+  }));
+
+  const { error } = await supabase.from("bills_tags").insert(billTags);
+
+  if (error) {
+    throw new Error(`Failed to create bill tags: ${error.message}`);
+  }
+}


### PR DESCRIPTION
## Summary
- admin/bills-edit featureにrepositoryレイヤーを追加
- loaders/actionsのSupabase直接呼び出しをrepository関数に集約

## Test plan
- [x] pnpm typecheck 通過
- [x] pnpm lint 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)