### PR TITLE
feat: AIモデル推定コスト表示を円表記に変更

### DIFF
--- a/admin/src/features/interview-config/client/components/interview-config-form.tsx
+++ b/admin/src/features/interview-config/client/components/interview-config-form.tsx
@@ -299,7 +299,7 @@ export function InterviewConfigForm({
                       </FormControl>
                       <SelectContent>
                         <SelectItem value="__default__">
-                          デフォルト（GPT-4o mini ~$0.01/回）
+                          デフォルト（GPT-4o mini ~2円/回）
                         </SelectItem>
                         {CHAT_MODEL_GROUPS.map((group) => (
                           <SelectGroup key={group.provider}>

--- a/admin/src/features/interview-config/shared/utils/chat-model-options.test.ts
+++ b/admin/src/features/interview-config/shared/utils/chat-model-options.test.ts
@@ -46,7 +46,7 @@ describe("CHAT_MODEL_GROUPS", () => {
     for (const group of CHAT_MODEL_GROUPS) {
       for (const option of group.options) {
         expect(option.estimatedCost).not.toBeNull();
-        expect(option.estimatedCost).toMatch(/^~\$/);
+        expect(option.estimatedCost).toMatch(/^~\d+円$/);
       }
     }
   });

--- a/admin/src/features/interview-config/shared/utils/estimate-interview-cost.test.ts
+++ b/admin/src/features/interview-config/shared/utils/estimate-interview-cost.test.ts
@@ -35,13 +35,17 @@ describe("estimateInterviewCostUsd", () => {
 });
 
 describe("formatEstimatedCost", () => {
-  it("$0.01未満のコストを~$0.01と表示する", () => {
-    expect(formatEstimatedCost(0.005)).toBe("~$0.01");
+  it("1円未満のコストを~1円と表示する", () => {
+    // $0.005 * 150 = 0.75円 → ~1円
+    expect(formatEstimatedCost(0.005)).toBe("~1円");
   });
 
-  it("$0.01以上のコストを小数第2位まで表示する", () => {
-    expect(formatEstimatedCost(0.0135)).toBe("~$0.01");
-    expect(formatEstimatedCost(0.225)).toBe("~$0.23");
-    expect(formatEstimatedCost(0.5)).toBe("~$0.50");
+  it("コストを四捨五入して円表示する", () => {
+    // $0.01455 * 150 = 2.18円 → ~2円
+    expect(formatEstimatedCost(0.01455)).toBe("~2円");
+    // $0.225 * 150 = 33.75円 → ~34円
+    expect(formatEstimatedCost(0.225)).toBe("~34円");
+    // $0.5 * 150 = 75円 → ~75円
+    expect(formatEstimatedCost(0.5)).toBe("~75円");
   });
 });

--- a/admin/src/features/interview-config/shared/utils/estimate-interview-cost.ts
+++ b/admin/src/features/interview-config/shared/utils/estimate-interview-cost.ts
@@ -63,13 +63,17 @@ export function estimateInterviewCostUsd(modelId: string): number | null {
   return inputCost + outputCost;
 }
 
+/** USD→JPY換算レート */
+const USD_TO_JPY = 150;
+
 /**
- * 推定コストを表示用文字列にフォーマットする
- * 例: "~$0.01", "~$0.23", "~$0.50"
+ * 推定コストを日本円の表示用文字列にフォーマットする
+ * 例: "~2円", "~21円", "~75円"
  */
 export function formatEstimatedCost(costUsd: number): string {
-  if (costUsd < 0.01) {
-    return "~$0.01";
+  const yen = Math.round(costUsd * USD_TO_JPY);
+  if (yen < 1) {
+    return "~1円";
   }
-  return `~$${costUsd.toFixed(2)}`;
+  return `~${yen}円`;
 }


### PR DESCRIPTION
## Summary
- AIモデル選択の推定コスト表示をUSD（~$0.14）から日本円（~21円）に変更
- 換算レート: 1USD = 150円
- 表示例: `~2円/回`、`~21円/回`、`~75円/回`

## 変更内容
- `estimate-interview-cost.ts`: `formatEstimatedCost` を円表記に変更
- `interview-config-form.tsx`: デフォルト選択肢の表示を円に更新
- テストを円表記に合わせて更新

## Test plan
- [x] `pnpm lint` 通過
- [x] `pnpm typecheck` 通過
- [x] `pnpm test` 全テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)