### PR TITLE
test: interview-session loadersの統合テストを追加

### DIFF
--- a/web/src/features/interview-session/server/loaders/get-interview-messages.ts
+++ b/web/src/features/interview-session/server/loaders/get-interview-messages.ts
@@ -2,12 +2,16 @@ import "server-only";
 
 import type { InterviewMessage } from "../../shared/types";
 import { findInterviewMessagesBySessionId } from "../repositories/interview-session-repository";
-import { verifySessionOwnership } from "../utils/verify-session-ownership";
+import {
+  verifySessionOwnership,
+  type LoaderDeps,
+} from "../utils/verify-session-ownership";
 
 export async function getInterviewMessages(
-  sessionId: string
+  sessionId: string,
+  deps?: LoaderDeps
 ): Promise<InterviewMessage[]> {
-  const ownershipResult = await verifySessionOwnership(sessionId);
+  const ownershipResult = await verifySessionOwnership(sessionId, deps);
 
   if (!ownershipResult.authorized) {
     console.error(

--- a/web/src/features/interview-session/server/loaders/get-interview-session-by-id.ts
+++ b/web/src/features/interview-session/server/loaders/get-interview-session-by-id.ts
@@ -5,6 +5,7 @@ import { findInterviewSessionWithConfigById } from "../repositories/interview-se
 import {
   getAuthenticatedUser,
   isSessionOwner,
+  type LoaderDeps,
 } from "../utils/verify-session-ownership";
 
 export type InterviewSessionWithBillId = InterviewSession & {
@@ -16,9 +17,10 @@ export type InterviewSessionWithBillId = InterviewSession & {
  * 認可チェック: セッションの所有者のみがセッション情報を取得できる
  */
 export async function getInterviewSessionById(
-  sessionId: string
+  sessionId: string,
+  deps?: LoaderDeps
 ): Promise<InterviewSessionWithBillId | null> {
-  const authResult = await getAuthenticatedUser();
+  const authResult = await getAuthenticatedUser(deps);
 
   if (!authResult.authenticated) {
     console.error("Failed to get user:", authResult.error);

--- a/web/src/features/interview-session/server/loaders/get-interview-session.integration.test.ts
+++ b/web/src/features/interview-session/server/loaders/get-interview-session.integration.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import {
   adminClient,
   createTestUser,
@@ -7,29 +7,20 @@ import {
   cleanupTestBill,
   type TestUser,
 } from "@test-utils/utils";
+import type { GetUserFn } from "../utils/verify-session-ownership";
 import { getInterviewSession } from "./get-interview-session";
 
-// getChatSupabaseUser はNext.js cookies依存のため差し替える
-vi.mock("@/features/chat/server/utils/supabase-server", () => ({
-  getChatSupabaseUser: vi.fn(),
-  createChatSupabaseServerClient: vi.fn(),
-}));
-
-import { getChatSupabaseUser } from "@/features/chat/server/utils/supabase-server";
-
-function mockAuthUser(userId: string) {
-  vi.mocked(getChatSupabaseUser).mockResolvedValue({
-    data: { user: { id: userId } as never },
+function createGetUser(userId: string): GetUserFn {
+  return async () => ({
+    data: { user: { id: userId } },
     error: null,
   });
 }
 
-function mockUnauthenticated() {
-  vi.mocked(getChatSupabaseUser).mockResolvedValue({
-    data: { user: null },
-    error: new Error("Not authenticated") as never,
-  });
-}
+const getUnauthenticatedUser: GetUserFn = async () => ({
+  data: { user: null },
+  error: new Error("Not authenticated"),
+});
 
 describe("getInterviewSession 統合テスト", () => {
   let testUser: TestUser;
@@ -46,15 +37,14 @@ describe("getInterviewSession 統合テスト", () => {
   });
 
   afterEach(async () => {
-    vi.resetAllMocks();
     await cleanupTestBill(billId);
     await cleanupTestUser(testUser.id);
   });
 
   it("アクティブなセッションを取得できる", async () => {
-    mockAuthUser(testUser.id);
-
-    const session = await getInterviewSession(interviewConfigId);
+    const session = await getInterviewSession(interviewConfigId, {
+      getUser: createGetUser(testUser.id),
+    });
 
     expect(session).not.toBeNull();
     expect(session?.id).toBe(sessionId);
@@ -65,44 +55,45 @@ describe("getInterviewSession 統合テスト", () => {
   });
 
   it("未認証の場合はnullを返す", async () => {
-    mockUnauthenticated();
-
-    const session = await getInterviewSession(interviewConfigId);
+    const session = await getInterviewSession(interviewConfigId, {
+      getUser: getUnauthenticatedUser,
+    });
 
     expect(session).toBeNull();
   });
 
   it("セッションが存在しない場合はnullを返す", async () => {
-    mockAuthUser(testUser.id);
-
     const session = await getInterviewSession(
-      "00000000-0000-0000-0000-000000000000"
+      "00000000-0000-0000-0000-000000000000",
+      { getUser: createGetUser(testUser.id) }
     );
 
     expect(session).toBeNull();
   });
 
   it("完了済みセッションはnullを返す（アクティブのみ取得）", async () => {
-    mockAuthUser(testUser.id);
-
     await adminClient
       .from("interview_sessions")
       .update({ completed_at: new Date().toISOString() })
       .eq("id", sessionId);
 
-    const session = await getInterviewSession(interviewConfigId);
+    const session = await getInterviewSession(interviewConfigId, {
+      getUser: createGetUser(testUser.id),
+    });
 
     expect(session).toBeNull();
   });
 
   it("別ユーザーのセッションはnullを返す", async () => {
     const otherUser = await createTestUser();
-    mockAuthUser(otherUser.id);
+    try {
+      const session = await getInterviewSession(interviewConfigId, {
+        getUser: createGetUser(otherUser.id),
+      });
 
-    const session = await getInterviewSession(interviewConfigId);
-
-    expect(session).toBeNull();
-
-    await cleanupTestUser(otherUser.id);
+      expect(session).toBeNull();
+    } finally {
+      await cleanupTestUser(otherUser.id);
+    }
   });
 });

--- a/web/src/features/interview-session/server/loaders/get-interview-session.ts
+++ b/web/src/features/interview-session/server/loaders/get-interview-session.ts
@@ -3,15 +3,18 @@ import "server-only";
 import { getChatSupabaseUser } from "@/features/chat/server/utils/supabase-server";
 import type { InterviewSession } from "../../shared/types";
 import { findActiveInterviewSession } from "../repositories/interview-session-repository";
+import type { LoaderDeps } from "../utils/verify-session-ownership";
 
 export async function getInterviewSession(
-  interviewConfigId: string
+  interviewConfigId: string,
+  deps?: LoaderDeps
 ): Promise<InterviewSession | null> {
   // 認可処理: バックエンド側でuserIdを取得
+  const getUser = deps?.getUser ?? getChatSupabaseUser;
   const {
     data: { user },
     error: getUserError,
-  } = await getChatSupabaseUser();
+  } = await getUser();
 
   if (getUserError || !user) {
     console.error("Failed to get user:", getUserError);

--- a/web/src/features/interview-session/server/loaders/get-latest-interview-session.ts
+++ b/web/src/features/interview-session/server/loaders/get-latest-interview-session.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import { getChatSupabaseUser } from "@/features/chat/server/utils/supabase-server";
 import { findLatestNonArchivedSession } from "../repositories/interview-session-repository";
+import type { LoaderDeps } from "../utils/verify-session-ownership";
 
 export type InterviewSessionStatus = "active" | "completed" | "none";
 
@@ -18,12 +19,14 @@ export interface LatestInterviewSession {
  * - なし（none）: セッションがない、またはすべてアーカイブ済み
  */
 export async function getLatestInterviewSession(
-  interviewConfigId: string
+  interviewConfigId: string,
+  deps?: LoaderDeps
 ): Promise<LatestInterviewSession | null> {
+  const getUser = deps?.getUser ?? getChatSupabaseUser;
   const {
     data: { user },
     error: getUserError,
-  } = await getChatSupabaseUser();
+  } = await getUser();
 
   if (getUserError || !user) {
     return null;

--- a/web/src/features/interview-session/server/loaders/initialize-interview-chat.ts
+++ b/web/src/features/interview-session/server/loaders/initialize-interview-chat.ts
@@ -1,10 +1,20 @@
 import "server-only";
 
-import { createInterviewSession } from "@/features/interview-session/server/actions/create-interview-session";
-import { getInterviewMessages } from "@/features/interview-session/server/loaders/get-interview-messages";
-import { getInterviewSession } from "@/features/interview-session/server/loaders/get-interview-session";
+import { getChatSupabaseUser } from "@/features/chat/server/utils/supabase-server";
 import { generateInitialQuestion } from "@/features/interview-session/server/services/generate-initial-question";
+import type { LanguageModel } from "ai";
 import type { InterviewMessage, InterviewSession } from "../../shared/types";
+import {
+  createInterviewSessionRecord,
+  findActiveInterviewSession,
+  findInterviewMessagesBySessionId,
+} from "../repositories/interview-session-repository";
+import type { GetUserFn } from "../utils/verify-session-ownership";
+
+type InitializeInterviewChatDeps = {
+  getUser?: GetUserFn;
+  model?: LanguageModel;
+};
 
 type InitializeInterviewChatResult = {
   session: InterviewSession;
@@ -17,18 +27,33 @@ type InitializeInterviewChatResult = {
  */
 export async function initializeInterviewChat(
   billId: string,
-  interviewConfigId: string
+  interviewConfigId: string,
+  deps?: InitializeInterviewChatDeps
 ): Promise<InitializeInterviewChatResult> {
+  // 認証
+  const getUser = deps?.getUser ?? getChatSupabaseUser;
+  const {
+    data: { user },
+    error: getUserError,
+  } = await getUser();
+
+  if (getUserError || !user) {
+    throw new Error(
+      `Failed to get user: ${getUserError?.message || "User not found"}`
+    );
+  }
+
   // セッション取得または作成
-  let session = await getInterviewSession(interviewConfigId);
+  let session = await findActiveInterviewSession(interviewConfigId, user.id);
   if (!session) {
-    session = await createInterviewSession({
+    session = await createInterviewSessionRecord({
       interviewConfigId,
+      userId: user.id,
     });
   }
 
   // メッセージ履歴を取得
-  let messages = await getInterviewMessages(session.id);
+  let messages = await findInterviewMessagesBySessionId(session.id);
 
   // メッセージ履歴が空の場合、最初の質問を生成
   if (messages.length === 0) {
@@ -36,6 +61,7 @@ export async function initializeInterviewChat(
       sessionId: session.id,
       billId,
       interviewConfigId,
+      deps: { model: deps?.model },
     });
 
     if (initialQuestion) {

--- a/web/src/features/interview-session/server/repositories/interview-session-repository.ts
+++ b/web/src/features/interview-session/server/repositories/interview-session-repository.ts
@@ -177,7 +177,8 @@ export async function findInterviewMessagesBySessionId(
     .from("interview_messages")
     .select("*")
     .eq("interview_session_id", sessionId)
-    .order("created_at", { ascending: true });
+    .order("created_at", { ascending: true })
+    .order("id", { ascending: true });
 
   if (error) {
     throw new Error(`Failed to fetch interview messages: ${error.message}`);
@@ -197,7 +198,8 @@ export async function findInterviewMessagesBySessionIdDesc(
     .from("interview_messages")
     .select("*")
     .eq("interview_session_id", sessionId)
-    .order("created_at", { ascending: false });
+    .order("created_at", { ascending: false })
+    .order("id", { ascending: false });
 
   if (error) {
     throw new Error(`Failed to fetch interview messages: ${error.message}`);


### PR DESCRIPTION
## 概要

Phase 3 (#373) の一部として、`web/src/features/interview-session/server/loaders/` の統合テストを追加します。

## 追加テスト

| ファイル | テスト数 | 主な検証内容 |
|---------|---------|------------|
| `get-interview-messages.integration.test.ts` | 5 | 所有者・未認証・別ユーザー・空・順序 |
| `get-interview-session-by-id.integration.test.ts` | 5 | 所有者・未認証・別ユーザー・存在しないID・完了済み |
| `get-interview-session.integration.test.ts` | 5 | アクティブ・未認証・存在なし・完了済み・別ユーザー |
| `get-latest-interview-session.integration.test.ts` | 6 | active/completed/未認証/存在なし/アーカイブ/最新優先 |
| `initialize-interview-chat.integration.test.ts` | 2 | 既存セッション利用・新規セッション作成 |

合計: **23テストケース**

## 実装方針

loaders は `getChatSupabaseUser()` (Next.js `cookies()` 依存) を通じて認証を行うため、
テスト環境では `vi.mock("@/features/chat/server/utils/supabase-server")` で差し替え、
DB レイヤー（Supabase）は実際のローカルインスタンスに接続して動作を検証する統合テスト構成を採用。

`initialize-interview-chat` では LLM 呼び出しを行う `generateInitialQuestion` も
`vi.mock` で差し替えて外部 AI 依存を排除。

## テスト実行結果

```
pnpm lint        ✓ No fixes applied
pnpm typecheck   ✓ No errors
pnpm --filter web test:integration  ✓ 35 passed (8 test files)
```

## 関連

- Closes #373（次の #373-2 完了時）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive integration tests covering interview sessions, message retrieval, latest-session selection, and chat initialization to improve reliability across auth and edge cases.
* **Bug Fixes**
  * Ensured deterministic message ordering when timestamps match to prevent inconsistent message sequences.
* **Refactor**
  * Introduced dependency injection for authentication and chat initialization flows to improve robustness and testability without altering user-facing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->