### PR TITLE
feat: インタビュー画面でフッターを非表示にする

### DIFF
--- a/web/src/components/layouts/footer/footer.tsx
+++ b/web/src/components/layouts/footer/footer.tsx
@@ -2,9 +2,17 @@
 
 import Image from "next/image";
 import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { isInterviewSection } from "@/lib/page-layout-utils";
 import { policyLinks, primaryLinks } from "./footer.config";
 
 export function Footer() {
+  const pathname = usePathname();
+
+  if (isInterviewSection(pathname)) {
+    return null;
+  }
+
   return (
     <footer className="bg-mirai-gradient text-slate-900">
       <div className="mx-auto flex w-full max-w-[500px] flex-col items-center px-6 py-14 pb-20 text-center">

--- a/web/src/lib/page-layout-utils.test.ts
+++ b/web/src/lib/page-layout-utils.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   extractBillIdFromPath,
   isInterviewPage,
+  isInterviewSection,
   isMainPage,
 } from "./page-layout-utils";
 
@@ -44,6 +45,28 @@ describe("isInterviewPage", () => {
 
   it("returns false for the top page", () => {
     expect(isInterviewPage("/")).toBe(false);
+  });
+});
+
+describe("isInterviewSection", () => {
+  it("returns true for the interview LP page", () => {
+    expect(isInterviewSection("/bills/abc-123/interview")).toBe(true);
+  });
+
+  it("returns true for the interview chat page", () => {
+    expect(isInterviewSection("/bills/abc-123/interview/chat")).toBe(true);
+  });
+
+  it("returns false for a bill detail page", () => {
+    expect(isInterviewSection("/bills/abc-123")).toBe(false);
+  });
+
+  it("returns false for the top page", () => {
+    expect(isInterviewSection("/")).toBe(false);
+  });
+
+  it("returns false for unrelated paths", () => {
+    expect(isInterviewSection("/about")).toBe(false);
   });
 });
 

--- a/web/src/lib/page-layout-utils.ts
+++ b/web/src/lib/page-layout-utils.ts
@@ -21,6 +21,12 @@ export function isInterviewPage(pathname: string): boolean {
   return /\/bills\/[^/]+\/interview\/chat$/.test(pathname);
 }
 
+/** インタビューセクション（LP・チャット含む）かどうかを判定 */
+export function isInterviewSection(pathname: string): boolean {
+  // /bills/[id]/interview 以下すべて
+  return /\/bills\/[^/]+\/interview(\/|$)/.test(pathname);
+}
+
 /** インタビューページからbillIdを抽出 */
 export function extractBillIdFromPath(pathname: string): string | null {
   const match = pathname.match(/\/bills\/([^/]+)/);


### PR DESCRIPTION
## Summary
- インタビュー画面（LP・チャット）でフッターを非表示にする
- `isInterviewSection` 判定関数を `page-layout-utils.ts` に追加
- `Footer` コンポーネントでパス判定し、インタビューセクションでは `null` を返す

## 変更ファイル
- `web/src/lib/page-layout-utils.ts` - `isInterviewSection` 関数追加
- `web/src/lib/page-layout-utils.test.ts` - テスト追加（5ケース）
- `web/src/components/layouts/footer/footer.tsx` - インタビュー画面で非表示

## Test plan
- [x] `pnpm lint` パス
- [x] `pnpm typecheck` パス
- [x] `pnpm test` パス（全322テスト通過）
- [x] Codex レビュー パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The footer is now automatically hidden when viewing interview pages, providing a cleaner and more focused user interface during interviews.

* **Tests**
  * Added comprehensive test coverage for interview section detection, ensuring proper behavior across various path scenarios and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->