### PR TITLE
chore: push前のローカルCI検証を必須ルール化

### DIFF
--- a/.claude/skills/parallel-pr/SKILL.md
+++ b/.claude/skills/parallel-pr/SKILL.md
@@ -84,8 +84,12 @@ Task(
 1. `git checkout -b {branch} develop` でブランチ作成
 2. 対象ファイルを読んで理解
 3. 実装・修正
-4. 検証（テスト実行 or typecheck）
-5. `pnpm lint:fix` でフォーマット
+4. push前のローカル検証（CIと同じコマンドを全て実行し、全て通過すること）:
+   - `pnpm lint:fix` でフォーマット修正
+   - `pnpm lint` でlintチェック通過を確認
+   - `pnpm typecheck` で型チェック通過を確認
+   - `pnpm test` でテスト通過を確認
+5. エラーがあれば修正して再度ステップ4を実行
 6. コミット（Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>）
 7. `git push -u origin {branch}`
 8. `gh pr create --base develop --title "{title}" --body "..."`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,12 @@ Repository レイヤーの詳細は [docs/repository-layer.md](docs/repository-l
 - テストの書き方・構造化・コード例などの詳細は [docs/テストガイドライン.md](docs/20260219_1000_テストガイドライン.md) を参照。
 
 ## Commit & Pull Request Guidelines
+- **push前のローカル検証（必須）**: `git push` の前に、CIと同じ検証コマンドをローカルで実行して通過を確認すること。CIで落ちてから直すのではなく、手元で事前に検知する。
+  ```bash
+  pnpm lint        # Biome format + lint チェック
+  pnpm typecheck   # TypeScript 型チェック
+  pnpm test        # 全ワークスペースのテスト実行
+  ```
 - **push / PR作成前のGitHub状態確認（必須）**: `git push` やPR作成を行う前に、必ず `gh pr list` や `gh pr view <番号>` でGitHub上のPR状態（open/merged/closed）を確認すること。マージ済みブランチへの追加pushや、既にクローズされたPRとの重複を防ぐ。
 - コミットメッセージは既存履歴同様、短い命令形主体（日本語可）とし、課題連携は `(#id)` を付与します。
 - PR ではスコープ概要、実行テスト記録（例: `pnpm dev`, `pnpm --filter web test`）、UI 変更時のスクリーンショットや GIF を添付します。


### PR DESCRIPTION
## 仕組み化サマリ

### 背景
並列PR作成時にCI失敗が発生（`@vitest/coverage-v8` 未インストール等）。push前にローカルでCIコマンドを実行していれば事前に検知できた。

### 仕組み化した項目
| 指摘 | 対応 | 追加先 |
|------|------|--------|
| push前にCIコマンドをローカル実行すべき | CLAUDE.mdにルール追加 | `AGENTS.md` (Commit & Pull Request Guidelines) |
| parallel-prのエージェント検証ステップが曖昧 | 具体的な4コマンドを明記 | `.claude/skills/parallel-pr/SKILL.md` |

### 変更内容
1. **AGENTS.md**: `push前のローカル検証（必須）`ルールを追加。`pnpm lint` / `pnpm typecheck` / `pnpm test` の3コマンドをpush前に実行することを義務化
2. **parallel-pr SKILL.md**: エージェントプロンプトの検証ステップを「テスト実行 or typecheck」→ lint:fix / lint / typecheck / test の4段階に具体化

🤖 Generated with [Claude Code](https://claude.com/claude-code)