### PR TITLE
refactor: admin データ変換・計算系純粋関数の切り出し

### DIFF
--- a/admin/src/features/interview-config/shared/types/index.ts
+++ b/admin/src/features/interview-config/shared/types/index.ts
@@ -49,17 +49,4 @@ export type InterviewQuestionsInput = z.infer<
   typeof interviewQuestionsInputSchema
 >;
 
-// テキストエリアから配列への変換ヘルパー
-export function textToArray(text: string | null | undefined): string[] {
-  if (!text) return [];
-  return text
-    .split("\n")
-    .map((line) => line.trim())
-    .filter((line) => line.length > 0);
-}
-
-// 配列からテキストエリア用の文字列への変換ヘルパー
-export function arrayToText(array: string[] | null | undefined): string {
-  if (!array || array.length === 0) return "";
-  return array.join("\n");
-}
+export { textToArray, arrayToText } from "../utils/array-text-conversion";

--- a/admin/src/features/interview-config/shared/utils/array-text-conversion.test.ts
+++ b/admin/src/features/interview-config/shared/utils/array-text-conversion.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { textToArray, arrayToText } from "./array-text-conversion";
+
+describe("textToArray", () => {
+  it("改行区切りテキストを配列に変換する", () => {
+    expect(textToArray("aaa\nbbb\nccc")).toEqual(["aaa", "bbb", "ccc"]);
+  });
+
+  it("空行をフィルタする", () => {
+    expect(textToArray("aaa\n\nbbb\n\n")).toEqual(["aaa", "bbb"]);
+  });
+
+  it("各行をトリムする", () => {
+    expect(textToArray("  aaa  \n  bbb  ")).toEqual(["aaa", "bbb"]);
+  });
+
+  it("nullの場合は空配列を返す", () => {
+    expect(textToArray(null)).toEqual([]);
+  });
+
+  it("undefinedの場合は空配列を返す", () => {
+    expect(textToArray(undefined)).toEqual([]);
+  });
+
+  it("空文字列の場合は空配列を返す", () => {
+    expect(textToArray("")).toEqual([]);
+  });
+});
+
+describe("arrayToText", () => {
+  it("配列を改行区切りテキストに変換する", () => {
+    expect(arrayToText(["aaa", "bbb", "ccc"])).toBe("aaa\nbbb\nccc");
+  });
+
+  it("nullの場合は空文字列を返す", () => {
+    expect(arrayToText(null)).toBe("");
+  });
+
+  it("undefinedの場合は空文字列を返す", () => {
+    expect(arrayToText(undefined)).toBe("");
+  });
+
+  it("空配列の場合は空文字列を返す", () => {
+    expect(arrayToText([])).toBe("");
+  });
+
+  it("1要素の配列はそのまま返す", () => {
+    expect(arrayToText(["aaa"])).toBe("aaa");
+  });
+});

--- a/admin/src/features/interview-config/shared/utils/array-text-conversion.ts
+++ b/admin/src/features/interview-config/shared/utils/array-text-conversion.ts
@@ -1,0 +1,19 @@
+/**
+ * テキストエリアから配列への変換ヘルパー
+ * 改行区切りテキストを配列に変換する
+ */
+export function textToArray(text: string | null | undefined): string[] {
+  if (!text) return [];
+  return text
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}
+
+/**
+ * 配列からテキストエリア用の文字列への変換ヘルパー
+ */
+export function arrayToText(array: string[] | null | undefined): string {
+  if (!array || array.length === 0) return "";
+  return array.join("\n");
+}

--- a/admin/src/features/interview-reports/server/components/session-list.tsx
+++ b/admin/src/features/interview-reports/server/components/session-list.tsx
@@ -24,6 +24,7 @@ import {
 import { SESSIONS_PER_PAGE } from "../loaders/get-interview-sessions";
 import type { InterviewSessionWithDetails } from "../../shared/types";
 import { formatDuration, getSessionStatus } from "../../shared/types";
+import { generatePageNumbers } from "../../shared/utils/pagination-utils";
 import { SessionStatusBadge } from "./session-status-badge";
 import { StanceBadge } from "./stance-badge";
 import { VisibilityBadge } from "./visibility-badge";
@@ -192,53 +193,22 @@ export function SessionList({
             </PaginationItem>
 
             {/* ページ番号表示（最大5ページ表示、省略記号付き） */}
-            {(() => {
-              const pages: (number | "ellipsis-start" | "ellipsis-end")[] = [];
-              if (totalPages <= 5) {
-                // 5ページ以下の場合はすべて表示
-                for (let i = 1; i <= totalPages; i++) {
-                  pages.push(i);
-                }
-              } else {
-                // 最初のページ
-                pages.push(1);
-
-                if (currentPage > 3) {
-                  pages.push("ellipsis-start");
-                }
-
-                // 現在のページ周辺
-                const start = Math.max(2, currentPage - 1);
-                const end = Math.min(totalPages - 1, currentPage + 1);
-                for (let i = start; i <= end; i++) {
-                  pages.push(i);
-                }
-
-                if (currentPage < totalPages - 2) {
-                  pages.push("ellipsis-end");
-                }
-
-                // 最後のページ
-                pages.push(totalPages);
-              }
-
-              return pages.map((page) =>
-                typeof page === "string" ? (
-                  <PaginationItem key={page}>
-                    <PaginationEllipsis />
-                  </PaginationItem>
-                ) : (
-                  <PaginationItem key={page}>
-                    <PaginationLink
-                      href={`/bills/${billId}/reports?page=${page}`}
-                      isActive={page === currentPage}
-                    >
-                      {page}
-                    </PaginationLink>
-                  </PaginationItem>
-                )
-              );
-            })()}
+            {generatePageNumbers(totalPages, currentPage).map((page) =>
+              typeof page === "string" ? (
+                <PaginationItem key={page}>
+                  <PaginationEllipsis />
+                </PaginationItem>
+              ) : (
+                <PaginationItem key={page}>
+                  <PaginationLink
+                    href={`/bills/${billId}/reports?page=${page}`}
+                    isActive={page === currentPage}
+                  >
+                    {page}
+                  </PaginationLink>
+                </PaginationItem>
+              )
+            )}
 
             <PaginationItem>
               <PaginationNext

--- a/admin/src/features/interview-reports/server/loaders/get-interview-sessions.ts
+++ b/admin/src/features/interview-reports/server/loaders/get-interview-sessions.ts
@@ -1,4 +1,5 @@
 import type { InterviewSessionWithDetails } from "../../shared/types";
+import { calculatePaginationRange } from "../../shared/utils/pagination-utils";
 import {
   countInterviewSessionsByConfigId,
   findInterviewConfigIdByBillId,
@@ -19,8 +20,7 @@ export async function getInterviewSessions(
   }
 
   // ページネーション計算
-  const from = (page - 1) * SESSIONS_PER_PAGE;
-  const to = from + SESSIONS_PER_PAGE - 1;
+  const { from, to } = calculatePaginationRange(page, SESSIONS_PER_PAGE);
 
   // セッション一覧を取得
   let sessions: Awaited<ReturnType<typeof findInterviewSessionsWithReport>>;

--- a/admin/src/features/interview-reports/shared/constants.ts
+++ b/admin/src/features/interview-reports/shared/constants.ts
@@ -20,6 +20,8 @@ export const roleLabels: Record<InterviewReportRole, string> = {
   general_citizen: "一市民として関心",
 };
 
+import { formatRoleLabel as formatRoleLabelPure } from "./utils/format-role-label";
+
 /**
  * 役割ラベルとrole_titleを中黒で結合して表示用文字列を生成
  * 例：「専門家・物流業者」
@@ -28,11 +30,5 @@ export function formatRoleLabel(
   role?: string | null,
   roleTitle?: string | null
 ): string | null {
-  const baseLabel = role
-    ? roleLabels[role as InterviewReportRole] || role
-    : null;
-  if (baseLabel && roleTitle) {
-    return `${baseLabel}・${roleTitle}`;
-  }
-  return roleTitle || baseLabel;
+  return formatRoleLabelPure(role, roleTitle, roleLabels);
 }

--- a/admin/src/features/interview-reports/shared/types/index.ts
+++ b/admin/src/features/interview-reports/shared/types/index.ts
@@ -19,28 +19,8 @@ export type InterviewSessionDetail = InterviewSession & {
   interview_messages: InterviewMessage[];
 };
 
-export type SessionStatus = "completed" | "in_progress";
-
-export function getSessionStatus(session: InterviewSession): SessionStatus {
-  return session.completed_at ? "completed" : "in_progress";
-}
-
-export function formatDuration(
-  startedAt: string,
-  completedAt: string | null
-): string {
-  if (!completedAt) return "-";
-
-  const start = new Date(startedAt);
-  const end = new Date(completedAt);
-  const diffMs = end.getTime() - start.getTime();
-
-  const minutes = Math.floor(diffMs / (1000 * 60));
-  const hours = Math.floor(minutes / 60);
-  const remainingMinutes = minutes % 60;
-
-  if (hours > 0) {
-    return `${hours}時間${remainingMinutes}分`;
-  }
-  return `${minutes}分`;
-}
+export {
+  type SessionStatus,
+  getSessionStatus,
+} from "../utils/get-session-status";
+export { formatDuration } from "../utils/format-duration";

--- a/admin/src/features/interview-reports/shared/utils/format-duration.test.ts
+++ b/admin/src/features/interview-reports/shared/utils/format-duration.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { formatDuration } from "./format-duration";
+
+describe("formatDuration", () => {
+  it("completedAtがnullの場合は'-'を返す", () => {
+    expect(formatDuration("2024-01-01T10:00:00Z", null)).toBe("-");
+  });
+
+  it("分のみの場合は「X分」を返す", () => {
+    expect(formatDuration("2024-01-01T10:00:00Z", "2024-01-01T10:30:00Z")).toBe(
+      "30分"
+    );
+  });
+
+  it("1時間ちょうどの場合は「1時間0分」を返す", () => {
+    expect(formatDuration("2024-01-01T10:00:00Z", "2024-01-01T11:00:00Z")).toBe(
+      "1時間0分"
+    );
+  });
+
+  it("時間と分がある場合は「X時間Y分」を返す", () => {
+    expect(formatDuration("2024-01-01T10:00:00Z", "2024-01-01T11:30:00Z")).toBe(
+      "1時間30分"
+    );
+  });
+
+  it("0分の場合は「0分」を返す", () => {
+    expect(formatDuration("2024-01-01T10:00:00Z", "2024-01-01T10:00:00Z")).toBe(
+      "0分"
+    );
+  });
+
+  it("複数時間の場合", () => {
+    expect(formatDuration("2024-01-01T10:00:00Z", "2024-01-01T12:45:00Z")).toBe(
+      "2時間45分"
+    );
+  });
+});

--- a/admin/src/features/interview-reports/shared/utils/format-duration.ts
+++ b/admin/src/features/interview-reports/shared/utils/format-duration.ts
@@ -1,0 +1,22 @@
+/**
+ * 開始時刻と完了時刻からミリ秒差を計算し「X時間Y分」の日本語表示に変換する
+ */
+export function formatDuration(
+  startedAt: string,
+  completedAt: string | null
+): string {
+  if (!completedAt) return "-";
+
+  const start = new Date(startedAt);
+  const end = new Date(completedAt);
+  const diffMs = end.getTime() - start.getTime();
+
+  const minutes = Math.floor(diffMs / (1000 * 60));
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+
+  if (hours > 0) {
+    return `${hours}時間${remainingMinutes}分`;
+  }
+  return `${minutes}分`;
+}

--- a/admin/src/features/interview-reports/shared/utils/format-role-label.test.ts
+++ b/admin/src/features/interview-reports/shared/utils/format-role-label.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { formatRoleLabel } from "./format-role-label";
+
+const roleLabels: Record<string, string> = {
+  subject_expert: "専門的な有識者",
+  work_related: "業務に関係",
+  daily_life_affected: "暮らしに影響",
+  general_citizen: "一市民として関心",
+};
+
+describe("formatRoleLabel", () => {
+  it("roleとroleTitleの両方がある場合は中黒で結合する", () => {
+    expect(formatRoleLabel("subject_expert", "物流業者", roleLabels)).toBe(
+      "専門的な有識者・物流業者"
+    );
+  });
+
+  it("roleのみの場合はラベルを返す", () => {
+    expect(formatRoleLabel("work_related", null, roleLabels)).toBe(
+      "業務に関係"
+    );
+  });
+
+  it("roleTitleのみの場合はroleTitleを返す", () => {
+    expect(formatRoleLabel(null, "市民代表", roleLabels)).toBe("市民代表");
+  });
+
+  it("両方nullの場合はnullを返す", () => {
+    expect(formatRoleLabel(null, null, roleLabels)).toBeNull();
+  });
+
+  it("未知のroleの場合はそのまま使用する", () => {
+    expect(formatRoleLabel("unknown_role", "テスト", roleLabels)).toBe(
+      "unknown_role・テスト"
+    );
+  });
+
+  it("roleがundefinedの場合", () => {
+    expect(formatRoleLabel(undefined, "テスト", roleLabels)).toBe("テスト");
+  });
+
+  it("roleTitleがundefinedの場合", () => {
+    expect(formatRoleLabel("general_citizen", undefined, roleLabels)).toBe(
+      "一市民として関心"
+    );
+  });
+});

--- a/admin/src/features/interview-reports/shared/utils/format-role-label.ts
+++ b/admin/src/features/interview-reports/shared/utils/format-role-label.ts
@@ -1,0 +1,15 @@
+/**
+ * 役割ラベルとrole_titleを中黒(・)で結合して表示用文字列を生成
+ * 例：「専門家・物流業者」
+ */
+export function formatRoleLabel(
+  role: string | null | undefined,
+  roleTitle: string | null | undefined,
+  roleLabels: Record<string, string>
+): string | null {
+  const baseLabel = role ? roleLabels[role] || role : null;
+  if (baseLabel && roleTitle) {
+    return `${baseLabel}・${roleTitle}`;
+  }
+  return roleTitle || baseLabel;
+}

--- a/admin/src/features/interview-reports/shared/utils/get-session-status.test.ts
+++ b/admin/src/features/interview-reports/shared/utils/get-session-status.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { getSessionStatus } from "./get-session-status";
+
+describe("getSessionStatus", () => {
+  it("completed_atがある場合は'completed'を返す", () => {
+    expect(getSessionStatus({ completed_at: "2024-01-01T12:00:00Z" })).toBe(
+      "completed"
+    );
+  });
+
+  it("completed_atがnullの場合は'in_progress'を返す", () => {
+    expect(getSessionStatus({ completed_at: null })).toBe("in_progress");
+  });
+});

--- a/admin/src/features/interview-reports/shared/utils/get-session-status.ts
+++ b/admin/src/features/interview-reports/shared/utils/get-session-status.ts
@@ -1,0 +1,10 @@
+export type SessionStatus = "completed" | "in_progress";
+
+/**
+ * completed_atの有無でセッションステータスを判定する
+ */
+export function getSessionStatus(session: {
+  completed_at: string | null;
+}): SessionStatus {
+  return session.completed_at ? "completed" : "in_progress";
+}

--- a/admin/src/features/interview-reports/shared/utils/pagination-utils.test.ts
+++ b/admin/src/features/interview-reports/shared/utils/pagination-utils.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import {
+  calculatePaginationRange,
+  generatePageNumbers,
+} from "./pagination-utils";
+
+describe("calculatePaginationRange", () => {
+  it("1ページ目のoffsetは0", () => {
+    expect(calculatePaginationRange(1, 30)).toEqual({ from: 0, to: 29 });
+  });
+
+  it("2ページ目のoffsetはperPage", () => {
+    expect(calculatePaginationRange(2, 30)).toEqual({ from: 30, to: 59 });
+  });
+
+  it("3ページ目（perPage=10）", () => {
+    expect(calculatePaginationRange(3, 10)).toEqual({ from: 20, to: 29 });
+  });
+});
+
+describe("generatePageNumbers", () => {
+  it("totalPages <= 5 の場合はすべてのページを返す", () => {
+    expect(generatePageNumbers(3, 1)).toEqual([1, 2, 3]);
+    expect(generatePageNumbers(5, 3)).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it("1ページの場合", () => {
+    expect(generatePageNumbers(1, 1)).toEqual([1]);
+  });
+
+  it("先頭付近（currentPage=1）で省略記号は後ろのみ", () => {
+    expect(generatePageNumbers(10, 1)).toEqual([1, 2, "ellipsis-end", 10]);
+  });
+
+  it("末尾付近（currentPage=10）で省略記号は前のみ", () => {
+    expect(generatePageNumbers(10, 10)).toEqual([1, "ellipsis-start", 9, 10]);
+  });
+
+  it("中間（currentPage=5）で前後に省略記号", () => {
+    expect(generatePageNumbers(10, 5)).toEqual([
+      1,
+      "ellipsis-start",
+      4,
+      5,
+      6,
+      "ellipsis-end",
+      10,
+    ]);
+  });
+
+  it("currentPage=3では前に省略記号なし", () => {
+    expect(generatePageNumbers(10, 3)).toEqual([
+      1,
+      2,
+      3,
+      4,
+      "ellipsis-end",
+      10,
+    ]);
+  });
+
+  it("currentPage=8では後ろに省略記号なし", () => {
+    expect(generatePageNumbers(10, 8)).toEqual([
+      1,
+      "ellipsis-start",
+      7,
+      8,
+      9,
+      10,
+    ]);
+  });
+});

--- a/admin/src/features/interview-reports/shared/utils/pagination-utils.ts
+++ b/admin/src/features/interview-reports/shared/utils/pagination-utils.ts
@@ -1,0 +1,51 @@
+/**
+ * ページネーションのoffset/limit計算とページ番号リスト生成
+ */
+
+/**
+ * ページ番号からoffset（from）とlimit（to）を計算する
+ */
+export function calculatePaginationRange(
+  page: number,
+  perPage: number
+): { from: number; to: number } {
+  const from = (page - 1) * perPage;
+  const to = from + perPage - 1;
+  return { from, to };
+}
+
+/**
+ * ページ番号リストを生成する（省略記号付き、最大5ページ表示）
+ */
+export function generatePageNumbers(
+  totalPages: number,
+  currentPage: number
+): (number | "ellipsis-start" | "ellipsis-end")[] {
+  const pages: (number | "ellipsis-start" | "ellipsis-end")[] = [];
+
+  if (totalPages <= 5) {
+    for (let i = 1; i <= totalPages; i++) {
+      pages.push(i);
+    }
+  } else {
+    pages.push(1);
+
+    if (currentPage > 3) {
+      pages.push("ellipsis-start");
+    }
+
+    const start = Math.max(2, currentPage - 1);
+    const end = Math.min(totalPages - 1, currentPage + 1);
+    for (let i = start; i <= end; i++) {
+      pages.push(i);
+    }
+
+    if (currentPage < totalPages - 2) {
+      pages.push("ellipsis-end");
+    }
+
+    pages.push(totalPages);
+  }
+
+  return pages;
+}

--- a/admin/src/lib/utils/calculate-set-diff.test.ts
+++ b/admin/src/lib/utils/calculate-set-diff.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { calculateSetDiff } from "./calculate-set-diff";
+
+describe("calculateSetDiff", () => {
+  it("追加と削除の両方がある場合", () => {
+    const result = calculateSetDiff(["a", "b", "c"], ["b", "c", "d"]);
+    expect(result.toAdd).toEqual(["d"]);
+    expect(result.toDelete).toEqual(["a"]);
+  });
+
+  it("追加のみの場合", () => {
+    const result = calculateSetDiff(["a"], ["a", "b", "c"]);
+    expect(result.toAdd).toEqual(["b", "c"]);
+    expect(result.toDelete).toEqual([]);
+  });
+
+  it("削除のみの場合", () => {
+    const result = calculateSetDiff(["a", "b", "c"], ["a"]);
+    expect(result.toAdd).toEqual([]);
+    expect(result.toDelete).toEqual(["b", "c"]);
+  });
+
+  it("変更なしの場合", () => {
+    const result = calculateSetDiff(["a", "b"], ["a", "b"]);
+    expect(result.toAdd).toEqual([]);
+    expect(result.toDelete).toEqual([]);
+  });
+
+  it("両方空の場合", () => {
+    const result = calculateSetDiff([], []);
+    expect(result.toAdd).toEqual([]);
+    expect(result.toDelete).toEqual([]);
+  });
+
+  it("既存が空で追加のみの場合", () => {
+    const result = calculateSetDiff([], ["a", "b"]);
+    expect(result.toAdd).toEqual(["a", "b"]);
+    expect(result.toDelete).toEqual([]);
+  });
+
+  it("数値でも動作する", () => {
+    const result = calculateSetDiff([1, 2, 3], [2, 3, 4]);
+    expect(result.toAdd).toEqual([4]);
+    expect(result.toDelete).toEqual([1]);
+  });
+});

--- a/admin/src/lib/utils/calculate-set-diff.ts
+++ b/admin/src/lib/utils/calculate-set-diff.ts
@@ -1,0 +1,15 @@
+/**
+ * 2つのセット（配列）を比較し、追加・削除すべき要素を算出する
+ */
+export function calculateSetDiff<T>(
+  existing: T[],
+  incoming: T[]
+): { toAdd: T[]; toDelete: T[] } {
+  const existingSet = new Set(existing);
+  const incomingSet = new Set(incoming);
+
+  const toDelete = existing.filter((item) => !incomingSet.has(item));
+  const toAdd = incoming.filter((item) => !existingSet.has(item));
+
+  return { toAdd, toDelete };
+}


### PR DESCRIPTION
## Summary
- admin側のデータ変換・計算ロジックを純粋関数としてshared/utilsに切り出し、ユニットテストを追加
- `formatDuration`: 所要時間フォーマット（ミリ秒→「X時間Y分」）
- `getSessionStatus`: セッションステータス判定（completed_atの有無）
- `generatePageNumbers` / `calculatePaginationRange`: ページネーション計算（省略記号付きページ番号リスト）
- `textToArray` / `arrayToText`: 改行区切りテキスト⇔配列変換
- `calculateSetDiff`: セット差分計算（追加・削除の算出）汎用関数
- `formatRoleLabel`: ロールラベルフォーマット（中黒結合）
- 元ファイルからはre-exportで参照を維持し、既存のimportパスに影響なし
- 全43テスト追加、vi.mock不使用

## Test plan
- [x] `npx vitest run --dir admin/src` で全43テスト通過
- [x] `pnpm lint:fix` 通過
- [x] `pnpm typecheck` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)