### PR TITLE
refactor: admin/interview-config featureにrepositoryレイヤーを追加

### DIFF
--- a/admin/src/features/interview-config/loaders/get-interview-config.ts
+++ b/admin/src/features/interview-config/loaders/get-interview-config.ts
@@ -1,5 +1,8 @@
-import { createAdminClient } from "@mirai-gikai/supabase";
 import type { InterviewConfig } from "../types";
+import {
+  findInterviewConfigById,
+  findInterviewConfigsByBillId,
+} from "../repositories/interview-config-repository";
 
 /**
  * 法案IDからすべてのインタビュー設定を取得する（複数設定対応）
@@ -7,20 +10,12 @@ import type { InterviewConfig } from "../types";
 export async function getInterviewConfigs(
   billId: string
 ): Promise<InterviewConfig[]> {
-  const supabase = createAdminClient();
-
-  const { data, error } = await supabase
-    .from("interview_configs")
-    .select("*")
-    .eq("bill_id", billId)
-    .order("created_at", { ascending: false });
-
-  if (error) {
+  try {
+    return await findInterviewConfigsByBillId(billId);
+  } catch (error) {
     console.error("Failed to fetch interview configs:", error);
     return [];
   }
-
-  return data || [];
 }
 
 /**
@@ -29,21 +24,10 @@ export async function getInterviewConfigs(
 export async function getInterviewConfigById(
   configId: string
 ): Promise<InterviewConfig | null> {
-  const supabase = createAdminClient();
-
-  const { data, error } = await supabase
-    .from("interview_configs")
-    .select("*")
-    .eq("id", configId)
-    .single();
-
-  if (error) {
-    if (error.code === "PGRST116") {
-      return null;
-    }
+  try {
+    return await findInterviewConfigById(configId);
+  } catch (error) {
     console.error("Failed to fetch interview config:", error);
     return null;
   }
-
-  return data;
 }

--- a/admin/src/features/interview-config/loaders/get-interview-questions.ts
+++ b/admin/src/features/interview-config/loaders/get-interview-questions.ts
@@ -1,21 +1,13 @@
-import { createAdminClient } from "@mirai-gikai/supabase";
 import type { InterviewQuestion } from "../types";
+import { findInterviewQuestionsByConfigId } from "../repositories/interview-config-repository";
 
 export async function getInterviewQuestions(
   interviewConfigId: string
 ): Promise<InterviewQuestion[]> {
-  const supabase = createAdminClient();
-
-  const { data, error } = await supabase
-    .from("interview_questions")
-    .select("*")
-    .eq("interview_config_id", interviewConfigId)
-    .order("question_order", { ascending: true });
-
-  if (error) {
+  try {
+    return await findInterviewQuestionsByConfigId(interviewConfigId);
+  } catch (error) {
     console.error("Failed to fetch interview questions:", error);
     return [];
   }
-
-  return data || [];
 }

--- a/admin/src/features/interview-config/repositories/interview-config-repository.ts
+++ b/admin/src/features/interview-config/repositories/interview-config-repository.ts
@@ -1,0 +1,188 @@
+import "server-only";
+
+import { createAdminClient } from "@mirai-gikai/supabase";
+import type { InterviewConfig, InterviewQuestion } from "../types";
+
+export async function findInterviewConfigsByBillId(
+  billId: string
+): Promise<InterviewConfig[]> {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("interview_configs")
+    .select("*")
+    .eq("bill_id", billId)
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    throw new Error(`Failed to fetch interview configs: ${error.message}`);
+  }
+
+  return data;
+}
+
+export async function findInterviewConfigById(
+  configId: string
+): Promise<InterviewConfig | null> {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("interview_configs")
+    .select("*")
+    .eq("id", configId)
+    .single();
+
+  if (error) {
+    if (error.code === "PGRST116") {
+      return null;
+    }
+    throw new Error(`Failed to fetch interview config: ${error.message}`);
+  }
+
+  return data;
+}
+
+export async function findInterviewConfigBillId(
+  configId: string
+): Promise<{ bill_id: string }> {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("interview_configs")
+    .select("bill_id")
+    .eq("id", configId)
+    .single();
+
+  if (error) {
+    throw new Error(`Failed to fetch interview config: ${error.message}`);
+  }
+
+  return data;
+}
+
+export async function findInterviewQuestionsByConfigId(
+  interviewConfigId: string
+): Promise<InterviewQuestion[]> {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("interview_questions")
+    .select("*")
+    .eq("interview_config_id", interviewConfigId)
+    .order("question_order", { ascending: true });
+
+  if (error) {
+    throw new Error(`Failed to fetch interview questions: ${error.message}`);
+  }
+
+  return data;
+}
+
+export async function closeOtherPublicConfigs(
+  billId: string,
+  excludeConfigId?: string
+): Promise<void> {
+  const supabase = createAdminClient();
+  const query = supabase
+    .from("interview_configs")
+    .update({ status: "closed", updated_at: new Date().toISOString() })
+    .eq("bill_id", billId)
+    .eq("status", "public");
+
+  if (excludeConfigId) {
+    query.neq("id", excludeConfigId);
+  }
+
+  await query;
+}
+
+export async function createInterviewConfigRecord(params: {
+  bill_id: string;
+  name: string;
+  status: "public" | "closed";
+  mode: "loop" | "bulk";
+  themes: string[] | null;
+  knowledge_source: string | null;
+}): Promise<{ id: string }> {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("interview_configs")
+    .insert(params)
+    .select()
+    .single();
+
+  if (error) {
+    throw new Error(`Failed to create interview config: ${error.message}`);
+  }
+
+  return data;
+}
+
+export async function updateInterviewConfigRecord(
+  configId: string,
+  params: {
+    name: string;
+    status: "public" | "closed";
+    mode: "loop" | "bulk";
+    themes: string[] | null;
+    knowledge_source: string | null;
+    updated_at: string;
+  }
+): Promise<{ id: string }> {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("interview_configs")
+    .update(params)
+    .eq("id", configId)
+    .select()
+    .single();
+
+  if (error) {
+    throw new Error(`Failed to update interview config: ${error.message}`);
+  }
+
+  return data;
+}
+
+export async function deleteInterviewConfigRecord(
+  configId: string
+): Promise<void> {
+  const supabase = createAdminClient();
+  const { error } = await supabase
+    .from("interview_configs")
+    .delete()
+    .eq("id", configId);
+
+  if (error) {
+    throw new Error(`Failed to delete interview config: ${error.message}`);
+  }
+}
+
+export async function createInterviewQuestions(
+  questions: {
+    interview_config_id: string;
+    question: string;
+    instruction: string | null;
+    quick_replies: string[] | null;
+    question_order: number;
+  }[]
+): Promise<void> {
+  const supabase = createAdminClient();
+  const { error } = await supabase
+    .from("interview_questions")
+    .insert(questions);
+
+  if (error) {
+    throw new Error(`Failed to create interview questions: ${error.message}`);
+  }
+}
+
+export async function deleteInterviewQuestionsByConfigId(
+  interviewConfigId: string
+): Promise<void> {
+  const supabase = createAdminClient();
+  const { error } = await supabase
+    .from("interview_questions")
+    .delete()
+    .eq("interview_config_id", interviewConfigId);
+
+  if (error) {
+    throw new Error(`Failed to delete interview questions: ${error.message}`);
+  }
+}


### PR DESCRIPTION
## Summary
- admin/interview-config featureにrepositoryレイヤーを追加
- loaders/actionsのSupabase直接呼び出しをrepository関数に集約

## Test plan
- [x] pnpm typecheck 通過
- [x] pnpm lint 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)