### PR TITLE
test: カバレッジ除外設定を追加

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,11 +2,23 @@ coverage:
   status:
     project:
       default:
-        target: auto
+        target: 80%
         threshold: 1%
     patch:
       default:
         target: 80%
+
+ignore:
+  - "web/src/components/ui/**"
+  - "web/src/app/**/page.tsx"
+  - "web/src/app/**/layout.tsx"
+  - "web/src/app/**/loading.tsx"
+  - "web/src/app/**/not-found.tsx"
+  - "web/src/app/**/error.tsx"
+  - "web/**/types.ts"
+  - "web/**/types/index.ts"
+  - "web/src/lib/telemetry/**"
+  - "web/src/config/**"
 
 comment:
   layout: "reach,diff,flags,files"

--- a/web/vitest.config.mts
+++ b/web/vitest.config.mts
@@ -9,6 +9,18 @@ export default defineConfig({
       provider: "v8",
       reporter: ["text", "json", "json-summary"],
       reportsDirectory: "./coverage",
+      exclude: [
+        "src/components/ui/**",
+        "src/app/**/page.tsx",
+        "src/app/**/layout.tsx",
+        "src/app/**/loading.tsx",
+        "src/app/**/not-found.tsx",
+        "src/app/**/error.tsx",
+        "**/types.ts",
+        "**/types/index.ts",
+        "src/lib/telemetry/**",
+        "src/config/**",
+      ],
     },
   },
   resolve: {

--- a/web/vitest.integration.config.mts
+++ b/web/vitest.integration.config.mts
@@ -18,6 +18,18 @@ export default defineConfig({
       provider: "v8",
       reporter: ["text", "json", "json-summary"],
       reportsDirectory: "./coverage-integration",
+      exclude: [
+        "src/components/ui/**",
+        "src/app/**/page.tsx",
+        "src/app/**/layout.tsx",
+        "src/app/**/loading.tsx",
+        "src/app/**/not-found.tsx",
+        "src/app/**/error.tsx",
+        "**/types.ts",
+        "**/types/index.ts",
+        "src/lib/telemetry/**",
+        "src/config/**",
+      ],
     },
   },
   resolve: {


### PR DESCRIPTION
## 概要

カバレッジ計測から除外すべきファイルを設定し、80%達成の見通しを改善する。

## 変更内容

- `web/vitest.config.mts`: `coverage.exclude` に除外パスを追加
- `web/vitest.integration.config.mts`: `coverage.exclude` に除外パスを追加
- `codecov.yml`: プロジェクトカバレッジ目標を `auto` から `80%` に更新、`ignore` パスを追加

## 除外対象

| パターン | 理由 |
|---------|------|
| `src/components/ui/**` | shadcn/ui の自動生成ファイル |
| `src/app/**/page.tsx` | Next.js ルーティングの薄いラッパー |
| `src/app/**/layout.tsx` | レイアウト設定ファイル |
| `src/app/**/loading.tsx` | ローディング UI |
| `src/app/**/not-found.tsx` | 404 ページ |
| `src/app/**/error.tsx` | エラー境界 |
| `**/types.ts`, `**/types/index.ts` | 型定義のみ |
| `src/lib/telemetry/**` | テレメトリ設定 |
| `src/config/**` | 設定ファイル |

## テスト実行記録

```
pnpm lint         ✅ passed (warning 1件は既存)
pnpm typecheck    ✅ passed
pnpm --filter web test  ✅ 41 files, 425 tests passed
```

Closes #370

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated code coverage configuration to enforce an 80% minimum threshold.
  * Expanded coverage exclusions to refine test reporting and focus on core business logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->