### PR TITLE
refactor: admin/mirai-stance featureにrepositoryレイヤーを追加

### DIFF
--- a/admin/src/features/mirai-stance/actions/create-stance.ts
+++ b/admin/src/features/mirai-stance/actions/create-stance.ts
@@ -1,23 +1,12 @@
 "use server";
 
-import { createAdminClient } from "@mirai-gikai/supabase";
 import { invalidateWebCache } from "@/lib/utils/cache-invalidation";
 import type { StanceInput } from "../types";
+import { createMiraiStance } from "../repositories/mirai-stance-repository";
 
 export async function createStance(billId: string, data: StanceInput) {
   try {
-    const supabase = createAdminClient();
-
-    const { error } = await supabase.from("mirai_stances").insert({
-      bill_id: billId,
-      type: data.type,
-      comment: data.comment || null,
-    });
-
-    if (error) {
-      console.error("Error creating stance:", error);
-      throw new Error("スタンスの作成に失敗しました");
-    }
+    await createMiraiStance(billId, data);
 
     invalidateWebCache();
     return { success: true };

--- a/admin/src/features/mirai-stance/actions/delete-stance.ts
+++ b/admin/src/features/mirai-stance/actions/delete-stance.ts
@@ -1,21 +1,11 @@
 "use server";
 
-import { createAdminClient } from "@mirai-gikai/supabase";
 import { invalidateWebCache } from "@/lib/utils/cache-invalidation";
+import { deleteMiraiStance } from "../repositories/mirai-stance-repository";
 
 export async function deleteStance(stanceId: string) {
   try {
-    const supabase = createAdminClient();
-
-    const { error } = await supabase
-      .from("mirai_stances")
-      .delete()
-      .eq("id", stanceId);
-
-    if (error) {
-      console.error("Error deleting stance:", error);
-      throw new Error("スタンスの削除に失敗しました");
-    }
+    await deleteMiraiStance(stanceId);
 
     invalidateWebCache();
     return { success: true };

--- a/admin/src/features/mirai-stance/actions/update-stance.ts
+++ b/admin/src/features/mirai-stance/actions/update-stance.ts
@@ -1,26 +1,12 @@
 "use server";
 
-import { createAdminClient } from "@mirai-gikai/supabase";
 import { invalidateWebCache } from "@/lib/utils/cache-invalidation";
 import type { StanceInput } from "../types";
+import { updateMiraiStance } from "../repositories/mirai-stance-repository";
 
 export async function updateStance(stanceId: string, data: StanceInput) {
   try {
-    const supabase = createAdminClient();
-
-    const { error } = await supabase
-      .from("mirai_stances")
-      .update({
-        type: data.type,
-        comment: data.comment || null,
-        updated_at: new Date().toISOString(),
-      })
-      .eq("id", stanceId);
-
-    if (error) {
-      console.error("Error updating stance:", error);
-      throw new Error("スタンスの更新に失敗しました");
-    }
+    await updateMiraiStance(stanceId, data);
 
     invalidateWebCache();
     return { success: true };

--- a/admin/src/features/mirai-stance/loaders/get-stance-by-bill-id.ts
+++ b/admin/src/features/mirai-stance/loaders/get-stance-by-bill-id.ts
@@ -1,24 +1,8 @@
-import { createAdminClient } from "@mirai-gikai/supabase";
 import type { MiraiStance } from "../types";
+import { findStanceByBillId } from "../repositories/mirai-stance-repository";
 
 export async function getStanceByBillId(
   billId: string
 ): Promise<MiraiStance | null> {
-  const supabase = createAdminClient();
-
-  const { data, error } = await supabase
-    .from("mirai_stances")
-    .select("*")
-    .eq("bill_id", billId)
-    .single();
-
-  if (error) {
-    if (error.code !== "PGRST116") {
-      // スタンスが存在しないエラー以外はログに出力
-      console.error("Failed to fetch stance:", error);
-    }
-    return null;
-  }
-
-  return data;
+  return findStanceByBillId(billId);
 }

--- a/admin/src/features/mirai-stance/repositories/mirai-stance-repository.ts
+++ b/admin/src/features/mirai-stance/repositories/mirai-stance-repository.ts
@@ -1,0 +1,63 @@
+import "server-only";
+
+import { createAdminClient } from "@mirai-gikai/supabase";
+import type { StanceInput } from "../types";
+
+export async function findStanceByBillId(billId: string) {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("mirai_stances")
+    .select("*")
+    .eq("bill_id", billId)
+    .single();
+
+  if (error) {
+    if (error.code !== "PGRST116") {
+      throw new Error(`Failed to fetch stance: ${error.message}`);
+    }
+    return null;
+  }
+
+  return data;
+}
+
+export async function createMiraiStance(billId: string, input: StanceInput) {
+  const supabase = createAdminClient();
+  const { error } = await supabase.from("mirai_stances").insert({
+    bill_id: billId,
+    type: input.type,
+    comment: input.comment || null,
+  });
+
+  if (error) {
+    throw new Error(`Failed to create stance: ${error.message}`);
+  }
+}
+
+export async function updateMiraiStance(stanceId: string, input: StanceInput) {
+  const supabase = createAdminClient();
+  const { error } = await supabase
+    .from("mirai_stances")
+    .update({
+      type: input.type,
+      comment: input.comment || null,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", stanceId);
+
+  if (error) {
+    throw new Error(`Failed to update stance: ${error.message}`);
+  }
+}
+
+export async function deleteMiraiStance(stanceId: string) {
+  const supabase = createAdminClient();
+  const { error } = await supabase
+    .from("mirai_stances")
+    .delete()
+    .eq("id", stanceId);
+
+  if (error) {
+    throw new Error(`Failed to delete stance: ${error.message}`);
+  }
+}


### PR DESCRIPTION
## Summary
- admin/mirai-stance featureにrepositoryレイヤーを追加
- loaders/actionsのSupabase直接呼び出しをrepository関数に集約

## Test plan
- [x] pnpm typecheck 通過
- [x] pnpm lint 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)