### PR TITLE
fix: ユーザーメッセージの改行がスペースになる問題を修正

### DIFF
--- a/web/src/features/chat/client/components/user-message.tsx
+++ b/web/src/features/chat/client/components/user-message.tsx
@@ -1,6 +1,5 @@
 import type { UIMessage } from "@ai-sdk/react";
 import { Message, MessageContent } from "@/components/ai-elements/message";
-import { Response } from "@/components/ai-elements/response";
 
 interface UserMessageProps {
   message: UIMessage;
@@ -16,9 +15,12 @@ export function UserMessage({ message }: UserMessageProps) {
         {message.parts.map((part, i: number) => {
           if (part.type === "text") {
             return (
-              <Response key={`${message.id}-${i}`} className="break-words">
+              <span
+                key={`${message.id}-${i}`}
+                className="whitespace-pre-wrap break-words"
+              >
                 {part.text}
-              </Response>
+              </span>
             );
           }
           return null;


### PR DESCRIPTION
## Summary
- インタビュー画面のユーザーメッセージ表示で、改行がスペースに変換されてしまう問題を修正
- `Response` コンポーネント（内部でMarkdownレンダラー `Streamdown` を使用）がMarkdown仕様に従い単一改行をスペースに変換していた
- ユーザーメッセージにはMarkdown処理が不要なため、`whitespace-pre-wrap` を使った `<span>` 要素に置き換え

## Test plan
- [x] `pnpm lint` 通過
- [x] `pnpm typecheck` 通過
- [x] `pnpm test` 通過（34ファイル、384テスト全通過）
- [ ] インタビュー画面で改行を含むメッセージを送信し、改行が正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)