### PR TITLE
feat: インタビューAIにLangfuse telemetryを追加

### DIFF
--- a/web/src/features/interview-session/server/services/generate-initial-question.ts
+++ b/web/src/features/interview-session/server/services/generate-initial-question.ts
@@ -62,6 +62,14 @@ export async function generateInitialQuestion({
       model,
       prompt: enhancedSystemPrompt,
       output: Output.object({ schema: interviewChatTextSchema }),
+      experimental_telemetry: {
+        isEnabled: true,
+        functionId: "interview-initial-question",
+        metadata: {
+          sessionId,
+          billId,
+        },
+      },
     });
 
     const generatedText = result.text;


### PR DESCRIPTION
## Summary
- インタビューAIの全LLM呼び出し（ファシリテーター/チャット/サマリー/初回質問生成）に `experimental_telemetry` を追加
- `sessionId` でインタビュー会話全体を1セッションとして、`langfuseTraceId` で同一リクエスト内の複数LLM呼び出しを1トレースとしてLangfuse上で追跡可能に

## 変更内容
- `handle-interview-chat-request.ts`: 3箇所のLLM呼び出し（facilitator/chat/summary）にtelemetry追加
- `generate-initial-question.ts`: 初回質問生成のLLM呼び出しにtelemetry追加

## Langfuse上でのトレース構造
```
Session (interview session ID)
├── Trace (request 1: 初回質問生成)
│   └── Generation: interview-initial-question
├── Trace (request 2: ユーザー返答 → AI応答)
│   ├── Generation: interview-facilitator
│   └── Generation: interview-chat
└── Trace (request N: サマリー生成)
    ├── Generation: interview-facilitator
    └── Generation: interview-summary
```

## Test plan
- [x] `pnpm typecheck` 通過
- [x] `pnpm lint` 通過
- [x] `pnpm --filter web test` 全317テスト通過
- [ ] ローカルでLangfuse環境変数を設定してインタビューを実行し、Langfuseダッシュボードでセッション単位のトレース表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)