### PR TITLE
test: prompt/ownership純粋関数切り出し・テスト追加

### DIFF
--- a/web/src/features/interview-session/server/utils/verify-session-ownership.ts
+++ b/web/src/features/interview-session/server/utils/verify-session-ownership.ts
@@ -2,77 +2,46 @@ import "server-only";
 
 import { getChatSupabaseUser } from "@/features/chat/server/utils/supabase-server";
 import { findSessionOwnerById } from "../repositories/interview-session-repository";
+import { resolveOwnership } from "../../shared/utils/resolve-ownership";
 
-export type AuthenticatedUserResult =
-  | {
-      authenticated: true;
-      userId: string;
-    }
-  | {
-      authenticated: false;
-      error: string;
-    };
+// 型をre-export
+export type {
+  AuthenticatedUserResult,
+  VerifySessionOwnershipResult,
+} from "../../shared/utils/resolve-ownership";
 
 /**
  * 認証済みユーザーを取得する共通ユーティリティ
  */
-export async function getAuthenticatedUser(): Promise<AuthenticatedUserResult> {
+export async function getAuthenticatedUser() {
   const {
     data: { user },
     error: getUserError,
   } = await getChatSupabaseUser();
 
   if (getUserError || !user) {
-    return { authenticated: false, error: "認証が必要です" };
+    return { authenticated: false as const, error: "認証が必要です" };
   }
 
-  return { authenticated: true, userId: user.id };
+  return { authenticated: true as const, userId: user.id };
 }
-
-export type VerifySessionOwnershipResult =
-  | {
-      authorized: true;
-      userId: string;
-    }
-  | {
-      authorized: false;
-      error: string;
-    };
 
 /**
  * セッションの所有者確認を行う共通ユーティリティ
  * - ユーザー認証を確認
  * - セッションの所有者と現在のユーザーが一致するか確認
  */
-export async function verifySessionOwnership(
-  sessionId: string
-): Promise<VerifySessionOwnershipResult> {
+export async function verifySessionOwnership(sessionId: string) {
   const authResult = await getAuthenticatedUser();
 
-  if (!authResult.authenticated) {
-    return { authorized: false, error: authResult.error };
-  }
-
-  const { userId } = authResult;
-
-  let session: { user_id: string };
+  let session: { user_id: string } | null = null;
   try {
     session = await findSessionOwnerById(sessionId);
   } catch {
-    return {
-      authorized: false,
-      error: "セッションが見つかりません",
-    };
+    // session remains null
   }
 
-  if (session.user_id !== userId) {
-    return {
-      authorized: false,
-      error: "このセッションへのアクセス権限がありません",
-    };
-  }
-
-  return { authorized: true, userId };
+  return resolveOwnership(authResult, session);
 }
 
 // Re-export from shared

--- a/web/src/features/interview-session/shared/utils/resolve-ownership.test.ts
+++ b/web/src/features/interview-session/shared/utils/resolve-ownership.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { resolveOwnership } from "./resolve-ownership";
+
+describe("resolveOwnership", () => {
+  it("認証失敗の場合はauthorized: falseとエラーメッセージを返す", () => {
+    const authResult = {
+      authenticated: false as const,
+      error: "認証が必要です",
+    };
+
+    const result = resolveOwnership(authResult, null);
+
+    expect(result).toEqual({
+      authorized: false,
+      error: "認証が必要です",
+    });
+  });
+
+  it("セッションがnullの場合はセッションが見つからないエラーを返す", () => {
+    const authResult = {
+      authenticated: true as const,
+      userId: "user-123",
+    };
+
+    const result = resolveOwnership(authResult, null);
+
+    expect(result).toEqual({
+      authorized: false,
+      error: "セッションが見つかりません",
+    });
+  });
+
+  it("所有者が不一致の場合はアクセス権限エラーを返す", () => {
+    const authResult = {
+      authenticated: true as const,
+      userId: "user-123",
+    };
+    const session = { user_id: "user-456" };
+
+    const result = resolveOwnership(authResult, session);
+
+    expect(result).toEqual({
+      authorized: false,
+      error: "このセッションへのアクセス権限がありません",
+    });
+  });
+
+  it("所有者が一致する場合はauthorized: trueとuserIdを返す", () => {
+    const authResult = {
+      authenticated: true as const,
+      userId: "user-123",
+    };
+    const session = { user_id: "user-123" };
+
+    const result = resolveOwnership(authResult, session);
+
+    expect(result).toEqual({
+      authorized: true,
+      userId: "user-123",
+    });
+  });
+});

--- a/web/src/features/interview-session/shared/utils/resolve-ownership.ts
+++ b/web/src/features/interview-session/shared/utils/resolve-ownership.ts
@@ -1,0 +1,44 @@
+export type AuthenticatedUserResult =
+  | {
+      authenticated: true;
+      userId: string;
+    }
+  | {
+      authenticated: false;
+      error: string;
+    };
+
+export type VerifySessionOwnershipResult =
+  | {
+      authorized: true;
+      userId: string;
+    }
+  | {
+      authorized: false;
+      error: string;
+    };
+
+/**
+ * 認証結果とセッション情報から所有権チェック結果を決定する純粋関数
+ */
+export function resolveOwnership(
+  authResult: AuthenticatedUserResult,
+  session: { user_id: string } | null
+): VerifySessionOwnershipResult {
+  if (!authResult.authenticated) {
+    return { authorized: false, error: authResult.error };
+  }
+
+  if (!session) {
+    return { authorized: false, error: "セッションが見つかりません" };
+  }
+
+  if (session.user_id !== authResult.userId) {
+    return {
+      authorized: false,
+      error: "このセッションへのアクセス権限がありません",
+    };
+  }
+
+  return { authorized: true, userId: authResult.userId };
+}

--- a/web/src/lib/prompt/langfuse/langfuse-prompt-provider.ts
+++ b/web/src/lib/prompt/langfuse/langfuse-prompt-provider.ts
@@ -1,6 +1,7 @@
 import type { Langfuse } from "langfuse";
 import type { PromptProvider } from "../interface/prompt-provider";
 import type { CompiledPrompt, PromptVariables } from "../interface/types";
+import { compilePrompt } from "../shared/compile-prompt";
 import { env } from "@/lib/env";
 
 export class LangfusePromptProvider implements PromptProvider {
@@ -15,15 +16,7 @@ export class LangfusePromptProvider implements PromptProvider {
         label: env.langfuse.promptLabel,
       });
 
-      const content = fetchedPrompt.compile(variables || {});
-
-      // Langfuse prompt linkingのためのJSON形式データ
-      const metadata = fetchedPrompt.toJSON();
-
-      return {
-        content,
-        metadata,
-      };
+      return compilePrompt(fetchedPrompt, variables);
     } catch (error) {
       throw new Error(
         `Failed to fetch prompt "${name}" from Langfuse: ${error instanceof Error ? error.message : String(error)}`

--- a/web/src/lib/prompt/shared/compile-prompt.test.ts
+++ b/web/src/lib/prompt/shared/compile-prompt.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { compilePrompt } from "./compile-prompt";
+
+describe("compilePrompt", () => {
+  it("プロンプトをコンパイルして正しい形式で返す", () => {
+    const fetchedPrompt = {
+      compile: (variables: Record<string, string>) =>
+        `Hello, ${variables.name}!`,
+      toJSON: () => '{"name":"greeting","version":1}',
+    };
+
+    const result = compilePrompt(fetchedPrompt, { name: "World" });
+
+    expect(result).toEqual({
+      content: "Hello, World!",
+      metadata: '{"name":"greeting","version":1}',
+    });
+  });
+
+  it("variables付きでcompileが呼ばれる", () => {
+    const variables = { city: "Tokyo", lang: "ja" };
+    let receivedVariables: Record<string, string> = {};
+
+    const fetchedPrompt = {
+      compile: (vars: Record<string, string>) => {
+        receivedVariables = vars;
+        return "compiled";
+      },
+      toJSON: () => "{}",
+    };
+
+    compilePrompt(fetchedPrompt, variables);
+
+    expect(receivedVariables).toEqual({ city: "Tokyo", lang: "ja" });
+  });
+
+  it("variablesなしの場合は空オブジェクトでcompileが呼ばれる", () => {
+    let receivedVariables: Record<string, string> | undefined;
+
+    const fetchedPrompt = {
+      compile: (vars: Record<string, string>) => {
+        receivedVariables = vars;
+        return "compiled";
+      },
+      toJSON: () => "{}",
+    };
+
+    compilePrompt(fetchedPrompt);
+
+    expect(receivedVariables).toEqual({});
+  });
+});

--- a/web/src/lib/prompt/shared/compile-prompt.ts
+++ b/web/src/lib/prompt/shared/compile-prompt.ts
@@ -1,0 +1,16 @@
+import type { CompiledPrompt, PromptVariables } from "../interface/types";
+
+/**
+ * Langfuseから取得したプロンプトをコンパイルする純粋関数
+ */
+export function compilePrompt(
+  fetchedPrompt: {
+    compile: (variables: Record<string, string>) => string;
+    toJSON: () => string;
+  },
+  variables?: PromptVariables
+): CompiledPrompt {
+  const content = fetchedPrompt.compile(variables || {});
+  const metadata = fetchedPrompt.toJSON();
+  return { content, metadata };
+}


### PR DESCRIPTION
## Summary
- `LangfusePromptProvider` の `compilePrompt` ロジックを純粋関数として `shared/` に切り出し、テスト追加
- `verify-session-ownership` の `resolveOwnership` ロジックを純粋関数として `shared/utils` に切り出し、テスト追加
- 元ファイルからは re-export で互換性を維持

## Test plan
- [x] `pnpm --filter web test`（新規テスト含め全テスト通過）
- [x] `pnpm typecheck`
- [x] `pnpm lint`

Part of #371