### PR TITLE
feat: インタビュー設定アシスタントのAIモデルをGPT-5.2に変更

### DIFF
--- a/admin/src/features/interview-config/server/services/handle-config-generation.ts
+++ b/admin/src/features/interview-config/server/services/handle-config-generation.ts
@@ -90,7 +90,7 @@ export async function handleConfigGeneration({
   const result =
     stage === "theme_proposal"
       ? streamText({
-          model: AI_MODELS.gpt4o_mini,
+          model: AI_MODELS.gpt5_2,
           system: systemPrompt,
           messages: modelMessages,
           output: Output.object({ schema: themeProposalSchema }),
@@ -99,7 +99,7 @@ export async function handleConfigGeneration({
           },
         })
       : streamText({
-          model: AI_MODELS.gpt4o_mini,
+          model: AI_MODELS.gpt5_2,
           system: systemPrompt,
           messages: modelMessages,
           output: Output.object({ schema: questionProposalSchema }),


### PR DESCRIPTION
## Summary
- インタビュー設定アシスタント（テーマ提案・質問提案）で使用するAIモデルを `gpt-4o-mini` から `gpt-5.2` に変更
- テーマ提案フェーズ・質問提案フェーズの両方で `AI_MODELS.gpt5_2` を使用するように統一

## 変更内容
- `admin/src/features/interview-config/server/services/handle-config-generation.ts`
  - `streamText` の `model` を `AI_MODELS.gpt4o_mini` → `AI_MODELS.gpt5_2` に変更（2箇所）

## テスト
- `pnpm lint` ✅
- `pnpm typecheck` ✅
- `pnpm test` ✅（313テスト全通過）

🤖 Generated with [Claude Code](https://claude.com/claude-code)