### PR TITLE
fix: インタビューチャット入力欄の高さが送信後にリセットされない問題を修正

### DIFF
--- a/web/src/features/interview-session/client/components/interview-chat-input.tsx
+++ b/web/src/features/interview-session/client/components/interview-chat-input.tsx
@@ -2,7 +2,7 @@
 
 import type { ChangeEvent } from "react";
 import Image from "next/image";
-import { useRef } from "react";
+import { useEffect, useRef } from "react";
 import {
   PromptInput,
   PromptInputBody,
@@ -33,6 +33,12 @@ export function InterviewChatInput({
 }: InterviewChatInputProps) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const isDesktop = useIsDesktop();
+
+  useEffect(() => {
+    if (!input && textareaRef.current) {
+      textareaRef.current.style.height = "";
+    }
+  }, [input]);
 
   const handleInputChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
     onInputChange(e.target.value);


### PR DESCRIPTION
## 概要
インタビューチャットで1行+改行で送信すると、inputがクリアされた後もtextareaが2行分の高さのまま戻らない問題を修正。

## 原因
`handleInputChange`でtextareaの`style.height`をインラインスタイルで設定しているが、送信後にpropsの`input`が空になっても`handleInputChange`は呼ばれないため、インラインの高さが残り続けていた。

## 修正内容
`useEffect`で`input`が空になったときに`textareaRef`経由でインラインの`style.height`をクリアし、CSSの`field-sizing-content`による本来のサイズに戻るようにした。

## テスト
- `pnpm lint` ✅
- `pnpm typecheck` ✅
- `pnpm test` ✅ (32 files, 323 tests passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)