### PR TITLE
CLAUDE.mdにテストのmock回避ルールを追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,7 @@ src/features/{feature}/
 
 ## Testing Guidelines
 - Vitest の単体テストを `*.test.ts` として実装と同階層に配置し、AI コスト計算や Markdown 処理などデータ変換の変更時は必ず回帰テストを追加します。
+- **mock は極力使わない**: `vi.mock("server-only")` 等のモックに頼らず、テスト対象のロジックを純粋関数として `shared/` に切り出してからテストしてください。`server-only` や外部依存を含むファイルからは re-export で参照を維持します。
 - Supabase など外部依存はフィクスチャでモックし、単体テストから実サービスへ接続しないでください。
 - PR 前に `pnpm --filter web test:watch` で失敗を早期検知し、必要に応じて `vitest run --coverage` でカバレッジ低下を確認します。
 


### PR DESCRIPTION
## Summary
- Testing GuidelinesセクションにVitest mockの使用を極力避けるルールを追加
- `vi.mock("server-only")` 等のモックに頼らず、純粋関数を `shared/` に切り出してテストする方針を明文化
- PR #344 のレビュー指摘を受けた再発防止策

## 背景
PR #344（純粋関数テスト追加）のレビューで「mockは極力使わない。純粋関数を別ファイルに切り出したほうがいい」という指摘があり、コードは修正済み。今回はその方針をCLAUDE.mdにルールとして定着させる。

## Test plan
- [x] ドキュメントのみの変更のため、テスト不要

🤖 Generated with [Claude Code](https://claude.com/claude-code)