### PR TITLE
AI設定生成プロンプトビルダーのユニットテストを追加

### DIFF
--- a/admin/src/features/interview-config/server/utils/build-config-generation-prompt.test.ts
+++ b/admin/src/features/interview-config/server/utils/build-config-generation-prompt.test.ts
@@ -1,7 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
-
-vi.mock("server-only", () => ({}));
-
+import { describe, expect, it } from "vitest";
 import { buildConfigGenerationPrompt } from "./build-config-generation-prompt";
 
 const baseParams = {

--- a/admin/vitest.config.mts
+++ b/admin/vitest.config.mts
@@ -4,6 +4,7 @@ import path from "path";
 export default defineConfig({
   test: {
     globals: true,
+    setupFiles: ["./vitest.setup.ts"],
   },
   resolve: {
     alias: {

--- a/admin/vitest.setup.ts
+++ b/admin/vitest.setup.ts
@@ -1,0 +1,5 @@
+import { vi } from "vitest";
+
+// Next.js の "server-only" パッケージをモック
+// サーバー専用ファイルのユニットテストで必要
+vi.mock("server-only", () => ({}));


### PR DESCRIPTION
## Summary
- `buildConfigGenerationPrompt` 関数の14テストケースを追加
- サーバーユーティリティのテストカバレッジ改善

## テストケース
| カテゴリ | テスト内容 |
|---------|-----------|
| 共通部分 | ベースロール（専門家の役割）を含む |
| 共通部分 | 法案情報セクション（名前、タイトル、要約、内容）を含む |
| theme_proposal | テーマ提案のガイドラインを含む |
| theme_proposal | 出力形式にthemesを指定する |
| theme_proposal | ナレッジソースなし → セクションヘッダーなし |
| theme_proposal | ナレッジソースあり → セクション含む |
| theme_proposal | ナレッジソースが空白のみ → セクションヘッダーなし |
| question_proposal | 質問提案のガイドラインを含む |
| question_proposal | 出力形式にquestionsを指定する |
| question_proposal | 確定テーマあり → テーマ一覧を含む |
| question_proposal | 確定テーマなし → テーマ未設定と表示 |
| question_proposal | 各質問フィールドの説明を含む |
| question_proposal | ナレッジソースあり → セクション含む |
| 不明ステージ | ベースロールのみを返す |

## Test plan
- [x] `pnpm --filter admin test` で全19テストファイル・124テスト通過
- [x] `pnpm lint` でエラーなし

Resolves #379

🤖 Generated with [Claude Code](https://claude.com/claude-code)