### PR TITLE
fix: レポートのパンくず「AIインタビュー」をリンクに変更

### DIFF
--- a/web/src/features/interview-report/shared/components/report-breadcrumb.tsx
+++ b/web/src/features/interview-report/shared/components/report-breadcrumb.tsx
@@ -1,6 +1,9 @@
 import { ChevronRight } from "lucide-react";
 import Link from "next/link";
-import { getBillDetailLink } from "@/features/interview-config/shared/utils/interview-links";
+import {
+  getBillDetailLink,
+  getInterviewLPLink,
+} from "@/features/interview-config/shared/utils/interview-links";
 
 interface BreadcrumbItem {
   label: string;
@@ -19,7 +22,7 @@ export function ReportBreadcrumb({
   const baseItems: BreadcrumbItem[] = [
     { label: "TOP", href: "/" },
     { label: "法案詳細", href: getBillDetailLink(billId) },
-    { label: "AIインタビュー" },
+    { label: "AIインタビュー", href: getInterviewLPLink(billId) },
     { label: "レポート" },
   ];
 


### PR DESCRIPTION
## Summary
- レポートページのパンくずナビゲーションで「AIインタビュー」がプレーンテキストだったのをリンクに変更
- `/bills/${billId}/interview` （AIインタビューLPページ）へ遷移できるようにした

## Test plan
- [x] `pnpm lint` パス
- [x] `pnpm typecheck` パス
- [x] `pnpm test` 全テストパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)