### PR TITLE
refactor: admin/admins featureにrepositoryレイヤーを追加

### DIFF
--- a/admin/src/features/admins/loaders/load-admins.ts
+++ b/admin/src/features/admins/loaders/load-admins.ts
@@ -1,16 +1,11 @@
 import { unstable_noStore as noStore } from "next/cache";
-import { createAdminClient } from "@mirai-gikai/supabase";
 import type { Admin } from "../types";
+import { findAdminUsers } from "../repositories/admin-repository";
 
 export async function loadAdmins(): Promise<Admin[]> {
   noStore();
-  const supabase = createAdminClient();
 
-  const { data, error } = await supabase.rpc("get_admin_users");
-
-  if (error) {
-    throw new Error(`管理者一覧の取得に失敗しました: ${error.message}`);
-  }
+  const data = await findAdminUsers();
 
   return (data ?? []).map((user) => ({
     id: user.id,

--- a/admin/src/features/admins/repositories/admin-repository.ts
+++ b/admin/src/features/admins/repositories/admin-repository.ts
@@ -1,0 +1,38 @@
+import "server-only";
+import { createAdminClient } from "@mirai-gikai/supabase";
+
+export async function findAdminUsers() {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase.rpc("get_admin_users");
+
+  if (error) {
+    throw new Error(`Failed to fetch admin users: ${error.message}`);
+  }
+  return data;
+}
+
+export async function createAuthUser(params: {
+  email: string;
+  password: string;
+}) {
+  const supabase = createAdminClient();
+  const { error } = await supabase.auth.admin.createUser({
+    email: params.email,
+    password: params.password,
+    email_confirm: true,
+    app_metadata: { roles: ["admin"] },
+  });
+
+  if (error) {
+    throw error;
+  }
+}
+
+export async function deleteAuthUser(userId: string) {
+  const supabase = createAdminClient();
+  const { error } = await supabase.auth.admin.deleteUser(userId);
+
+  if (error) {
+    throw error;
+  }
+}


### PR DESCRIPTION
## Summary
- admin/admins featureにrepositoryレイヤーを追加
- loaders/actionsのSupabase直接呼び出しをrepository関数に集約

## Test plan
- [ ] pnpm typecheck 通過
- [ ] pnpm lint 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)