### PR TITLE
テスト方針にローカルサービスreal/外部API DIルールを追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,8 @@ Repository レイヤーの詳細は [docs/repository-layer.md](docs/repository-l
 ## Testing Guidelines
 - Vitest の単体テストを `*.test.ts` として実装と同階層に配置し、AI コスト計算や Markdown 処理などデータ変換の変更時は必ず回帰テストを追加します。
 - **mock は極力使わない**: `vi.mock("server-only")` 等のモックに頼らず、テスト対象のロジックを純粋関数として `shared/` に切り出してからテストしてください。`server-only` や外部依存を含むファイルからは re-export で参照を維持します。
-- Supabase など外部依存はフィクスチャでモックし、単体テストから実サービスへ接続しないでください。
+- **ローカルサービスは real で動かす**: Supabase などローカルで起動できるサービスはモックせず、実際のローカルインスタンスに接続してテストします。
+- **外部 API は DI でモックする**: OpenAI などの外部 API クライアントはインターフェースを定義し、テストでは Fake/Mock 実装に差し替えます。
 - PR 前に `pnpm --filter web test:watch` で失敗を早期検知し、必要に応じて `vitest run --coverage` でカバレッジ低下を確認します。
 
 ## Commit & Pull Request Guidelines

--- a/docs/20260219_1000_テストガイドライン.md
+++ b/docs/20260219_1000_テストガイドライン.md
@@ -116,7 +116,9 @@ pnpm --filter web test:ui
 
 ### ポイント
 
-- モックは最小限にする。純粋関数のテストが理想
+- **mock は極力使わない**: `vi.mock("server-only")` 等のモックに頼らず、テスト対象のロジックを純粋関数として `shared/` に切り出してからテストする。`server-only` や外部依存を含むファイルからは re-export で参照を維持する
+- **ローカルサービスは real で動かす**: Supabase などローカルで起動できるサービスはモックせず、実際のローカルインスタンスに接続してテストする
+- **外部 API は DI でモックする**: OpenAI などの外部 API クライアントはインターフェースを定義し、テストでは Fake/Mock 実装に差し替える
 - `vitest.config.mts` で `globals: true` が有効なため `describe`/`it`/`expect` はグローバルで使えるが、明示的に `import { describe, expect, it } from "vitest"` する
 - テスト内で意図的に型を崩す場合は `as any` を使用してよい（`biome-ignore` コメント付き）
 - 浮動小数点の比較には `toBeCloseTo()` を使う


### PR DESCRIPTION
## Summary
テスト戦略の基本方針をCLAUDE.mdとdocs/テストガイドラインに明文化。

## 仕組み化サマリ

### コード修正
- なし

### 仕組み化した項目
| 指摘 | 対応 | 追加先 |
|------|------|--------|
| ローカルサービス（Supabase等）はrealで動かす | ルール追加 | CLAUDE.md, docs/テストガイドライン |
| 外部API（OpenAI等）はDIでモックする | ルール追加 | CLAUDE.md, docs/テストガイドライン |

### 変更詳細
- **削除**: 「Supabase など外部依存はフィクスチャでモックし、単体テストから実サービスへ接続しないでください」
- **追加**: 「ローカルサービスは real で動かす」「外部 API は DI でモックする」の2ルール

## Test plan
- [x] ドキュメントのみの変更のため、テスト不要

🤖 Generated with [Claude Code](https://claude.com/claude-code)