### PR TITLE
refactor: admin/tags featureにrepositoryレイヤーを追加

### DIFF
--- a/admin/src/features/tags/actions/delete-tag.ts
+++ b/admin/src/features/tags/actions/delete-tag.ts
@@ -1,24 +1,22 @@
 "use server";
 
-import { createAdminClient } from "@mirai-gikai/supabase";
 import { requireAdmin } from "@/features/auth/lib/auth-server";
 import { invalidateWebCache } from "@/lib/utils/cache-invalidation";
 import type { DeleteTagInput } from "../types";
+import { deleteTagRecord } from "../repositories/tag-repository";
 
 export async function deleteTag(input: DeleteTagInput) {
   try {
     await requireAdmin();
 
-    const supabase = createAdminClient();
+    const result = await deleteTagRecord(input.id);
 
-    const { error } = await supabase.from("tags").delete().eq("id", input.id);
-
-    if (error) {
+    if (result.error) {
       // レコードが見つからない
-      if (error.code === "PGRST116") {
+      if (result.error.code === "PGRST116") {
         return { error: "タグが見つかりません" };
       }
-      return { error: `タグの削除に失敗しました: ${error.message}` };
+      return { error: `タグの削除に失敗しました: ${result.error.message}` };
     }
 
     // web側のキャッシュを無効化

--- a/admin/src/features/tags/loaders/load-tags.ts
+++ b/admin/src/features/tags/loaders/load-tags.ts
@@ -1,29 +1,8 @@
-import { createAdminClient } from "@mirai-gikai/supabase";
 import type { TagWithBillCount } from "../types";
+import { findAllTagsWithBillCount } from "../repositories/tag-repository";
 
 export async function loadTags(): Promise<TagWithBillCount[]> {
-  const supabase = createAdminClient();
-
-  // Supabase クエリで議案数をカウント
-  const { data, error } = await supabase
-    .from("tags")
-    .select(
-      `
-      id,
-      label,
-      description,
-      featured_priority,
-      created_at,
-      updated_at,
-      bills_tags(count)
-    `
-    )
-    .order("featured_priority", { ascending: true, nullsFirst: false })
-    .order("created_at", { ascending: true });
-
-  if (error) {
-    throw new Error(`タグの取得に失敗しました: ${error.message}`);
-  }
+  const data = await findAllTagsWithBillCount();
 
   // データを整形
   return (

--- a/admin/src/features/tags/repositories/tag-repository.ts
+++ b/admin/src/features/tags/repositories/tag-repository.ts
@@ -1,0 +1,102 @@
+import "server-only";
+
+import { createAdminClient } from "@mirai-gikai/supabase";
+
+export async function findAllTagsWithBillCount() {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("tags")
+    .select(
+      `
+      id,
+      label,
+      description,
+      featured_priority,
+      created_at,
+      updated_at,
+      bills_tags(count)
+    `
+    )
+    .order("featured_priority", { ascending: true, nullsFirst: false })
+    .order("created_at", { ascending: true });
+
+  if (error) {
+    throw new Error(`タグの取得に失敗しました: ${error.message}`);
+  }
+
+  return data;
+}
+
+export async function createTagRecord(input: { label: string }) {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("tags")
+    .insert({ label: input.label })
+    .select()
+    .single();
+
+  if (error) {
+    if (error.code === "23505") {
+      return {
+        data: null,
+        error: { code: error.code, message: error.message },
+      };
+    }
+    throw new Error(`タグの作成に失敗しました: ${error.message}`);
+  }
+
+  return { data, error: null };
+}
+
+export async function updateTagRecord(
+  id: string,
+  input: {
+    label: string;
+    description?: string | null;
+    featured_priority?: number | null;
+  }
+) {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("tags")
+    .update({
+      label: input.label,
+      description: input.description,
+      featured_priority: input.featured_priority,
+    })
+    .eq("id", id)
+    .select()
+    .single();
+
+  if (error) {
+    if (error.code === "23505") {
+      return {
+        data: null,
+        error: { code: error.code, message: error.message },
+      };
+    }
+    if (error.code === "PGRST116") {
+      return {
+        data: null,
+        error: { code: error.code, message: error.message },
+      };
+    }
+    throw new Error(`タグの更新に失敗しました: ${error.message}`);
+  }
+
+  return { data, error: null };
+}
+
+export async function deleteTagRecord(id: string) {
+  const supabase = createAdminClient();
+  const { error } = await supabase.from("tags").delete().eq("id", id);
+
+  if (error) {
+    if (error.code === "PGRST116") {
+      return { error: { code: error.code, message: error.message } };
+    }
+    throw new Error(`タグの削除に失敗しました: ${error.message}`);
+  }
+
+  return { error: null };
+}


### PR DESCRIPTION
## Summary
- admin/tags featureにrepositoryレイヤーを追加
- loaders/actionsのSupabase直接呼び出しをrepository関数に集約

## Test plan
- [x] pnpm typecheck 通過
- [x] pnpm lint 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)