### PR TITLE
既存設定がある場合のAI生成ブラッシュアップモード

### DIFF
--- a/admin/src/app/api/interview-config/generate/route.ts
+++ b/admin/src/app/api/interview-config/generate/route.ts
@@ -15,12 +15,20 @@ export async function POST(req: Request) {
     configId,
     stage,
     confirmedThemes,
+    existingThemes,
+    existingQuestions,
   }: {
     messages: Array<{ role: string; content: string }>;
     billId: string;
     configId?: string;
     stage: "theme_proposal" | "question_proposal";
     confirmedThemes?: string[];
+    existingThemes?: string[];
+    existingQuestions?: Array<{
+      question: string;
+      instruction?: string | null;
+      quick_replies?: string[] | null;
+    }>;
   } = body;
 
   if (!billId) {
@@ -37,6 +45,8 @@ export async function POST(req: Request) {
       configId,
       stage,
       confirmedThemes,
+      existingThemes,
+      existingQuestions,
     });
   } catch (error) {
     console.error("Config generation error:", error);

--- a/admin/src/features/interview-config/client/components/config-generation-chat.tsx
+++ b/admin/src/features/interview-config/client/components/config-generation-chat.tsx
@@ -12,6 +12,8 @@ import { useConfigGenerationChat } from "../hooks/use-config-generation-chat";
 interface ConfigGenerationChatProps {
   billId: string;
   configId?: string;
+  existingThemes?: string[];
+  existingQuestions?: InterviewQuestionInput[];
   onThemesConfirmed: (themes: string[]) => void;
   onQuestionsConfirmed: (questions: InterviewQuestionInput[]) => void;
   getFormThemes?: () => string[];
@@ -20,6 +22,8 @@ interface ConfigGenerationChatProps {
 export function ConfigGenerationChat({
   billId,
   configId,
+  existingThemes,
+  existingQuestions,
   onThemesConfirmed,
   onQuestionsConfirmed,
   getFormThemes,
@@ -43,6 +47,8 @@ export function ConfigGenerationChat({
   } = useConfigGenerationChat({
     billId,
     configId,
+    existingThemes,
+    existingQuestions,
     onThemesConfirmed,
     onQuestionsConfirmed,
   });

--- a/admin/src/features/interview-config/client/components/interview-config-edit-client.tsx
+++ b/admin/src/features/interview-config/client/components/interview-config-edit-client.tsx
@@ -156,6 +156,12 @@ export function InterviewConfigEditClient({
         <ConfigGenerationChat
           billId={billId}
           configId={configId}
+          existingThemes={initialConfig?.themes ?? undefined}
+          existingQuestions={questions.map((q) => ({
+            question: q.question,
+            instruction: q.instruction ?? undefined,
+            quick_replies: q.quick_replies ?? undefined,
+          }))}
           onThemesConfirmed={handleThemesConfirmed}
           onQuestionsConfirmed={handleQuestionsConfirmed}
           getFormThemes={getFormThemes}

--- a/admin/src/features/interview-config/server/services/handle-config-generation.ts
+++ b/admin/src/features/interview-config/server/services/handle-config-generation.ts
@@ -13,12 +13,20 @@ import {
 import { buildConfigGenerationPrompt } from "../utils/build-config-generation-prompt";
 import { getInterviewConfigById } from "../loaders/get-interview-config";
 
+interface ExistingQuestion {
+  question: string;
+  instruction?: string | null;
+  quick_replies?: string[] | null;
+}
+
 interface HandleConfigGenerationParams {
   messages: Array<{ role: string; content: string }>;
   billId: string;
   configId?: string;
   stage: ConfigGenerationStage;
   confirmedThemes?: string[];
+  existingThemes?: string[];
+  existingQuestions?: ExistingQuestion[];
 }
 
 export async function handleConfigGeneration({
@@ -27,6 +35,8 @@ export async function handleConfigGeneration({
   configId,
   stage,
   confirmedThemes,
+  existingThemes,
+  existingQuestions,
 }: HandleConfigGenerationParams) {
   const [bill, billContents, config] = await Promise.all([
     getBillById(billId),
@@ -51,6 +61,8 @@ export async function handleConfigGeneration({
     stage,
     confirmedThemes,
     knowledgeSource: config?.knowledge_source || undefined,
+    existingThemes,
+    existingQuestions,
   });
 
   // メッセージが空の場合は初回呼び出し用のユーザーメッセージを追加


### PR DESCRIPTION
## Summary
- 既存のテーマや質問が設定済みの場合、AI生成チャットが自動生成ではなく「ブラッシュアップモード」で開始されるように変更
- 現在の設定内容を表示し、ユーザーに修正要望を聞く形にすることで、既存設定を活かした改善が可能に
- プロンプトにも既存テーマ・質問を含め、AIが既存内容を踏まえた改善提案を行えるようにした

## 変更内容
- `build-config-generation-prompt.ts`: 既存テーマ・質問をプロンプトに含めるセクションを追加
- `handle-config-generation.ts`: `existingThemes`/`existingQuestions` パラメータの受け渡し
- `route.ts`: APIリクエストボディに `existingThemes`/`existingQuestions` を追加
- `use-config-generation-chat.ts`: `startGeneration` で既存設定表示＋自動生成スキップ、各API呼び出しに既存データを送信
- `config-generation-chat.tsx`: 既存データpropsの受け渡し
- `interview-config-edit-client.tsx`: 初期設定データをチャットコンポーネントに渡す

## Test plan
- [ ] 新規作成時：従来通りAIが自動でテーマ提案を開始すること
- [ ] 既存テーマあり：現在のテーマが表示され、ブラッシュアップの要望を聞く形になること
- [ ] 既存質問あり：現在の質問が表示されること
- [ ] テキスト入力で修正要望を送信 → AIが既存設定を踏まえた提案を返すこと
- [ ] バッジクリックでテーマ・質問の再生成ができること
- [ ] `pnpm --filter admin typecheck` でエラーなし
- [ ] `pnpm lint` でエラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Added ability to refine existing interview configurations using AI assistance by providing current themes and questions as context.
* When editing existing configurations, the system now enters a browse/edit mode that displays current settings and requests refinements rather than generating new proposals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->