### PR TITLE
feat: インタビュー新規作成時にデフォルト設定名を追加

### DIFF
--- a/admin/src/features/interview-config/client/components/interview-config-form.tsx
+++ b/admin/src/features/interview-config/client/components/interview-config-form.tsx
@@ -34,6 +34,7 @@ import {
   arrayToText,
   textToArray,
 } from "../../shared/types";
+import { generateDefaultConfigName } from "../../shared/utils/default-config-name";
 import {
   createInterviewConfig,
   updateInterviewConfig,
@@ -53,21 +54,10 @@ export function InterviewConfigForm({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const isNew = !config;
 
-  const defaultName = () => {
-    if (config?.name) return config.name;
-    const date = new Intl.DateTimeFormat("ja-JP", {
-      year: "numeric",
-      month: "2-digit",
-      day: "2-digit",
-      timeZone: "Asia/Tokyo",
-    }).format(new Date());
-    return `${date} 作成`;
-  };
-
   const form = useForm<InterviewConfigInput>({
     resolver: zodResolver(interviewConfigSchema),
     defaultValues: {
-      name: defaultName(),
+      name: config?.name || generateDefaultConfigName(),
       status: config?.status || "closed",
       mode: config?.mode || "loop",
       themes: config?.themes || [],

--- a/admin/src/features/interview-config/shared/utils/default-config-name.test.ts
+++ b/admin/src/features/interview-config/shared/utils/default-config-name.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { generateDefaultConfigName } from "./default-config-name";
+
+describe("generateDefaultConfigName", () => {
+  it("日付を YYYY/MM/DD 作成 形式で返す", () => {
+    const date = new Date("2026-02-19T10:00:00+09:00");
+    expect(generateDefaultConfigName(date)).toBe("2026/02/19 作成");
+  });
+
+  it("UTCの日付がJSTで翌日になるケースを正しく扱う", () => {
+    // UTC 23:00 = JST 翌日 08:00
+    const date = new Date("2026-03-31T23:00:00Z");
+    expect(generateDefaultConfigName(date)).toBe("2026/04/01 作成");
+  });
+
+  it("引数なしで現在日付を使用する", () => {
+    const result = generateDefaultConfigName();
+    expect(result).toMatch(/^\d{4}\/\d{2}\/\d{2} 作成$/);
+  });
+});

--- a/admin/src/features/interview-config/shared/utils/default-config-name.ts
+++ b/admin/src/features/interview-config/shared/utils/default-config-name.ts
@@ -1,0 +1,13 @@
+/**
+ * インタビュー設定のデフォルト名を生成する。
+ * 日付は Asia/Tokyo タイムゾーンで「YYYY/MM/DD 作成」形式。
+ */
+export function generateDefaultConfigName(now: Date = new Date()): string {
+  const date = new Intl.DateTimeFormat("ja-JP", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    timeZone: "Asia/Tokyo",
+  }).format(now);
+  return `${date} 作成`;
+}


### PR DESCRIPTION
## Summary
- インタビュー設定の新規作成時に、設定名のデフォルト値として「YYYY/MM/DD 作成」（例: 2026/02/19 作成）を自動入力するようにした
- `Intl.DateTimeFormat` で `Asia/Tokyo` タイムゾーンを明示し、サーバー/クライアント間のタイムゾーン差異によるハイドレーションミスマッチを防止

## Test plan
- [ ] `pnpm --filter admin typecheck` が通ること ✅
- [ ] `pnpm lint` が通ること ✅
- [ ] インタビュー新規作成画面を開いた際、設定名に当日の日付が「YYYY/MM/DD 作成」形式でプリセットされること
- [ ] 既存のインタビュー設定の編集画面では、保存済みの設定名がそのまま表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Interview configurations now automatically generate descriptive default names using the current date when no name is provided during creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->