### PR TITLE
chore: AI_GATEWAY_API_KEYを.env.exampleのCommonセクションに移動

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,10 +6,10 @@ NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54421
 NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0
 # Web側のキャッシュを無効化するためのシークレットキー
 REVALIDATE_SECRET=your-secret-key-here
-
-#--- Web ---
 # Vercel AI GatewayのAPIキーを設定してください
 AI_GATEWAY_API_KEY=
+
+#--- Web ---
 # Basic認証をONにする場合は設定してください
 BASIC_AUTH_USER=
 BASIC_AUTH_PASSWORD=


### PR DESCRIPTION
## Summary
- `.env.example` の `AI_GATEWAY_API_KEY` を `#--- Web ---` セクションから `#--- Common ---` セクションに移動
- web/admin 両方で使用される共通キーとして適切な配置に変更

## Test plan
- [x] `.env.example` の構造が正しいことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)