### PR TITLE
chore: Codexレビュー通過後の自動PR作成ルールを追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ cd ../mirai-gikai-<branch-name> && pnpm install --frozen-lockfile
 
 ### Codexレビュー必須
 実装完了後（コミット前）に、必ず `/review-codex` スキルを実行してCodex CLIによるコードレビューを受けること。指摘があれば修正してからコミットする。
+Codexレビューを通過したら、ユーザーに確認せずそのままPR作成まで一気に進めること（push → `gh pr create`）。
 
 ### 並列PR作成
 複数の独立したPRを作成する場合は `/parallel-pr` スキルを使用すること。


### PR DESCRIPTION
## Summary
- Codexレビュー通過後、ユーザーに確認せずそのままPR作成まで一気に進めるルールをCLAUDE.mdに追加

## 仕組み化サマリ

### 仕組み化した項目
| 指摘 | 対応 | 追加先 |
|------|------|--------|
| Codexレビュー通過後に自動でPR作成 | CLAUDE.mdにルール追加 | `CLAUDE.md` (Codexレビュー必須セクション) |

## Test plan
- [x] ルールの記述が既存セクションと整合していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)