### PR TITLE
/codify コマンドにPR作成ステップを追加

### DIFF
--- a/.claude/commands/codify.md
+++ b/.claude/commands/codify.md
@@ -111,9 +111,50 @@ $ARGUMENTS
 
 ### 6. 検証
 
-最後に以下を実行して問題がないことを確認：
+以下を実行して問題がないことを確認：
 
 ```bash
 pnpm lint
 pnpm typecheck
+```
+
+### 7. コミットとPR作成（必須）
+
+仕組み化の変更を必ずPRとして提出する。CLAUDE.mdのworktreeルールに従うこと。
+
+#### 7a. worktree作成とファイルコピー
+
+```bash
+# メインリポジトリのルートで実行
+git worktree add ../mirai-gikai-<branch-name> -b <branch-name>
+mkdir -p ../mirai-gikai-<branch-name>/.claude
+cp .claude/settings.local.json ../mirai-gikai-<branch-name>/.claude/
+cp .env ../mirai-gikai-<branch-name>/
+```
+
+- ブランチ名は `chore/codify-<変更内容の要約>` とする（例: `chore/codify-add-pr-step`）
+- 変更対象のファイルをworktreeにコピーする
+
+#### 7b. コミットとpush
+
+```bash
+cd ../mirai-gikai-<branch-name>
+git add <変更ファイル>
+git commit -m "<コミットメッセージ>"
+git push -u origin <branch-name>
+```
+
+#### 7c. PR作成
+
+```bash
+gh pr create --title "<タイトル>" --body "<本文>"
+```
+
+- PR本文には「仕組み化サマリ」（ステップ5の出力）を含める
+- PR作成前に `gh pr list --state open` で既存PRとの重複を確認する
+
+#### 7d. worktreeクリーンアップ
+
+```bash
+git worktree remove ../mirai-gikai-<branch-name>
 ```


### PR DESCRIPTION
## Summary
- `/codify` コマンドの最終ステップにPR作成を必須化するステップ7を追加
- worktree作成 → コミット → PR作成 → クリーンアップの手順を明記
- ブランチ命名規則を `chore/codify-<要約>` に統一

## 仕組み化サマリ

### 仕組み化した項目
| 指摘 | 対応 | 追加先 |
|------|------|--------|
| /codify後にPRを出し忘れる | PR作成ステップを必須として追加 | `.claude/commands/codify.md` |

## Test plan
- [ ] `/codify` 実行時にステップ7のPR作成まで自動的に案内されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)