### PR TITLE
test: MockLanguageModelV3ラッパーとgenerateInitialQuestion統合テストを追加

### DIFF
--- a/web/src/features/interview-session/server/services/generate-initial-question.integration.test.ts
+++ b/web/src/features/interview-session/server/services/generate-initial-question.integration.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  adminClient,
+  createTestUser,
+  cleanupTestUser,
+  createTestInterviewData,
+  cleanupTestBill,
+  type TestUser,
+} from "@test-utils/utils";
+import { createGenerateMock } from "@/test-utils/mock-language-model";
+import { generateInitialQuestion } from "./generate-initial-question";
+
+// interviewChatTextSchema に準拠したモックレスポンス
+const validChatResponse = JSON.stringify({
+  text: "こんにちは！テストインタビューを始めましょう。最初の質問です。",
+  quick_replies: ["はい", "いいえ"],
+  question_id: null,
+  topic_title: null,
+  next_stage: "chat",
+});
+
+describe("generateInitialQuestion 統合テスト", () => {
+  let testUser: TestUser;
+  let sessionId: string;
+  let billId: string;
+  let interviewConfigId: string;
+
+  beforeEach(async () => {
+    testUser = await createTestUser();
+    const data = await createTestInterviewData(testUser.id);
+    sessionId = data.session.id;
+    billId = data.bill.id;
+    interviewConfigId = data.config.id;
+  });
+
+  afterEach(async () => {
+    await cleanupTestBill(billId);
+    await cleanupTestUser(testUser.id);
+  });
+
+  it("LLMが生成したテキストがassistantメッセージとしてDBに保存される", async () => {
+    const mockModel = createGenerateMock(validChatResponse);
+
+    const result = await generateInitialQuestion({
+      sessionId,
+      billId,
+      interviewConfigId,
+      deps: { model: mockModel },
+    });
+
+    // 戻り値を検証
+    expect(result).not.toBeNull();
+    expect(result?.role).toBe("assistant");
+    expect(result?.content).toBe(validChatResponse);
+
+    // DB 状態を検証: assistantメッセージが保存されていること
+    const { data: messages } = await adminClient
+      .from("interview_messages")
+      .select("*")
+      .eq("interview_session_id", sessionId)
+      .order("created_at", { ascending: true });
+
+    expect(messages).toHaveLength(1);
+    expect(messages?.[0].role).toBe("assistant");
+    expect(messages?.[0].content).toBe(validChatResponse);
+    expect(messages?.[0].interview_session_id).toBe(sessionId);
+  });
+
+  it("LLMが空テキストを返した場合はnullを返しDBに保存されない", async () => {
+    const mockModel = createGenerateMock("  "); // 空白のみ
+
+    const result = await generateInitialQuestion({
+      sessionId,
+      billId,
+      interviewConfigId,
+      deps: { model: mockModel },
+    });
+
+    // null が返ること
+    expect(result).toBeNull();
+
+    // DB 状態を検証: メッセージが保存されていないこと
+    const { data: messages } = await adminClient
+      .from("interview_messages")
+      .select("*")
+      .eq("interview_session_id", sessionId);
+
+    expect(messages).toHaveLength(0);
+  });
+
+  it("interview_configが存在しないbillIdの場合はnullを返す", async () => {
+    // 存在しないbillId
+    const nonExistentBillId = "00000000-0000-0000-0000-000000000000";
+    const mockModel = createGenerateMock(validChatResponse);
+
+    const result = await generateInitialQuestion({
+      sessionId,
+      billId: nonExistentBillId,
+      interviewConfigId,
+      deps: { model: mockModel },
+    });
+
+    // interview_config が見つからないためnullが返ること
+    expect(result).toBeNull();
+  });
+});

--- a/web/src/test-utils/mock-language-model.ts
+++ b/web/src/test-utils/mock-language-model.ts
@@ -1,0 +1,63 @@
+import { MockLanguageModelV3, convertArrayToReadableStream } from "ai/test";
+
+const MOCK_FINISH_REASON = {
+  unified: "stop" as const,
+  raw: undefined as string | undefined,
+};
+
+const MOCK_USAGE = {
+  inputTokens: {
+    total: 0 as number | undefined,
+    noCache: 0 as number | undefined,
+    cacheRead: 0 as number | undefined,
+    cacheWrite: 0 as number | undefined,
+  },
+  outputTokens: {
+    total: 0 as number | undefined,
+    text: 0 as number | undefined,
+    reasoning: 0 as number | undefined,
+  },
+};
+
+/**
+ * generateText() 用の MockLanguageModelV3 を作成する。
+ * @param text - モデルが返すテキスト（JSON文字列など）
+ */
+export function createGenerateMock(text: string): MockLanguageModelV3 {
+  return new MockLanguageModelV3({
+    doGenerate: {
+      content: [{ type: "text" as const, text }],
+      finishReason: MOCK_FINISH_REASON,
+      usage: MOCK_USAGE,
+      warnings: [],
+    },
+  });
+}
+
+/**
+ * streamText() 用の MockLanguageModelV3 を作成する。
+ * @param textChunks - ストリームで返すテキストチャンクの配列
+ */
+export function createStreamMock(textChunks: string[]): MockLanguageModelV3 {
+  const streamParts = [
+    { type: "stream-start" as const, warnings: [] as [] },
+    { type: "text-start" as const, id: "text-1" },
+    ...textChunks.map((delta) => ({
+      type: "text-delta" as const,
+      id: "text-1",
+      delta,
+    })),
+    { type: "text-end" as const, id: "text-1" },
+    {
+      type: "finish" as const,
+      usage: MOCK_USAGE,
+      finishReason: MOCK_FINISH_REASON,
+    },
+  ];
+
+  return new MockLanguageModelV3({
+    doStream: {
+      stream: convertArrayToReadableStream(streamParts),
+    },
+  });
+}

--- a/web/src/test-utils/mock-prompt-provider.ts
+++ b/web/src/test-utils/mock-prompt-provider.ts
@@ -1,0 +1,32 @@
+import type { PromptProvider } from "@/lib/prompt";
+import type { CompiledPrompt, PromptVariables } from "@/lib/prompt";
+
+/**
+ * テスト用の PromptProvider モック実装。
+ * Langfuse への通信を行わず、固定のプロンプト文字列を返す。
+ */
+export class MockPromptProvider implements PromptProvider {
+  private readonly content: string;
+
+  constructor(content = "テスト用システムプロンプト") {
+    this.content = content;
+  }
+
+  async getPrompt(
+    _name: string,
+    _variables?: PromptVariables
+  ): Promise<CompiledPrompt> {
+    return {
+      content: this.content,
+      metadata: "{}",
+    };
+  }
+}
+
+/**
+ * MockPromptProvider のファクトリ関数。
+ * @param content - getPrompt が返すプロンプト文字列（省略時はデフォルト値）
+ */
+export function createMockPromptProvider(content?: string): MockPromptProvider {
+  return new MockPromptProvider(content);
+}

--- a/web/vitest.integration.setup.ts
+++ b/web/vitest.integration.setup.ts
@@ -4,3 +4,27 @@ import { vi } from "vitest";
 // ガードを無効化する。これはビルド時チェックのバイパスであり、
 // アプリケーションロジックのモックではない。
 vi.mock("server-only", () => ({}));
+
+// 統合テストはリクエストスコープ外で実行するため、Next.js の
+// cookies()/headers() を空のスタブに置き換える。
+// アプリケーションロジックのモックではなく、フレームワーク境界のバイパスである。
+vi.mock("next/headers", () => ({
+  cookies: () =>
+    Promise.resolve({
+      get: () => undefined,
+      getAll: () => [],
+      has: () => false,
+    }),
+  headers: () => Promise.resolve(new Headers()),
+}));
+
+// 統合テストは Next.js のインクリメンタルキャッシュ機構を持たないため、
+// unstable_cache をキャッシュなしで直接実行するスタブに置き換える。
+vi.mock("next/cache", () => ({
+  unstable_cache:
+    <T extends (...args: Parameters<T>) => ReturnType<T>>(fn: T) =>
+    (...args: Parameters<T>) =>
+      fn(...args),
+  revalidateTag: () => undefined,
+  revalidatePath: () => undefined,
+}));


### PR DESCRIPTION
## Summary

- `web/src/test-utils/mock-language-model.ts` を新規作成: `createGenerateMock` / `createStreamMock` ファクトリ関数を提供し、AI SDK の `MockLanguageModelV3`（`ai/test`）をラップ
- `web/src/test-utils/mock-prompt-provider.ts` を新規作成: `MockPromptProvider` クラスと `createMockPromptProvider` ファクトリ関数を提供（`#372-2` / `#372-3` でも使用予定）
- `generate-initial-question.integration.test.ts` を追加: モック LLM を DI して `generateInitialQuestion` を呼び出し、assistant メッセージが DB に保存されることを検証（3 ケース）
- `vitest.integration.setup.ts` を更新: `next/headers`（cookies）と `next/cache`（unstable_cache）のフレームワーク境界モックを追加（テストが Node.js 環境で動くための infrastructure バイパス）

## Test plan

- [x] `pnpm --filter web test:integration` → 15 tests all passed（既存 12 件 + 新規 3 件）
- [x] `pnpm lint` → No fixes applied（既存 warning のみ）
- [x] `pnpm typecheck` → Done

Resolves #372 (partial: #372-1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration tests for question generation functionality with validation of database persistence and error handling
  * Introduced test utilities for mocking language model behavior, supporting both single-shot and streaming scenarios
  * Added test utilities for prompt provider mocking to enable flexible test scenarios
  * Enhanced integration test setup with mock implementations for framework dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->