### PR TITLE
refactor: admin/bills featureにrepositoryレイヤーを追加

### DIFF
--- a/admin/src/features/bills/actions/delete-bill.ts
+++ b/admin/src/features/bills/actions/delete-bill.ts
@@ -1,21 +1,15 @@
 "use server";
 
-import { createAdminClient } from "@mirai-gikai/supabase";
 import { revalidatePath } from "next/cache";
 import { requireAdmin } from "@/features/auth/lib/auth-server";
+import { deleteBillById } from "../repositories/bill-repository";
 
 export async function deleteBill(id: string) {
   try {
     await requireAdmin();
 
-    const supabase = createAdminClient();
-
     // 議案を削除
-    const { error } = await supabase.from("bills").delete().eq("id", id);
-
-    if (error) {
-      throw new Error(`議案の削除に失敗しました: ${error.message}`);
-    }
+    await deleteBillById(id);
 
     // キャッシュをリフレッシュ
     revalidatePath("/bills");

--- a/admin/src/features/bills/actions/update-publish-status.ts
+++ b/admin/src/features/bills/actions/update-publish-status.ts
@@ -1,10 +1,10 @@
 "use server";
 
-import { createAdminClient } from "@mirai-gikai/supabase";
 import { revalidatePath } from "next/cache";
 import { requireAdmin } from "@/features/auth/lib/auth-server";
 import { invalidateWebCache } from "@/lib/utils/cache-invalidation";
 import type { BillPublishStatus } from "../types";
+import { updateBillPublishStatus } from "../repositories/bill-repository";
 
 interface UpdatePublishStatusResult {
   success: boolean;
@@ -36,20 +36,7 @@ async function _updateBillPublishStatus(
   publishStatus: BillPublishStatus
 ): Promise<UpdatePublishStatusResult> {
   try {
-    const supabase = createAdminClient();
-
-    const { error } = await supabase
-      .from("bills")
-      .update({ publish_status: publishStatus })
-      .eq("id", billId);
-
-    if (error) {
-      console.error("Failed to update publish status:", error);
-      return {
-        success: false,
-        error: "ステータスの更新に失敗しました",
-      };
-    }
+    await updateBillPublishStatus(billId, publishStatus);
 
     // web側のキャッシュを無効化
     await invalidateWebCache();
@@ -59,7 +46,7 @@ async function _updateBillPublishStatus(
     console.error("Error updating publish status:", error);
     return {
       success: false,
-      error: "予期しないエラーが発生しました",
+      error: "ステータスの更新に失敗しました",
     };
   }
 }

--- a/admin/src/features/bills/loaders/get-bills.ts
+++ b/admin/src/features/bills/loaders/get-bills.ts
@@ -1,17 +1,7 @@
-import { createAdminClient } from "@mirai-gikai/supabase";
 import type { BillWithDietSession } from "../types";
+import { findBillsWithDietSessions } from "../repositories/bill-repository";
 
 export async function getBills(): Promise<BillWithDietSession[]> {
-  const supabase = createAdminClient();
-
-  const { data, error } = await supabase
-    .from("bills")
-    .select("*, diet_sessions(name)")
-    .order("created_at", { ascending: false });
-
-  if (error) {
-    throw new Error(`議案の取得に失敗しました: ${error.message}`);
-  }
-
+  const data = await findBillsWithDietSessions();
   return data || [];
 }

--- a/admin/src/features/bills/repositories/bill-repository.ts
+++ b/admin/src/features/bills/repositories/bill-repository.ts
@@ -1,0 +1,157 @@
+import "server-only";
+import type { Database } from "@mirai-gikai/supabase";
+import { createAdminClient } from "@mirai-gikai/supabase";
+import type { BillInsert, BillPublishStatus } from "../types";
+
+type BillContentInsert =
+  Database["public"]["Tables"]["bill_contents"]["Insert"];
+
+export async function findBillsWithDietSessions() {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("bills")
+    .select("*, diet_sessions(name)")
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    throw new Error(`Failed to fetch bills: ${error.message}`);
+  }
+  return data;
+}
+
+export async function findBillById(billId: string) {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("bills")
+    .select("*")
+    .eq("id", billId)
+    .single();
+
+  if (error) {
+    throw new Error(`Failed to fetch bill: ${error.message}`);
+  }
+  return data;
+}
+
+export async function createBill(insertData: BillInsert) {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("bills")
+    .insert(insertData)
+    .select("id")
+    .single();
+
+  if (error) {
+    throw new Error(`Failed to create bill: ${error.message}`);
+  }
+  return data;
+}
+
+export async function deleteBillById(id: string) {
+  const supabase = createAdminClient();
+  const { error } = await supabase.from("bills").delete().eq("id", id);
+
+  if (error) {
+    throw new Error(`Failed to delete bill: ${error.message}`);
+  }
+}
+
+export async function updateBillPublishStatus(
+  billId: string,
+  publishStatus: BillPublishStatus
+) {
+  const supabase = createAdminClient();
+  const { error } = await supabase
+    .from("bills")
+    .update({ publish_status: publishStatus })
+    .eq("id", billId);
+
+  if (error) {
+    throw new Error(`Failed to update bill publish status: ${error.message}`);
+  }
+}
+
+export async function findBillContentsByBillId(billId: string) {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("bill_contents")
+    .select("*")
+    .eq("bill_id", billId);
+
+  if (error) {
+    throw new Error(`Failed to fetch bill contents: ${error.message}`);
+  }
+  return data;
+}
+
+export async function createBillContents(contents: BillContentInsert[]) {
+  const supabase = createAdminClient();
+  const { error } = await supabase.from("bill_contents").insert(contents);
+
+  if (error) {
+    throw new Error(`Failed to create bill contents: ${error.message}`);
+  }
+}
+
+export async function findPreviewToken(billId: string) {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("preview_tokens")
+    .select("token, expires_at")
+    .eq("bill_id", billId)
+    .single();
+
+  if (error || !data) {
+    return null;
+  }
+  return data;
+}
+
+export async function createPreviewToken(params: {
+  billId: string;
+  token: string;
+  expiresAt: string;
+  createdBy: string;
+}) {
+  const supabase = createAdminClient();
+  const { error } = await supabase.from("preview_tokens").insert({
+    bill_id: params.billId,
+    token: params.token,
+    expires_at: params.expiresAt,
+    created_by: params.createdBy,
+  });
+
+  if (error) {
+    throw new Error(`Failed to insert preview token: ${error.message}`);
+  }
+}
+
+export async function deletePreviewTokenByBillId(billId: string) {
+  const supabase = createAdminClient();
+  const { error } = await supabase
+    .from("preview_tokens")
+    .delete()
+    .eq("bill_id", billId);
+
+  if (error) {
+    throw new Error(`Failed to delete preview token: ${error.message}`);
+  }
+}
+
+export async function findPreviewTokenForValidation(
+  billId: string,
+  token: string
+) {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("preview_tokens")
+    .select("expires_at")
+    .eq("bill_id", billId)
+    .eq("token", token)
+    .single();
+
+  if (error || !data) {
+    return null;
+  }
+  return data;
+}


### PR DESCRIPTION
## Summary
- admin/bills featureにrepositoryレイヤーを追加
- loaders/actions/servicesのSupabase直接呼び出しをrepository関数に集約

## Test plan
- [ ] pnpm typecheck 通過
- [ ] pnpm lint 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)