### PR TITLE
feat: クイックリプライ5個以上で横並びレイアウトに切り替え

### DIFF
--- a/web/src/features/interview-session/client/components/quick-reply-buttons.tsx
+++ b/web/src/features/interview-session/client/components/quick-reply-buttons.tsx
@@ -15,8 +15,16 @@ export function QuickReplyButtons({
     return null;
   }
 
+  const isHorizontal = replies.length >= 5;
+
   return (
-    <div className="flex flex-col items-end gap-2 mt-2">
+    <div
+      className={
+        isHorizontal
+          ? "flex flex-row flex-wrap justify-end gap-2 mt-2 ml-auto w-1/2"
+          : "flex flex-col items-end gap-2 mt-2"
+      }
+    >
       {replies.map((reply) => (
         <button
           key={reply}


### PR DESCRIPTION
## Summary
- インタビューのクイックリプライが5個以上ある場合、横並び（`flex-row flex-wrap`）レイアウトに切り替え
- 横並び時は画面右半分（`w-1/2 ml-auto`）を使用して右寄せ表示
- 4個以下の場合は従来通りの縦並びレイアウトを維持

## 変更内容
`QuickReplyButtons` コンポーネントで `replies.length >= 5` の場合にレイアウトを切り替える条件分岐を追加。

## Test plan
- [x] `pnpm lint` 通過
- [x] `pnpm typecheck` 通過
- [x] `pnpm test` 全317テスト通過
- [ ] クイックリプライが5個以上の質問でUIを目視確認
- [ ] クイックリプライが4個以下の質問で従来通りのレイアウトを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced responsive design for quick reply buttons. The component now intelligently adapts its layout: when displaying 5 or more quick reply options, buttons arrange horizontally with wrapping to optimize space; for fewer options, the vertical layout is preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->