### PR TITLE
chore: dvhビューポート単位ルールをスタイルガイドに追加

### DIFF
--- a/docs/20260220_1530_スタイルガイド.md
+++ b/docs/20260220_1530_スタイルガイド.md
@@ -1,0 +1,40 @@
+# スタイルガイド
+
+Tailwind CSS / CSS に関するプロジェクト共通のスタイルルール。
+
+## ビューポート高さ: `dvh` を使う
+
+### ルール
+
+- `h-screen` / `min-h-screen` は**使用禁止**
+- 代わりに `h-dvh` / `min-h-dvh` を使用する
+- `calc()` 内の `100vh` も `100dvh` に置き換える
+
+### 理由
+
+モバイルブラウザ（iOS Safari, Android Chrome 等）では、アドレスバーやナビゲーションバーの表示/非表示により、`100vh` が実際の可視領域と一致しない。`dvh`（Dynamic Viewport Height）を使うことで、ブラウザ UI の状態に応じた正確な高さを取得できる。
+
+### ビューポート単位の比較
+
+| CSS 単位 | Tailwind クラス | 説明 |
+|----------|----------------|------|
+| `100vh` | `h-screen` | ブラウザ UI を含む固定サイズ。モバイルで問題あり |
+| `100dvh` | `h-dvh` | ブラウザ UI の表示/非表示に応じて動的に変化 |
+| `100svh` | `h-svh` | ブラウザ UI が表示された状態の最小ビューポート |
+| `100lvh` | `h-lvh` | ブラウザ UI が非表示の状態の最大ビューポート |
+
+### 具体例
+
+```tsx
+// NG
+<div className="min-h-screen bg-gray-50">
+<div className="h-screen md:h-[calc(100vh-96px)]">
+
+// OK
+<div className="min-h-dvh bg-gray-50">
+<div className="h-dvh md:h-[calc(100dvh-96px)]">
+```
+
+### ブラウザサポート
+
+`dvh` は主要ブラウザで広くサポート済み（Chrome 108+, Safari 15.4+, Firefox 101+）。


### PR DESCRIPTION
## Summary
- CLAUDE.md の Coding Style セクションに `h-screen` / `min-h-screen` 禁止ルールを追加
- `docs/20260220_1530_スタイルガイド.md` を新規作成し、ビューポート単位の詳細（背景・比較表・具体例・ブラウザサポート）を記載

## 仕組み化サマリ

### 仕組み化した項目
| 指摘 | 対応 | 追加先 |
|------|------|--------|
| dvh を使う | CLAUDE.md にルール追加 | `CLAUDE.md` Coding Style セクション |
| dvh を使う | スタイルガイドドキュメント作成 | `docs/20260220_1530_スタイルガイド.md` |

### 関連PR
- #384 (実際のコード修正)

## Test plan
- [x] `pnpm lint` パス
- [x] `pnpm typecheck` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)