### PR TITLE
docs: admin featureのserver/client/shared構成をCLAUDE.mdに反映

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,33 +70,7 @@ src/features/{feature}/
 - 型定義やServer/Client両方で使う関数は `shared/` に配置
 - シンプルな feature は従来の `components|actions|api|types` 構成でも可
 
-### Repository レイヤー
-Supabase への直接アクセスは `repositories/` に集約し、loaders/actions/services からは repository 関数を呼び出します。
-
-```typescript
-// repositories/{feature}-repository.ts
-import "server-only";
-import { createAdminClient } from "@mirai-gikai/supabase";
-
-export async function findBillById(id: string) {
-  const supabase = createAdminClient();
-  const { data, error } = await supabase
-    .from("bills")
-    .select("*")
-    .eq("id", id)
-    .single();
-  if (error) {
-    throw new Error(`Failed to fetch bill: ${error.message}`);
-  }
-  return data;
-}
-```
-
-- **`import "server-only"`** を必ず先頭に付与
-- **`createAdminClient()`** の呼び出しは repository 内に閉じ込め、loaders/actions/services からは直接呼ばない
-- repository 関数は「Supabase クエリ実行 + エラーハンドリング」のみを担当し、ビジネスロジック（キャッシュ制御、認証チェック、データ変換等）は呼び出し元に残す
-- 関数名は操作に応じて `find*` / `create*` / `update*` / `delete*` で統一
-- クライアント側の Supabase 呼び出し（`createBrowserClient` を使う認証・Storage 操作等）は repository の対象外
+Repository レイヤーの詳細は [docs/repository-layer.md](docs/repository-layer.md) を参照。
 
 ## Build, Test, and Development Commands
 - 依存導入は `pnpm install`、全てのスクリプトは pnpm 経由で実行します。

--- a/docs/repository-layer.md
+++ b/docs/repository-layer.md
@@ -1,0 +1,32 @@
+# Repository レイヤー設計方針
+
+Supabase への直接アクセスは `server/repositories/` に集約し、loaders/actions/services からは repository 関数を呼び出します。
+
+## 基本パターン
+
+```typescript
+// server/repositories/{feature}-repository.ts
+import "server-only";
+import { createAdminClient } from "@mirai-gikai/supabase";
+
+export async function findBillById(id: string) {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("bills")
+    .select("*")
+    .eq("id", id)
+    .single();
+  if (error) {
+    throw new Error(`Failed to fetch bill: ${error.message}`);
+  }
+  return data;
+}
+```
+
+## ルール
+
+- **`import "server-only"`** を必ず先頭に付与
+- **`createAdminClient()`** の呼び出しは repository 内に閉じ込め、loaders/actions/services からは直接呼ばない
+- repository 関数は「Supabase クエリ実行 + エラーハンドリング」のみを担当し、ビジネスロジック（キャッシュ制御、認証チェック、データ変換等）は呼び出し元に残す
+- 関数名は操作に応じて `find*` / `create*` / `update*` / `delete*` で統一
+- クライアント側の Supabase 呼び出し（`createBrowserClient` を使う認証・Storage 操作等）は repository の対象外


### PR DESCRIPTION
## Summary
- admin featureもweb同様のserver/client/shared構成に移行したため、CLAUDE.mdのドキュメントを更新
- フラット構成の記述を削除し、統一された構成を記載
- admin側ではServer Components中心のため `client/` ディレクトリを省略している場合がある旨を補足

## 依存PR
- #336 (docs/repository-layer) のマージコミットを含む

🤖 Generated with [Claude Code](https://claude.com/claude-code)