### PR TITLE
refactor: admin/diet-sessions featureにrepositoryレイヤーを追加

### DIFF
--- a/admin/src/features/diet-sessions/actions/delete-diet-session.ts
+++ b/admin/src/features/diet-sessions/actions/delete-diet-session.ts
@@ -1,24 +1,15 @@
 "use server";
 
-import { createAdminClient } from "@mirai-gikai/supabase";
 import { requireAdmin } from "@/features/auth/lib/auth-server";
 import { invalidateWebCache } from "@/lib/utils/cache-invalidation";
 import type { DeleteDietSessionInput } from "../types";
+import { deleteDietSessionRecord } from "../repositories/diet-session-repository";
 
 export async function deleteDietSession(input: DeleteDietSessionInput) {
   try {
     await requireAdmin();
 
-    const supabase = createAdminClient();
-
-    const { error } = await supabase
-      .from("diet_sessions")
-      .delete()
-      .eq("id", input.id);
-
-    if (error) {
-      return { error: `国会会期の削除に失敗しました: ${error.message}` };
-    }
+    await deleteDietSessionRecord(input.id);
 
     await invalidateWebCache();
     return { success: true };

--- a/admin/src/features/diet-sessions/actions/set-active-diet-session.ts
+++ b/admin/src/features/diet-sessions/actions/set-active-diet-session.ts
@@ -1,8 +1,11 @@
 "use server";
 
-import { createAdminClient } from "@mirai-gikai/supabase";
 import { requireAdmin } from "@/features/auth/lib/auth-server";
 import { invalidateWebCache } from "@/lib/utils/cache-invalidation";
+import {
+  setActiveDietSessionRecord,
+  findDietSessionById,
+} from "../repositories/diet-session-repository";
 
 export type SetActiveDietSessionInput = {
   id: string;
@@ -12,32 +15,12 @@ export async function setActiveDietSession(input: SetActiveDietSessionInput) {
   try {
     await requireAdmin();
 
-    const supabase = createAdminClient();
-
     // Atomic operation: set only the target session as active
     // Uses a database function to avoid race conditions
-    const { error: rpcError } = await supabase.rpc("set_active_diet_session", {
-      target_session_id: input.id,
-    });
-
-    if (rpcError) {
-      return {
-        error: `アクティブセッションの設定に失敗しました: ${rpcError.message}`,
-      };
-    }
+    await setActiveDietSessionRecord(input.id);
 
     // Fetch the updated session to return
-    const { data, error } = await supabase
-      .from("diet_sessions")
-      .select()
-      .eq("id", input.id)
-      .single();
-
-    if (error) {
-      return {
-        error: `セッション情報の取得に失敗しました: ${error.message}`,
-      };
-    }
+    const data = await findDietSessionById(input.id);
 
     await invalidateWebCache();
     return { data };

--- a/admin/src/features/diet-sessions/actions/update-diet-session.ts
+++ b/admin/src/features/diet-sessions/actions/update-diet-session.ts
@@ -1,15 +1,13 @@
 "use server";
 
-import { createAdminClient } from "@mirai-gikai/supabase";
 import { requireAdmin } from "@/features/auth/lib/auth-server";
 import { invalidateWebCache } from "@/lib/utils/cache-invalidation";
 import type { UpdateDietSessionInput } from "../types";
+import { updateDietSessionRecord } from "../repositories/diet-session-repository";
 
 export async function updateDietSession(input: UpdateDietSessionInput) {
   try {
     await requireAdmin();
-
-    const supabase = createAdminClient();
 
     // バリデーション
     if (!input.name || input.name.trim().length === 0) {
@@ -39,22 +37,13 @@ export async function updateDietSession(input: UpdateDietSessionInput) {
       return { error: "終了日は開始日以降の日付を指定してください" };
     }
 
-    const { data, error } = await supabase
-      .from("diet_sessions")
-      .update({
-        name: input.name.trim(),
-        slug: input.slug?.trim() || null,
-        shugiin_url: input.shugiin_url?.trim() || null,
-        start_date: input.start_date,
-        end_date: input.end_date,
-      })
-      .eq("id", input.id)
-      .select()
-      .single();
-
-    if (error) {
-      return { error: `国会会期の更新に失敗しました: ${error.message}` };
-    }
+    const data = await updateDietSessionRecord(input.id, {
+      name: input.name.trim(),
+      slug: input.slug?.trim() || null,
+      shugiin_url: input.shugiin_url?.trim() || null,
+      start_date: input.start_date,
+      end_date: input.end_date,
+    });
 
     await invalidateWebCache();
     return { data };

--- a/admin/src/features/diet-sessions/loaders/load-diet-sessions.ts
+++ b/admin/src/features/diet-sessions/loaders/load-diet-sessions.ts
@@ -1,17 +1,7 @@
-import { createAdminClient } from "@mirai-gikai/supabase";
 import type { DietSession } from "../types";
+import { findAllDietSessions } from "../repositories/diet-session-repository";
 
 export async function loadDietSessions(): Promise<DietSession[]> {
-  const supabase = createAdminClient();
-
-  const { data, error } = await supabase
-    .from("diet_sessions")
-    .select("*")
-    .order("start_date", { ascending: false });
-
-  if (error) {
-    throw new Error(`国会会期の取得に失敗しました: ${error.message}`);
-  }
-
+  const data = await findAllDietSessions();
   return data || [];
 }

--- a/admin/src/features/diet-sessions/repositories/diet-session-repository.ts
+++ b/admin/src/features/diet-sessions/repositories/diet-session-repository.ts
@@ -1,0 +1,112 @@
+import "server-only";
+
+import { createAdminClient } from "@mirai-gikai/supabase";
+
+export async function findAllDietSessions() {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("diet_sessions")
+    .select("*")
+    .order("start_date", { ascending: false });
+
+  if (error) {
+    throw new Error(`国会会期の取得に失敗しました: ${error.message}`);
+  }
+
+  return data;
+}
+
+export async function createDietSessionRecord(input: {
+  name: string;
+  slug: string | null;
+  shugiin_url: string | null;
+  start_date: string;
+  end_date: string;
+}) {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("diet_sessions")
+    .insert({
+      name: input.name,
+      slug: input.slug,
+      shugiin_url: input.shugiin_url,
+      start_date: input.start_date,
+      end_date: input.end_date,
+    })
+    .select()
+    .single();
+
+  if (error) {
+    throw new Error(`国会会期の作成に失敗しました: ${error.message}`);
+  }
+
+  return data;
+}
+
+export async function updateDietSessionRecord(
+  id: string,
+  input: {
+    name: string;
+    slug: string | null;
+    shugiin_url: string | null;
+    start_date: string;
+    end_date: string;
+  }
+) {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("diet_sessions")
+    .update({
+      name: input.name,
+      slug: input.slug,
+      shugiin_url: input.shugiin_url,
+      start_date: input.start_date,
+      end_date: input.end_date,
+    })
+    .eq("id", id)
+    .select()
+    .single();
+
+  if (error) {
+    throw new Error(`国会会期の更新に失敗しました: ${error.message}`);
+  }
+
+  return data;
+}
+
+export async function deleteDietSessionRecord(id: string) {
+  const supabase = createAdminClient();
+  const { error } = await supabase.from("diet_sessions").delete().eq("id", id);
+
+  if (error) {
+    throw new Error(`国会会期の削除に失敗しました: ${error.message}`);
+  }
+}
+
+export async function setActiveDietSessionRecord(id: string) {
+  const supabase = createAdminClient();
+  const { error: rpcError } = await supabase.rpc("set_active_diet_session", {
+    target_session_id: id,
+  });
+
+  if (rpcError) {
+    throw new Error(
+      `アクティブセッションの設定に失敗しました: ${rpcError.message}`
+    );
+  }
+}
+
+export async function findDietSessionById(id: string) {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("diet_sessions")
+    .select()
+    .eq("id", id)
+    .single();
+
+  if (error) {
+    throw new Error(`セッション情報の取得に失敗しました: ${error.message}`);
+  }
+
+  return data;
+}


### PR DESCRIPTION
## Summary
- admin/diet-sessions featureにrepositoryレイヤーを追加
- loaders/actionsのSupabase直接呼び出しをrepository関数に集約

## Test plan
- [x] pnpm typecheck 通過
- [x] pnpm lint 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)