### PR TITLE
fix: h-screen を h-dvh に置換してモバイルブラウザの表示を改善

### DIFF
--- a/admin/src/app/(protected)/layout.tsx
+++ b/admin/src/app/(protected)/layout.tsx
@@ -11,7 +11,7 @@ export default async function MainLayout({
 }) {
   const admin = await getCurrentAdmin();
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-dvh bg-gray-50">
       {/* Header */}
       <header className="bg-white shadow-sm">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/admin/src/app/login/page.tsx
+++ b/admin/src/app/login/page.tsx
@@ -4,7 +4,7 @@ import { LoginForm } from "@/features/auth/client/components/login-form";
 
 export default function LoginPage() {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-gray-50 to-gray-100 p-4">
+    <div className="min-h-dvh flex items-center justify-center bg-gradient-to-br from-gray-50 to-gray-100 p-4">
       <Card className="w-full max-w-md">
         <CardHeader className="space-y-1">
           <CardTitle className="text-2xl font-bold text-center">

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -98,7 +98,7 @@ export default function RootLayout({
 
         <MainLayout>
           <Header />
-          <main className="min-h-screen bg-[#F7F4F0]">{children}</main>
+          <main className="min-h-dvh bg-[#F7F4F0]">{children}</main>
           <Footer />
         </MainLayout>
       </body>

--- a/web/src/features/interview-report/server/components/report-chat-log-page.tsx
+++ b/web/src/features/interview-report/server/components/report-chat-log-page.tsx
@@ -30,7 +30,7 @@ export async function ReportChatLogPage({ reportId }: ReportChatLogPageProps) {
   const opinions = parseOpinions(report.opinions);
 
   return (
-    <div className="min-h-screen bg-[#F7F4F0]">
+    <div className="min-h-dvh bg-[#F7F4F0]">
       {/* Header Section */}
       <div className="px-4 pt-24 pb-8">
         <div className="flex flex-col items-center">

--- a/web/src/features/interview-report/server/components/report-complete-page.tsx
+++ b/web/src/features/interview-report/server/components/report-complete-page.tsx
@@ -56,7 +56,7 @@ export async function ReportCompletePage({
   const characterCount = countCharacters(messages);
 
   return (
-    <div className="min-h-screen bg-[#F7F4F0]">
+    <div className="min-h-dvh bg-[#F7F4F0]">
       {/* 法案サムネイル画像 */}
       {bill.thumbnail_url && (
         <div className="relative w-full h-[320px]">

--- a/web/src/features/interview-session/client/components/interview-chat-client.tsx
+++ b/web/src/features/interview-session/client/components/interview-chat-client.tsx
@@ -76,7 +76,7 @@ export function InterviewChatClient({
   const showStreamingMessage = object && !isStreamingMessageCommitted;
 
   return (
-    <div className="flex flex-col h-screen md:h-[calc(100vh-96px)] pt-24 md:pt-4 bg-white">
+    <div className="flex flex-col h-dvh md:h-[calc(100dvh-96px)] pt-24 md:pt-4 bg-white">
       {showProgressBar && progress && (
         <div className="px-4 pb-1 pt-2">
           <InterviewProgressBar


### PR DESCRIPTION
## Summary
- `min-h-screen` / `h-screen` を `min-h-dvh` / `h-dvh` に置換（6箇所）
- モバイルブラウザでアドレスバー/ナビゲーションバーにより `100vh` が実際の可視領域と一致しない問題を修正
- `calc(100vh-96px)` も `calc(100dvh-96px)` に更新

## 変更対象ファイル
- `admin/src/app/login/page.tsx` — `min-h-screen` → `min-h-dvh`
- `admin/src/app/(protected)/layout.tsx` — `min-h-screen` → `min-h-dvh`
- `web/src/app/layout.tsx` — `min-h-screen` → `min-h-dvh`
- `web/.../report-complete-page.tsx` — `min-h-screen` → `min-h-dvh`
- `web/.../report-chat-log-page.tsx` — `min-h-screen` → `min-h-dvh`
- `web/.../interview-chat-client.tsx` — `h-screen` → `h-dvh`, `100vh` → `100dvh`

## Test plan
- [x] `pnpm lint` パス
- [x] `pnpm typecheck` パス
- [x] `pnpm test` 全テストパス
- [x] Codex レビュー指摘なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)