### PR TITLE
fix: Loop Modeでスキップ時にインタビューが誤って終了する問題を修正

### DIFF
--- a/web/src/features/interview-session/shared/utils/skip-detection.test.ts
+++ b/web/src/features/interview-session/shared/utils/skip-detection.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { isEndMessage, isSkipMessage } from "./skip-detection";
+
+describe("isSkipMessage", () => {
+  it("UIのスキップボタンメッセージを検出する", () => {
+    expect(isSkipMessage("次のテーマに進みたいです")).toBe(true);
+  });
+
+  it("部分一致の「次のテーマに進みたい」を検出する", () => {
+    expect(isSkipMessage("次のテーマに進みたい")).toBe(true);
+  });
+
+  it("「スキップ」を含むメッセージを検出する", () => {
+    expect(isSkipMessage("この質問をスキップしたい")).toBe(true);
+  });
+
+  it("「次の質問」を含むメッセージを検出する", () => {
+    expect(isSkipMessage("次の質問に進んでください")).toBe(true);
+  });
+
+  it("通常の回答メッセージはスキップではない", () => {
+    expect(isSkipMessage("私は賛成です")).toBe(false);
+  });
+
+  it("終了希望メッセージはスキップではない", () => {
+    expect(isSkipMessage("もう終わりにしたいです")).toBe(false);
+  });
+
+  it("空文字列はスキップではない", () => {
+    expect(isSkipMessage("")).toBe(false);
+  });
+
+  it("スキップと終了が混在する場合は終了を優先しスキップではない", () => {
+    expect(isSkipMessage("残りはスキップして終わりにしたい")).toBe(false);
+  });
+
+  it("スキップと終了が混在する場合（終了したい）", () => {
+    expect(isSkipMessage("全部スキップして終了したい")).toBe(false);
+  });
+
+  it("「スキップして終了します」は終了を優先", () => {
+    expect(isSkipMessage("スキップして終了します")).toBe(false);
+  });
+
+  it("「スキップして終わりです」は終了を優先", () => {
+    expect(isSkipMessage("スキップして終わりです")).toBe(false);
+  });
+});
+
+describe("isEndMessage", () => {
+  it("「終わりにしたい」を検出する", () => {
+    expect(isEndMessage("もう終わりにしたいです")).toBe(true);
+  });
+
+  it("「終了したい」を検出する", () => {
+    expect(isEndMessage("インタビューを終了したい")).toBe(true);
+  });
+
+  it("「終了します」を検出する", () => {
+    expect(isEndMessage("スキップして終了します")).toBe(true);
+  });
+
+  it("「終わりです」を検出する", () => {
+    expect(isEndMessage("スキップして終わりです")).toBe(true);
+  });
+
+  it("「以上です」を検出する", () => {
+    expect(isEndMessage("以上です")).toBe(true);
+  });
+
+  it("通常の回答は終了ではない", () => {
+    expect(isEndMessage("私は賛成です")).toBe(false);
+  });
+
+  it("スキップメッセージは終了ではない", () => {
+    expect(isEndMessage("次のテーマに進みたいです")).toBe(false);
+  });
+});

--- a/web/src/features/interview-session/shared/utils/skip-detection.ts
+++ b/web/src/features/interview-session/shared/utils/skip-detection.ts
@@ -1,0 +1,27 @@
+const END_PATTERNS = ["終わり", "終了", "以上です", "もう大丈夫"];
+
+const SKIP_PATTERNS = [
+  "次のテーマに進みたいです",
+  "次のテーマに進みたい",
+  "スキップ",
+  "次の質問",
+];
+
+/**
+ * 終了意思を含むメッセージかどうかを判定する
+ */
+export function isEndMessage(content: string): boolean {
+  return END_PATTERNS.some((pattern) => content.includes(pattern));
+}
+
+/**
+ * スキップリクエストかどうかを判定する
+ * UIの「スキップする」ボタンは "次のテーマに進みたいです" を送信する
+ * 終了意思を含むメッセージはスキップとして扱わない
+ */
+export function isSkipMessage(content: string): boolean {
+  if (isEndMessage(content)) {
+    return false;
+  }
+  return SKIP_PATTERNS.some((pattern) => content.includes(pattern));
+}


### PR DESCRIPTION
## Summary
- Loop Modeで「スキップする」ボタンを押した際、ファシリテーターLLMが「次のテーマに進みたいです」を終了意思と誤判定し、インタビュー途中でレポート生成に進んでしまうバグを修正
- `checkProgress`にアルゴリズムガードを追加し、残り質問がある+スキップメッセージの場合はLLM判定をバイパスして`chat`を継続
- ファシリテータープロンプトに「スキップ ≠ 終了」の区別を明記
- スキップと終了が混在するメッセージ（例：「スキップして終了したい」）では終了意思を優先

## 変更内容
- `shared/utils/skip-detection.ts`: `isSkipMessage`/`isEndMessage`純粋関数を新規追加
- `server/utils/interview-logic/loop-mode.ts`: `checkProgress`にスキップ検出ガードを追加、ファシリテータープロンプト改善

## Test plan
- [x] `pnpm lint` 通過
- [x] `pnpm typecheck` 通過  
- [x] `pnpm test` 全331テスト通過（新規テスト含む）
- [x] Codex CLIレビュー通過
- [ ] Loop Modeでスキップボタンを押して次のテーマに正しく遷移することを確認
- [ ] 全質問完了後にsummaryフェーズに正しく遷移することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now explicitly skip to the next interview question using natural language requests.
  * Enhanced interview session logic to intelligently detect and handle skip requests, distinguishing them from interview completion requests.

* **Tests**
  * Added unit tests for message detection functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->