### PR TITLE
fix: middlewareにSupabaseセッションリフレッシュを追加

### DIFF
--- a/web/src/lib/supabase-middleware.ts
+++ b/web/src/lib/supabase-middleware.ts
@@ -1,0 +1,44 @@
+import { createServerClient } from "@supabase/ssr";
+import { type NextRequest, NextResponse } from "next/server";
+
+/**
+ * Supabaseセッションをミドルウェアでリフレッシュする
+ *
+ * Server Componentが実行される前にアクセストークンをリフレッシュし、
+ * レスポンスcookieに書き戻すことで、サーバー側での認証切れを防ぐ。
+ * これがないと匿名ユーザーのトークン期限切れ時にセッションが失われる。
+ */
+export async function refreshSupabaseSession(
+  request: NextRequest
+): Promise<NextResponse> {
+  let response = NextResponse.next({ request });
+
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!supabaseUrl || !supabaseAnonKey) {
+    return response;
+  }
+
+  const supabase = createServerClient(supabaseUrl, supabaseAnonKey, {
+    cookies: {
+      getAll() {
+        return request.cookies.getAll();
+      },
+      setAll(cookiesToSet) {
+        for (const { name, value } of cookiesToSet) {
+          request.cookies.set(name, value);
+        }
+        response = NextResponse.next({ request });
+        for (const { name, value, options } of cookiesToSet) {
+          response.cookies.set(name, value, options);
+        }
+      },
+    },
+  });
+
+  // getUser()を呼ぶことでトークンリフレッシュがトリガーされる
+  await supabase.auth.getUser();
+
+  return response;
+}


### PR DESCRIPTION
## Summary

- インタビュー中断後に再開するとデータが消えて見える問題を修正
- Next.js middlewareにSupabaseセッションリフレッシュ処理を追加
- `config.matcher`で静的アセットを除外しパフォーマンスへの影響を最小化

## 原因

middlewareにSupabaseのセッションリフレッシュ処理がなく、以下の流れで問題が発生していた：

1. ユーザーがインタビューを実施（匿名ユーザーAでセッション・メッセージがDBに保存）
2. 中断後しばらく経過してアクセストークンが期限切れ
3. 再訪問時、Server Component（チャットページ）がサーバー側で先に実行
4. `getChatSupabaseUser()` がcookieから期限切れトークンを読むが、`createChatSupabaseServerClient` の `setAll()` がno-opのためリフレッシュされたトークンをcookieに書き戻せない
5. ユーザー認証失敗 → 既存セッション取得不可 → 新しい匿名ユーザーBが作成される
6. 旧セッション（ユーザーA）のデータにアクセスできず、データが消えたように見える

## 対応内容

- `web/src/lib/supabase-middleware.ts` を新規作成: Supabase公式推奨パターンに従い、`createServerClient` でリクエストcookieからトークンを読み、`getUser()` でリフレッシュをトリガーし、レスポンスcookieに書き戻す
- `web/src/middleware.ts` を修正: `refreshSupabaseSession()` を既存のmiddleware処理（難易度cookie、Basic認証）の前に実行
- `config.matcher` を追加: `_next/static`, `_next/image`, favicon、画像ファイルなど静的アセットへのリクエストをmiddleware対象から除外

## テスト記録

```
pnpm lint       ✅
pnpm typecheck  ✅
pnpm test       ✅ (web: 32 passed, admin: 18 passed)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)