### PR TITLE
fix: インタビューやり直し時の画面遷移中ローディング維持

### DIFF
--- a/web/src/features/interview-session/client/components/restart-interview-button.tsx
+++ b/web/src/features/interview-session/client/components/restart-interview-button.tsx
@@ -32,16 +32,17 @@ export function RestartInterviewButton({
       const result = await archiveInterviewSession(sessionId);
       if (result.success) {
         // アーカイブ成功後、チャットページに遷移（新しいセッションが作成される）
+        // 遷移完了までローディングを維持するため、成功時は setIsLoading(false) を呼ばない
         const chatLink = getInterviewChatLink(billId, previewToken);
         router.push(chatLink);
       } else {
         console.error("Failed to archive session:", result.error);
         alert(result.error || "やり直しに失敗しました");
+        setIsLoading(false);
       }
     } catch (error) {
       console.error("Failed to archive session:", error);
       alert("やり直しに失敗しました");
-    } finally {
       setIsLoading(false);
     }
   };


### PR DESCRIPTION
## Summary
- インタビューの「もう一度最初から回答する」ボタンクリック後、`router.push()` による画面遷移が完了するまでの間にローディング表示が解除されてしまう問題を修正
- `finally` ブロックで無条件に `setIsLoading(false)` していたのを、エラー時のみリセットするよう変更
- 成功時はページ遷移完了（コンポーネントアンマウント）まで「処理中...」表示を維持

## Test plan
- [x] `pnpm lint` 通過
- [x] `pnpm typecheck` 通過
- [x] `pnpm test` 全317テスト通過
- [ ] 手動確認: やり直しボタンクリック → 確認ダイアログ → 「処理中...」が画面遷移完了まで表示され続けること
- [ ] 手動確認: サーバーエラー時にローディングが解除されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved loading state handling in the restart interview flow—the loading indicator now persists during navigation after a successful operation and properly clears when errors occur, providing better visual feedback to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->