### PR TITLE
test: bulk-mode/loop-mode純粋関数切り出し・テスト追加

### DIFF
--- a/web/src/features/interview-session/server/utils/interview-logic/bulk-mode.ts
+++ b/web/src/features/interview-session/server/utils/interview-logic/bulk-mode.ts
@@ -1,10 +1,9 @@
 import "server-only";
 
 import {
-  buildBulkModeStageGuidance,
-  buildTimeManagementGuidance,
-} from "@/features/interview-session/shared/utils/stage-transition-guidance";
-import { collectAskedQuestionIds } from "../interview-logic";
+  buildBulkModeSystemPrompt,
+  calculateBulkModeNextQuestionId,
+} from "@/features/interview-session/shared/utils/interview-logic/bulk-mode";
 import type {
   InterviewModeLogic,
   InterviewPromptParams,
@@ -23,171 +22,15 @@ import type {
  * - 事前定義質問をすべて消化することを最優先
  * - 深掘りは事前定義質問完了後に一括で行う
  * - follow_up_guide は質問リストに含めない
+ *
+ * 実ロジックは shared/utils/interview-logic/bulk-mode.ts に純粋関数として切り出し済み
  */
 export const bulkModeLogic: InterviewModeLogic = {
   buildSystemPrompt(params: InterviewPromptParams): string {
-    const {
-      bill,
-      interviewConfig,
-      questions,
-      nextQuestionId,
-      currentStage,
-      askedQuestionIds,
-      remainingMinutes,
-    } = params;
-
-    const billName = bill?.name || "";
-    const billTitle = bill?.bill_content?.title || "";
-    const billSummary = bill?.bill_content?.summary || "";
-    const billContent = bill?.bill_content?.content || "";
-    const themes = interviewConfig?.themes || [];
-    const knowledgeSource = interviewConfig?.knowledge_source || "";
-
-    // Bulk Mode: follow_up_guide を含めない
-    const questionsText = questions
-      .map(
-        (q, index) =>
-          `${index + 1}. [ID: ${q.id}] ${q.question}${q.quick_replies ? `\n   クイックリプライ: ${q.quick_replies.join(", ")}` : ""}`
-      )
-      .join("\n");
-
-    // 質問進捗情報を構築
-    const stageTransitionGuidance = buildBulkModeStageGuidance({
-      currentStage,
-      questions,
-      askedQuestionIds,
-    });
-
-    // タイムマネジメントガイダンスを構築
-    const remainingQuestionsCount =
-      questions.length -
-      questions.filter((q) => askedQuestionIds.has(q.id)).length;
-    const timeManagementGuidance = buildTimeManagementGuidance({
-      remainingMinutes,
-      remainingQuestions: remainingQuestionsCount,
-    });
-
-    // nextQuestionId がある場合の特別なプロンプト
-    if (nextQuestionId) {
-      const nextQuestion = questions.find((q) => q.id === nextQuestionId);
-      if (nextQuestion) {
-        return `あなたは熟練のインタビュアーです。現在は「一括回答優先モード」で進行しています。
-
-## 法案情報
-- 法案名: ${billName}
-- 法案要約: ${billSummary}
-
-## 重要指示
-あなたはこれから必ず事前定義質問 **[ID: ${nextQuestion.id}] ${nextQuestion.question}** を行ってください。
-深掘りや他の話題への逸脱は一切禁止されています。
-
-1つのメッセージにつき、この1つの質問のみをしてください。
-
-## クイックリプライについて
-quick_repliesフィールドについては以下を使用してください。
-${nextQuestion.quick_replies}
-
-${stageTransitionGuidance}
-`;
-      }
-    }
-
-    // 通常のプロンプト
-    const nextQuestion = nextQuestionId
-      ? questions.find((q) => q.id === nextQuestionId)
-      : null;
-
-    const modeInstructions = `
-## インタビューモード: **一括回答優先モード** (Bulk Mode)
-現在は、まず全体的な意見を効率的に伺うフェーズです。
-
-1. **基本方針**: 事前定義された各質問項目をすべて消化することを最優先してください。
-${nextQuestion ? `2. **重要指示**: あなたはこれから必ず事前定義質問 **[ID: ${nextQuestion.id}] ${nextQuestion.question}** を行ってください。深掘りや他の話題への逸脱は一切禁止されています。` : "2. **重要指示**: 事前定義された質問のうち、まだ聞いていないものを優先して選んでください。"}
-3. **リアクション**: ユーザーの回答に対しては「承知いたしました」「ありがとうございます」といった簡潔な受容に留め、すぐに次の事前定義質問へ移行してください。
-4. **深掘りの抑制**: ユーザーの回答に興味深い点があっても、このフェーズでは深追いしないでください。事実確認や、極端に抽象的な場合の短い補足要求のみに留めます。
-5. **移行の合図**: すべての事前定義質問が完了した後に初めて、「これまでの回答を詳しく拝見しました。ここからは、特に気になった点について深くお伺いしていきます」と宣言し、一括して深掘りを行ってください。
-
-## 深掘りフェーズのテクニック（事前定義質問完了後に活用）
-一括して深掘りを行う際は、以下のテクニックを活用してください：
-
-- **抽象⇔具体の往復**: 抽象的な回答には「具体的にはどんな場面で？」、具体的すぎる回答には「それは要するにどういうことですか？」と往復する
-- **「なぜ」を避けた深掘り**: 「なぜですか？」は詰問調になるため、「どのような背景で」「どんな経験からそう感じられましたか」「何がきっかけで」と言い換える
-- **感情の言語化**: 回答者の感情を具体的に受け止める（例:「それは不安に感じられるのですね」「期待されているのですね」）
-- **仮定質問**: 「もしこの法案が成立したら、あなたの○○はどう変わると思いますか？」と具体的なシナリオを想像させる
-- **逆側の視点**: 賛成の方には「一方で懸念される点はありますか？」、反対の方には「期待できる点があるとすれば？」と多角的な視点を引き出す
-- **矛盾の穏やかな確認**: 前の発言と異なる点があれば「先ほど○○とおっしゃっていましたが、今のお話との関係を教えていただけますか？」と丁寧に確認する`;
-
-    return `あなたは半構造化デプスインタビューを実施する熟練のインタビュアーです。
-  あなたの目標は、インタビュイーから深い洞察を引き出すことです。
-
-## あなたの責任
-- インタビュイーが自由に話せるようにしながら会話をリードする
-- 興味深い点を深く掘り下げるためにフォローアップの質問をする
-- 会話から専門知識のレベルを推測し、それに応じてインタビュー内容を調整する
-
-## 専門知識レベルの検出
-インタビュイーの専門知識レベルを継続的に評価します。
-
-- 初心者：簡単な言葉を使い、概念を説明し、サポートする
-- 中級：専門用語を少し使用し、中程度の深さ
-- 専門家: ドメイン固有の用語を使用し、深い技術的議論に参加する
-
-## 法案情報
-- 法案名: ${billName}
-- 法案タイトル: ${billTitle}
-- 法案要約: ${billSummary}
-- 法案詳細: ${billContent}
-
-## インタビューテーマ
-${themes.length > 0 ? themes.map((t: string) => `- ${t}`).join("\n") : "（テーマ未設定）"}
-
-## 知識ソース
-${knowledgeSource || "（知識ソース未設定）"}
-
-## 事前定義質問
-以下の質問を会話の流れに応じて適切なタイミングで使用してください。質問は順番通りに使う必要はなく、会話の流れに応じて選んでください。
-
-${questionsText || "（賛成か、反対か）"}
-
-## インタビューの進め方
-${modeInstructions}
-
-1. **事前定義質問の活用**: 会話全体の中で、リストにある質問を網羅することを目指してください。
-
-2. **深掘りのタイミング**: 上記のモード別指示を厳守してください。
-  - 一括回答優先モード：事前定義質問をすべて終えるまで深掘りを控える
-3. **インタビューの終了判定**:
-  - 全ての事前定義質問を終え、かつ十分な深掘りが完了した時
-  - ユーザーから終了の意思表示があった時
-4. **完了時の案内**: 最後に「これまでの内容をまとめ、レポートを作成します」と伝え、要約フェーズへ進むことを案内してください。
-
-## クイックリプライについて
-- 事前定義質問そのものをこれから行う場合は、その質問のIDをレスポンスの \`question_id\` フィールドに含めてください
-- 事前定義質問にクイックリプライが設定されている場合、その質問をする際はレスポンスの \`quick_replies\` フィールドにその選択肢を含めてください
-- クイックリプライは事前定義質問に設定されているもののみを使用してください
-- 深掘り質問など、事前定義質問以外の質問をする場合は \`question_id\` を含めず、\`quick_replies\` も含めないでください
-
-${stageTransitionGuidance}
-
-${timeManagementGuidance}
-
-## 注意事項
-- 丁寧で親しみやすい口調で話してください
-- ユーザーの回答を尊重し、押し付けがましくならないようにしてください
-- **1つのメッセージでは1つの論点だけを聞いてください。** 括弧書きや補足で別の論点を追加しないでください。
-  - 悪い例: 「どの程度関係がありますか？（どのように関係しているかも教えてください）」→ 程度と具体的内容の2つを同時に聞いている
-  - 良い例: 「どの程度関係がありますか？」→ まず程度だけを聞き、回答後に具体的内容を深掘りする
-- **「なぜ」の多用を避ける**: 「なぜそう思うのですか？」ではなく「どのような背景で」「何がきっかけで」など柔らかい表現を使う
-- 法案に関する質問のみに集中してください
-`;
+    return buildBulkModeSystemPrompt(params);
   },
 
   calculateNextQuestionId(params: NextQuestionParams): string | undefined {
-    const { messages, questions } = params;
-
-    // Bulk Mode: 次に聞くべき質問を強制的に指定
-    const askedQuestionIds = collectAskedQuestionIds(messages);
-    const nextUnasked = questions.find((q) => !askedQuestionIds.has(q.id));
-    return nextUnasked?.id;
+    return calculateBulkModeNextQuestionId(params);
   },
 };

--- a/web/src/features/interview-session/server/utils/interview-logic/loop-mode.ts
+++ b/web/src/features/interview-session/server/utils/interview-logic/loop-mode.ts
@@ -1,9 +1,9 @@
 import "server-only";
 
 import {
-  buildLoopModeStageGuidance,
-  buildTimeManagementGuidance,
-} from "@/features/interview-session/shared/utils/stage-transition-guidance";
+  buildLoopModeSystemPrompt,
+  calculateLoopModeNextQuestionId,
+} from "@/features/interview-session/shared/utils/interview-logic/loop-mode";
 import type {
   InterviewModeLogic,
   InterviewPromptParams,
@@ -22,141 +22,15 @@ import type {
  * - 1つのテーマについて多角的に掘り下げる
  * - ユーザーの回答に共感し、追加の質問を重ねる
  * - follow_up_guide を質問リストに含める
+ *
+ * 実ロジックは shared/utils/interview-logic/loop-mode.ts に純粋関数として切り出し済み
  */
 export const loopModeLogic: InterviewModeLogic = {
   buildSystemPrompt(params: InterviewPromptParams): string {
-    const {
-      bill,
-      interviewConfig,
-      questions,
-      currentStage,
-      askedQuestionIds,
-      remainingMinutes,
-    } = params;
-
-    const billName = bill?.name || "";
-    const billTitle = bill?.bill_content?.title || "";
-    const billSummary = bill?.bill_content?.summary || "";
-    const billContent = bill?.bill_content?.content || "";
-    const themes = interviewConfig?.themes || [];
-    const knowledgeSource = interviewConfig?.knowledge_source || "";
-
-    // Loop Mode: follow_up_guide を含める
-    const questionsText = questions
-      .map(
-        (q, index) =>
-          `${index + 1}. [ID: ${q.id}] ${q.question}${q.follow_up_guide ? `\n   フォローアップ指針: ${q.follow_up_guide}` : ""}${q.quick_replies ? `\n   クイックリプライ: ${q.quick_replies.join(", ")}` : ""}`
-      )
-      .join("\n");
-
-    // ステージ遷移ガイダンスを構築
-    const stageTransitionGuidance = buildLoopModeStageGuidance({
-      currentStage,
-      questions,
-      askedQuestionIds,
-    });
-
-    // タイムマネジメントガイダンスを構築
-    const remainingQuestionsCount =
-      questions.length -
-      questions.filter((q) => askedQuestionIds.has(q.id)).length;
-    const timeManagementGuidance = buildTimeManagementGuidance({
-      remainingMinutes,
-      remainingQuestions: remainingQuestionsCount,
-    });
-
-    const modeInstructions = `
-## インタビューモード: **都度深掘りモード** (Loop Mode)
-現在は、1つのテーマについて多角的に掘り下げていくフェーズです。
-
-1. **基本方針**: 事前定義された質問をトリガーにして、ユーザーの回答から背景、理由、具体的なエピソードを徹底的に引き出してください。
-2. **リアクション**: ユーザーの回答の感情を具体的に受け止め（例:「それは不安に感じられるのですね」「期待されているのですね」）、その文脈に沿った追加の質問を2〜3問重ねてください。
-3. **次のテーマへ**: そのテーマについて十分な示唆が得られた、あるいは話題が尽きたと判断した場合にのみ、次の事前定義質問に移ってください。
-
-## 深掘りテクニック
-以下のテクニックを会話の流れに応じて適宜活用してください：
-
-- **抽象⇔具体の往復**: 抽象的な回答には「具体的にはどんな場面で？」、具体的すぎる回答には「それは要するにどういうことですか？」と往復する
-- **「なぜ」を避けた深掘り**: 「なぜですか？」は詰問調になるため、「どのような背景で」「どんな経験からそう感じられましたか」「何がきっかけで」と言い換える
-- **仮定質問**: 「もしこの法案が成立したら、あなたの○○はどう変わると思いますか？」「成立しなかった場合は？」と具体的なシナリオを想像させる
-- **逆側の視点**: 賛成の方には「一方で懸念される点はありますか？」、反対の方には「期待できる点があるとすれば？」と多角的な視点を引き出す
-- **矛盾の穏やかな確認**: 前の発言と異なる点があれば「先ほど○○とおっしゃっていましたが、今のお話との関係を教えていただけますか？」と丁寧に確認する
-- **中間要約と追加確認**: 深掘りが続いたら「ここまでのお話を整理すると○○ということですね。他に補足したいことはありますか？」と認識合わせする`;
-
-    return `あなたは半構造化デプスインタビューを実施する熟練のインタビュアーです。
-  あなたの目標は、インタビュイーから深い洞察を引き出すことです。
-
-## あなたの責任
-- インタビュイーが自由に話せるようにしながら会話をリードする
-- 興味深い点を深く掘り下げるためにフォローアップの質問をする
-- 会話から専門知識のレベルを推測し、それに応じてインタビュー内容を調整する
-
-## 専門知識レベルの検出
-インタビュイーの専門知識レベルを継続的に評価します。
-
-- 初心者：簡単な言葉を使い、概念を説明し、サポートする
-- 中級：専門用語を少し使用し、中程度の深さ
-- 専門家: ドメイン固有の用語を使用し、深い技術的議論に参加する
-
-## 法案情報
-- 法案名: ${billName}
-- 法案タイトル: ${billTitle}
-- 法案要約: ${billSummary}
-- 法案詳細: ${billContent}
-
-## インタビューテーマ
-${themes.length > 0 ? themes.map((t: string) => `- ${t}`).join("\n") : "（テーマ未設定）"}
-
-## 知識ソース
-${knowledgeSource || "（知識ソース未設定）"}
-
-## 事前定義質問
-以下の質問を会話の流れに応じて適切なタイミングで使用してください。質問は順番通りに使う必要はなく、会話の流れに応じて選んでください。
-
-${questionsText || "（賛成か、反対か）"}
-
-## インタビューの進め方
-${modeInstructions}
-
-1. **事前定義質問の活用**: 会話全体の中で、リストにある質問を網羅することを目指してください。
-  ただし、会話の流れで不自然な場合や、すでに回答が得られている場合は、事前定義質問を避けること。
-
-2. **深掘りのタイミング**: 上記のモード別指示を厳守してください。
-  - 都度深掘りモード：回答の都度、深く掘り下げる
-3. **インタビューの終了判定**:
-  - 全ての事前定義質問を終え、かつ十分な深掘りが完了した時
-  - ユーザーから終了の意思表示があった時
-4. **完了時の案内**: 最後に「これまでの内容をまとめ、レポートを作成します」と伝え、要約フェーズへ進むことを案内してください。
-
-## クイックリプライについて
-- 事前定義質問そのものをこれから行う場合は、その質問のIDをレスポンスの \`question_id\` フィールドに含めてください
-- 事前定義質問にクイックリプライが設定されている場合、その質問をする際はレスポンスの \`quick_replies\` フィールドにその選択肢を含めてください
-- クイックリプライは事前定義質問に設定されているもののみを使用してください
-- 深掘り質問など、事前定義質問以外の質問をする場合は \`question_id\` を含めず、\`quick_replies\` も含めないでください
-
-## トピックタイトルについて
-- 事前定義質問をこれから行う場合は、\`topic_title\` フィールドにその質問のテーマを短く（20文字以内）で記載してください
-- 例: 「業務への影響」「家計への影響」「医療制度の変化」
-- 深掘り質問など、事前定義質問以外の質問をする場合は \`topic_title\` を含めないでください
-
-${stageTransitionGuidance}
-
-${timeManagementGuidance}
-
-## 注意事項
-- 丁寧で親しみやすい口調で話してください
-- ユーザーの回答を尊重し、押し付けがましくならないようにしてください
-- **1つのメッセージでは1つの論点だけを聞いてください。** 括弧書きや補足で別の論点を追加しないでください。
-  - 悪い例: 「どの程度関係がありますか？（どのように関係しているかも教えてください）」→ 程度と具体的内容の2つを同時に聞いている
-  - 良い例: 「どの程度関係がありますか？」→ まず程度だけを聞き、回答後に具体的内容を深掘りする
-- **フォローアップ指針は、回答を得た後のフォローアップの指針です。** 最初の質問に混ぜず、ユーザーの回答を受けてから活用してください。
-- **「なぜ」の多用を避ける**: 「なぜそう思うのですか？」ではなく「どのような背景で」「何がきっかけで」など柔らかい表現を使う
-- 法案に関する質問のみに集中してください
-`;
+    return buildLoopModeSystemPrompt(params);
   },
 
-  calculateNextQuestionId(_params: NextQuestionParams): string | undefined {
-    // Loop Mode: 次の質問を強制しない（LLMに任せる）
-    return undefined;
+  calculateNextQuestionId(params: NextQuestionParams): string | undefined {
+    return calculateLoopModeNextQuestionId(params);
   },
 };

--- a/web/src/features/interview-session/shared/utils/interview-logic/bulk-mode.test.ts
+++ b/web/src/features/interview-session/shared/utils/interview-logic/bulk-mode.test.ts
@@ -1,0 +1,357 @@
+import { describe, expect, it } from "vitest";
+import type { BillWithContent } from "@/features/bills/shared/types";
+import {
+  buildBulkModeSystemPrompt,
+  calculateBulkModeNextQuestionId,
+} from "./bulk-mode";
+import type { InterviewPromptInput } from "./types";
+
+const makeBill = (
+  overrides: Partial<BillWithContent> = {}
+): BillWithContent => ({
+  id: "bill-1",
+  name: "テスト法案",
+  is_featured: false,
+  originating_house: "HR",
+  shugiin_url: null,
+  diet_session_id: null,
+  publish_status: "published",
+  published_at: null,
+  share_thumbnail_url: null,
+  status: "introduced",
+  status_note: null,
+  thumbnail_url: null,
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+  bill_content: {
+    id: "bc-1",
+    bill_id: "bill-1",
+    title: "テスト法案タイトル",
+    summary: "テスト法案の要約です",
+    content: "テスト法案の内容",
+    difficulty_level: "normal",
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  },
+  tags: [],
+  ...overrides,
+});
+
+const sampleQuestions = [
+  { id: "q1", question: "この法案についてどう思いますか？" },
+  {
+    id: "q2",
+    question: "業務への影響はありますか？",
+    quick_replies: ["はい", "いいえ", "わからない"],
+  },
+  { id: "q3", question: "改善案はありますか？" },
+];
+
+const baseParams: InterviewPromptInput = {
+  bill: makeBill(),
+  interviewConfig: {
+    themes: ["医療", "教育"],
+    knowledge_source: "厚生労働省の報告書",
+  },
+  questions: sampleQuestions,
+  currentStage: "chat",
+  askedQuestionIds: new Set(),
+};
+
+describe("buildBulkModeSystemPrompt", () => {
+  it("法案情報がプロンプトに含まれる", () => {
+    const result = buildBulkModeSystemPrompt(baseParams);
+
+    expect(result).toContain("テスト法案");
+    expect(result).toContain("テスト法案タイトル");
+    expect(result).toContain("テスト法案の要約です");
+    expect(result).toContain("テスト法案の内容");
+  });
+
+  it("bill=nullの場合は空文字にフォールバックする", () => {
+    const result = buildBulkModeSystemPrompt({
+      ...baseParams,
+      bill: null,
+    });
+
+    expect(result).toContain("- 法案名: \n");
+    expect(result).toContain("- 法案タイトル: \n");
+    expect(result).toContain("- 法案要約: \n");
+  });
+
+  it("テーマがプロンプトに含まれる", () => {
+    const result = buildBulkModeSystemPrompt(baseParams);
+
+    expect(result).toContain("- 医療");
+    expect(result).toContain("- 教育");
+  });
+
+  it("テーマ未設定の場合「（テーマ未設定）」が含まれる", () => {
+    const result = buildBulkModeSystemPrompt({
+      ...baseParams,
+      interviewConfig: null,
+    });
+
+    expect(result).toContain("（テーマ未設定）");
+  });
+
+  it("知識ソースがプロンプトに含まれる", () => {
+    const result = buildBulkModeSystemPrompt(baseParams);
+
+    expect(result).toContain("厚生労働省の報告書");
+  });
+
+  it("知識ソース未設定の場合「（知識ソース未設定）」が含まれる", () => {
+    const result = buildBulkModeSystemPrompt({
+      ...baseParams,
+      interviewConfig: { themes: ["テーマ1"] },
+    });
+
+    expect(result).toContain("（知識ソース未設定）");
+  });
+
+  it("質問リストがID付きで含まれる", () => {
+    const result = buildBulkModeSystemPrompt(baseParams);
+
+    expect(result).toContain("[ID: q1] この法案についてどう思いますか？");
+    expect(result).toContain("[ID: q2] 業務への影響はありますか？");
+    expect(result).toContain("[ID: q3] 改善案はありますか？");
+  });
+
+  it("クイックリプライが質問テキストに含まれる", () => {
+    const result = buildBulkModeSystemPrompt(baseParams);
+
+    expect(result).toContain("クイックリプライ: はい, いいえ, わからない");
+  });
+
+  it("follow_up_guideは含まれない（Bulk Modeの特徴）", () => {
+    const questionsWithFollowUp = [
+      {
+        id: "q1",
+        question: "テスト質問",
+        follow_up_guide: "具体的な事例を聞く",
+      },
+    ];
+    const result = buildBulkModeSystemPrompt({
+      ...baseParams,
+      questions: questionsWithFollowUp,
+    });
+
+    expect(result).not.toContain("フォローアップ指針");
+    expect(result).not.toContain("具体的な事例を聞く");
+  });
+
+  it("一括回答優先モード (Bulk Mode) と表示される", () => {
+    const result = buildBulkModeSystemPrompt(baseParams);
+
+    expect(result).toContain("一括回答優先モード");
+    expect(result).toContain("Bulk Mode");
+  });
+
+  it("質問が空の場合「（賛成か、反対か）」がフォールバックとして含まれる", () => {
+    const result = buildBulkModeSystemPrompt({
+      ...baseParams,
+      questions: [],
+    });
+
+    expect(result).toContain("（賛成か、反対か）");
+  });
+
+  describe("nextQuestionIdが指定されている場合", () => {
+    it("該当する質問が見つかると特別なプロンプトを返す", () => {
+      const result = buildBulkModeSystemPrompt({
+        ...baseParams,
+        nextQuestionId: "q2",
+      });
+
+      expect(result).toContain(
+        "必ず事前定義質問 **[ID: q2] 業務への影響はありますか？**"
+      );
+      expect(result).toContain("深掘りや他の話題への逸脱は一切禁止");
+      // 特別プロンプトでは法案詳細やテーマは含まれない
+      expect(result).not.toContain("法案詳細");
+    });
+
+    it("該当する質問が見つからない場合は通常のプロンプトを返す", () => {
+      const result = buildBulkModeSystemPrompt({
+        ...baseParams,
+        nextQuestionId: "q_nonexistent",
+      });
+
+      // 通常プロンプトのフォールバック
+      expect(result).toContain("半構造化デプスインタビュー");
+      expect(result).toContain("法案詳細");
+    });
+
+    it("nextQuestionIdが通常プロンプト内のモード指示にも反映される", () => {
+      // nextQuestionIdが存在するが質問が見つからないケース→通常プロンプトだがnextQuestion参照あり
+      // nextQuestionIdが存在し質問も見つかるケース→特別プロンプト
+      // nextQuestionIdが未指定→通常プロンプトでデフォルト指示
+      const resultWithout = buildBulkModeSystemPrompt(baseParams);
+      expect(resultWithout).toContain(
+        "まだ聞いていないものを優先して選んでください"
+      );
+    });
+  });
+
+  it("ステージ遷移ガイダンスが含まれる", () => {
+    const result = buildBulkModeSystemPrompt(baseParams);
+
+    expect(result).toContain("ステージ遷移判定");
+    expect(result).toContain("next_stage");
+  });
+
+  it("残り時間ガイダンスが含まれる（remainingMinutes指定時）", () => {
+    const result = buildBulkModeSystemPrompt({
+      ...baseParams,
+      remainingMinutes: 10,
+    });
+
+    expect(result).toContain("残り目安時間");
+    expect(result).toContain("10分");
+  });
+
+  it("残り時間ガイダンスが空（remainingMinutes=null時）", () => {
+    const result = buildBulkModeSystemPrompt({
+      ...baseParams,
+      remainingMinutes: null,
+    });
+
+    expect(result).not.toContain("タイムマネジメント");
+  });
+
+  it("質問進捗がaskedQuestionIdsに基づいて反映される", () => {
+    const result = buildBulkModeSystemPrompt({
+      ...baseParams,
+      askedQuestionIds: new Set(["q1"]),
+    });
+
+    expect(result).toContain("3問中1問完了（残り2問）");
+  });
+
+  it("残り質問数が正しく計算される", () => {
+    const result = buildBulkModeSystemPrompt({
+      ...baseParams,
+      askedQuestionIds: new Set(["q1", "q2"]),
+      remainingMinutes: 5,
+    });
+
+    expect(result).toContain("1問");
+  });
+});
+
+describe("calculateBulkModeNextQuestionId", () => {
+  it("未回答の最初の質問IDを返す", () => {
+    const result = calculateBulkModeNextQuestionId({
+      messages: [],
+      questions: sampleQuestions,
+    });
+
+    expect(result).toBe("q1");
+  });
+
+  it("既に回答済みの質問をスキップして次の未回答を返す", () => {
+    const result = calculateBulkModeNextQuestionId({
+      messages: [
+        {
+          role: "assistant",
+          content: JSON.stringify({
+            text: "質問です",
+            question_id: "q1",
+          }),
+        },
+        { role: "user", content: "回答です" },
+      ],
+      questions: sampleQuestions,
+    });
+
+    expect(result).toBe("q2");
+  });
+
+  it("複数の質問が回答済みの場合、残りの最初を返す", () => {
+    const result = calculateBulkModeNextQuestionId({
+      messages: [
+        {
+          role: "assistant",
+          content: JSON.stringify({
+            text: "質問1",
+            question_id: "q1",
+          }),
+        },
+        { role: "user", content: "回答1" },
+        {
+          role: "assistant",
+          content: JSON.stringify({
+            text: "質問2",
+            question_id: "q2",
+          }),
+        },
+        { role: "user", content: "回答2" },
+      ],
+      questions: sampleQuestions,
+    });
+
+    expect(result).toBe("q3");
+  });
+
+  it("全質問が回答済みの場合はundefinedを返す", () => {
+    const result = calculateBulkModeNextQuestionId({
+      messages: [
+        {
+          role: "assistant",
+          content: JSON.stringify({
+            text: "質問1",
+            question_id: "q1",
+          }),
+        },
+        { role: "user", content: "回答1" },
+        {
+          role: "assistant",
+          content: JSON.stringify({
+            text: "質問2",
+            question_id: "q2",
+          }),
+        },
+        { role: "user", content: "回答2" },
+        {
+          role: "assistant",
+          content: JSON.stringify({
+            text: "質問3",
+            question_id: "q3",
+          }),
+        },
+        { role: "user", content: "回答3" },
+      ],
+      questions: sampleQuestions,
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  it("質問リストが空の場合はundefinedを返す", () => {
+    const result = calculateBulkModeNextQuestionId({
+      messages: [],
+      questions: [],
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  it("userメッセージのquestion_idは無視される", () => {
+    const result = calculateBulkModeNextQuestionId({
+      messages: [
+        {
+          role: "user",
+          content: JSON.stringify({
+            text: "回答",
+            question_id: "q1",
+          }),
+        },
+      ],
+      questions: sampleQuestions,
+    });
+
+    // userメッセージのquestion_idは無視されるため、q1は未回答のまま
+    expect(result).toBe("q1");
+  });
+});

--- a/web/src/features/interview-session/shared/utils/interview-logic/bulk-mode.ts
+++ b/web/src/features/interview-session/shared/utils/interview-logic/bulk-mode.ts
@@ -1,0 +1,182 @@
+import {
+  buildBulkModeStageGuidance,
+  buildTimeManagementGuidance,
+} from "../stage-transition-guidance";
+import { collectAskedQuestionIds } from "../../collect-asked-question-ids";
+import type { InterviewPromptInput, NextQuestionInput } from "./types";
+
+/**
+ * Bulk Mode（一括回答優先モード）のシステムプロンプトを構築する純粋関数
+ */
+export function buildBulkModeSystemPrompt(
+  params: InterviewPromptInput
+): string {
+  const {
+    bill,
+    interviewConfig,
+    questions,
+    nextQuestionId,
+    currentStage,
+    askedQuestionIds,
+    remainingMinutes,
+  } = params;
+
+  const billName = bill?.name || "";
+  const billTitle = bill?.bill_content?.title || "";
+  const billSummary = bill?.bill_content?.summary || "";
+  const billContent = bill?.bill_content?.content || "";
+  const themes = interviewConfig?.themes || [];
+  const knowledgeSource = interviewConfig?.knowledge_source || "";
+
+  // Bulk Mode: follow_up_guide を含めない
+  const questionsText = questions
+    .map(
+      (q, index) =>
+        `${index + 1}. [ID: ${q.id}] ${q.question}${q.quick_replies ? `\n   クイックリプライ: ${q.quick_replies.join(", ")}` : ""}`
+    )
+    .join("\n");
+
+  // 質問進捗情報を構築
+  const stageTransitionGuidance = buildBulkModeStageGuidance({
+    currentStage,
+    questions,
+    askedQuestionIds,
+  });
+
+  // タイムマネジメントガイダンスを構築
+  const remainingQuestionsCount =
+    questions.length -
+    questions.filter((q) => askedQuestionIds.has(q.id)).length;
+  const timeManagementGuidance = buildTimeManagementGuidance({
+    remainingMinutes,
+    remainingQuestions: remainingQuestionsCount,
+  });
+
+  // nextQuestionId がある場合の特別なプロンプト
+  if (nextQuestionId) {
+    const nextQuestion = questions.find((q) => q.id === nextQuestionId);
+    if (nextQuestion) {
+      return `あなたは熟練のインタビュアーです。現在は「一括回答優先モード」で進行しています。
+
+## 法案情報
+- 法案名: ${billName}
+- 法案要約: ${billSummary}
+
+## 重要指示
+あなたはこれから必ず事前定義質問 **[ID: ${nextQuestion.id}] ${nextQuestion.question}** を行ってください。
+深掘りや他の話題への逸脱は一切禁止されています。
+
+1つのメッセージにつき、この1つの質問のみをしてください。
+
+## クイックリプライについて
+quick_repliesフィールドについては以下を使用してください。
+${nextQuestion.quick_replies}
+
+${stageTransitionGuidance}
+`;
+    }
+  }
+
+  // 通常のプロンプト
+  const nextQuestion = nextQuestionId
+    ? questions.find((q) => q.id === nextQuestionId)
+    : null;
+
+  const modeInstructions = `
+## インタビューモード: **一括回答優先モード** (Bulk Mode)
+現在は、まず全体的な意見を効率的に伺うフェーズです。
+
+1. **基本方針**: 事前定義された各質問項目をすべて消化することを最優先してください。
+${nextQuestion ? `2. **重要指示**: あなたはこれから必ず事前定義質問 **[ID: ${nextQuestion.id}] ${nextQuestion.question}** を行ってください。深掘りや他の話題への逸脱は一切禁止されています。` : "2. **重要指示**: 事前定義された質問のうち、まだ聞いていないものを優先して選んでください。"}
+3. **リアクション**: ユーザーの回答に対しては「承知いたしました」「ありがとうございます」といった簡潔な受容に留め、すぐに次の事前定義質問へ移行してください。
+4. **深掘りの抑制**: ユーザーの回答に興味深い点があっても、このフェーズでは深追いしないでください。事実確認や、極端に抽象的な場合の短い補足要求のみに留めます。
+5. **移行の合図**: すべての事前定義質問が完了した後に初めて、「これまでの回答を詳しく拝見しました。ここからは、特に気になった点について深くお伺いしていきます」と宣言し、一括して深掘りを行ってください。
+
+## 深掘りフェーズのテクニック（事前定義質問完了後に活用）
+一括して深掘りを行う際は、以下のテクニックを活用してください：
+
+- **抽象⇔具体の往復**: 抽象的な回答には「具体的にはどんな場面で？」、具体的すぎる回答には「それは要するにどういうことですか？」と往復する
+- **「なぜ」を避けた深掘り**: 「なぜですか？」は詰問調になるため、「どのような背景で」「どんな経験からそう感じられましたか」「何がきっかけで」と言い換える
+- **感情の言語化**: 回答者の感情を具体的に受け止める（例:「それは不安に感じられるのですね」「期待されているのですね」）
+- **仮定質問**: 「もしこの法案が成立したら、あなたの○○はどう変わると思いますか？」と具体的なシナリオを想像させる
+- **逆側の視点**: 賛成の方には「一方で懸念される点はありますか？」、反対の方には「期待できる点があるとすれば？」と多角的な視点を引き出す
+- **矛盾の穏やかな確認**: 前の発言と異なる点があれば「先ほど○○とおっしゃっていましたが、今のお話との関係を教えていただけますか？」と丁寧に確認する`;
+
+  return `あなたは半構造化デプスインタビューを実施する熟練のインタビュアーです。
+  あなたの目標は、インタビュイーから深い洞察を引き出すことです。
+
+## あなたの責任
+- インタビュイーが自由に話せるようにしながら会話をリードする
+- 興味深い点を深く掘り下げるためにフォローアップの質問をする
+- 会話から専門知識のレベルを推測し、それに応じてインタビュー内容を調整する
+
+## 専門知識レベルの検出
+インタビュイーの専門知識レベルを継続的に評価します。
+
+- 初心者：簡単な言葉を使い、概念を説明し、サポートする
+- 中級：専門用語を少し使用し、中程度の深さ
+- 専門家: ドメイン固有の用語を使用し、深い技術的議論に参加する
+
+## 法案情報
+- 法案名: ${billName}
+- 法案タイトル: ${billTitle}
+- 法案要約: ${billSummary}
+- 法案詳細: ${billContent}
+
+## インタビューテーマ
+${themes.length > 0 ? themes.map((t: string) => `- ${t}`).join("\n") : "（テーマ未設定）"}
+
+## 知識ソース
+${knowledgeSource || "（知識ソース未設定）"}
+
+## 事前定義質問
+以下の質問を会話の流れに応じて適切なタイミングで使用してください。質問は順番通りに使う必要はなく、会話の流れに応じて選んでください。
+
+${questionsText || "（賛成か、反対か）"}
+
+## インタビューの進め方
+${modeInstructions}
+
+1. **事前定義質問の活用**: 会話全体の中で、リストにある質問を網羅することを目指してください。
+
+2. **深掘りのタイミング**: 上記のモード別指示を厳守してください。
+  - 一括回答優先モード：事前定義質問をすべて終えるまで深掘りを控える
+3. **インタビューの終了判定**:
+  - 全ての事前定義質問を終え、かつ十分な深掘りが完了した時
+  - ユーザーから終了の意思表示があった時
+4. **完了時の案内**: 最後に「これまでの内容をまとめ、レポートを作成します」と伝え、要約フェーズへ進むことを案内してください。
+
+## クイックリプライについて
+- 事前定義質問そのものをこれから行う場合は、その質問のIDをレスポンスの \`question_id\` フィールドに含めてください
+- 事前定義質問にクイックリプライが設定されている場合、その質問をする際はレスポンスの \`quick_replies\` フィールドにその選択肢を含めてください
+- クイックリプライは事前定義質問に設定されているもののみを使用してください
+- 深掘り質問など、事前定義質問以外の質問をする場合は \`question_id\` を含めず、\`quick_replies\` も含めないでください
+
+${stageTransitionGuidance}
+
+${timeManagementGuidance}
+
+## 注意事項
+- 丁寧で親しみやすい口調で話してください
+- ユーザーの回答を尊重し、押し付けがましくならないようにしてください
+- **1つのメッセージでは1つの論点だけを聞いてください。** 括弧書きや補足で別の論点を追加しないでください。
+  - 悪い例: 「どの程度関係がありますか？（どのように関係しているかも教えてください）」→ 程度と具体的内容の2つを同時に聞いている
+  - 良い例: 「どの程度関係がありますか？」→ まず程度だけを聞き、回答後に具体的内容を深掘りする
+- **「なぜ」の多用を避ける**: 「なぜそう思うのですか？」ではなく「どのような背景で」「何がきっかけで」など柔らかい表現を使う
+- 法案に関する質問のみに集中してください
+`;
+}
+
+/**
+ * Bulk Mode: 次に聞くべき質問IDを算出する純粋関数
+ *
+ * 未回答の質問のうち最初のものを返す
+ */
+export function calculateBulkModeNextQuestionId(
+  params: NextQuestionInput
+): string | undefined {
+  const { messages, questions } = params;
+  const askedQuestionIds = collectAskedQuestionIds(messages);
+  const nextUnasked = questions.find((q) => !askedQuestionIds.has(q.id));
+  return nextUnasked?.id;
+}

--- a/web/src/features/interview-session/shared/utils/interview-logic/loop-mode.test.ts
+++ b/web/src/features/interview-session/shared/utils/interview-logic/loop-mode.test.ts
@@ -1,0 +1,276 @@
+import { describe, expect, it } from "vitest";
+import type { BillWithContent } from "@/features/bills/shared/types";
+import {
+  buildLoopModeSystemPrompt,
+  calculateLoopModeNextQuestionId,
+} from "./loop-mode";
+import type { InterviewPromptInput } from "./types";
+
+const makeBill = (
+  overrides: Partial<BillWithContent> = {}
+): BillWithContent => ({
+  id: "bill-1",
+  name: "テスト法案",
+  is_featured: false,
+  originating_house: "HR",
+  shugiin_url: null,
+  diet_session_id: null,
+  publish_status: "published",
+  published_at: null,
+  share_thumbnail_url: null,
+  status: "introduced",
+  status_note: null,
+  thumbnail_url: null,
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+  bill_content: {
+    id: "bc-1",
+    bill_id: "bill-1",
+    title: "テスト法案タイトル",
+    summary: "テスト法案の要約です",
+    content: "テスト法案の内容",
+    difficulty_level: "normal",
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  },
+  tags: [],
+  ...overrides,
+});
+
+const sampleQuestions = [
+  {
+    id: "q1",
+    question: "この法案についてどう思いますか？",
+    follow_up_guide: "賛成・反対の理由を深掘りする",
+  },
+  {
+    id: "q2",
+    question: "業務への影響はありますか？",
+    quick_replies: ["はい", "いいえ", "わからない"],
+    follow_up_guide: "具体的な業務内容を聞く",
+  },
+  { id: "q3", question: "改善案はありますか？" },
+];
+
+const baseParams: InterviewPromptInput = {
+  bill: makeBill(),
+  interviewConfig: {
+    themes: ["医療", "教育"],
+    knowledge_source: "厚生労働省の報告書",
+  },
+  questions: sampleQuestions,
+  currentStage: "chat",
+  askedQuestionIds: new Set(),
+};
+
+describe("buildLoopModeSystemPrompt", () => {
+  it("法案情報がプロンプトに含まれる", () => {
+    const result = buildLoopModeSystemPrompt(baseParams);
+
+    expect(result).toContain("テスト法案");
+    expect(result).toContain("テスト法案タイトル");
+    expect(result).toContain("テスト法案の要約です");
+    expect(result).toContain("テスト法案の内容");
+  });
+
+  it("bill=nullの場合は空文字にフォールバックする", () => {
+    const result = buildLoopModeSystemPrompt({
+      ...baseParams,
+      bill: null,
+    });
+
+    expect(result).toContain("- 法案名: \n");
+    expect(result).toContain("- 法案タイトル: \n");
+    expect(result).toContain("- 法案要約: \n");
+  });
+
+  it("テーマがプロンプトに含まれる", () => {
+    const result = buildLoopModeSystemPrompt(baseParams);
+
+    expect(result).toContain("- 医療");
+    expect(result).toContain("- 教育");
+  });
+
+  it("テーマ未設定の場合「（テーマ未設定）」が含まれる", () => {
+    const result = buildLoopModeSystemPrompt({
+      ...baseParams,
+      interviewConfig: null,
+    });
+
+    expect(result).toContain("（テーマ未設定）");
+  });
+
+  it("知識ソースがプロンプトに含まれる", () => {
+    const result = buildLoopModeSystemPrompt(baseParams);
+
+    expect(result).toContain("厚生労働省の報告書");
+  });
+
+  it("知識ソース未設定の場合「（知識ソース未設定）」が含まれる", () => {
+    const result = buildLoopModeSystemPrompt({
+      ...baseParams,
+      interviewConfig: { themes: ["テーマ1"] },
+    });
+
+    expect(result).toContain("（知識ソース未設定）");
+  });
+
+  it("質問リストがID付きで含まれる", () => {
+    const result = buildLoopModeSystemPrompt(baseParams);
+
+    expect(result).toContain("[ID: q1] この法案についてどう思いますか？");
+    expect(result).toContain("[ID: q2] 業務への影響はありますか？");
+    expect(result).toContain("[ID: q3] 改善案はありますか？");
+  });
+
+  it("follow_up_guideが質問テキストに含まれる（Loop Modeの特徴）", () => {
+    const result = buildLoopModeSystemPrompt(baseParams);
+
+    expect(result).toContain(
+      "フォローアップ指針: 賛成・反対の理由を深掘りする"
+    );
+    expect(result).toContain("フォローアップ指針: 具体的な業務内容を聞く");
+  });
+
+  it("follow_up_guideがない質問にはフォローアップ指針が付かない", () => {
+    const result = buildLoopModeSystemPrompt(baseParams);
+    const lines = result.split("\n");
+
+    // q3は follow_up_guide を持たないため、その直後にフォローアップ指針がない
+    const q3Line = lines.find((l) => l.includes("[ID: q3]"));
+    expect(q3Line).toBeDefined();
+    expect(q3Line).not.toContain("フォローアップ指針");
+  });
+
+  it("クイックリプライが質問テキストに含まれる", () => {
+    const result = buildLoopModeSystemPrompt(baseParams);
+
+    expect(result).toContain("クイックリプライ: はい, いいえ, わからない");
+  });
+
+  it("都度深掘りモード (Loop Mode) と表示される", () => {
+    const result = buildLoopModeSystemPrompt(baseParams);
+
+    expect(result).toContain("都度深掘りモード");
+    expect(result).toContain("Loop Mode");
+  });
+
+  it("質問が空の場合「（賛成か、反対か）」がフォールバックとして含まれる", () => {
+    const result = buildLoopModeSystemPrompt({
+      ...baseParams,
+      questions: [],
+    });
+
+    expect(result).toContain("（賛成か、反対か）");
+  });
+
+  it("深掘りテクニックが含まれる", () => {
+    const result = buildLoopModeSystemPrompt(baseParams);
+
+    expect(result).toContain("抽象⇔具体の往復");
+    expect(result).toContain("仮定質問");
+    expect(result).toContain("逆側の視点");
+    expect(result).toContain("中間要約と追加確認");
+  });
+
+  it("トピックタイトルのガイダンスが含まれる", () => {
+    const result = buildLoopModeSystemPrompt(baseParams);
+
+    expect(result).toContain("topic_title");
+    expect(result).toContain("20文字以内");
+  });
+
+  it("ステージ遷移ガイダンスが含まれる", () => {
+    const result = buildLoopModeSystemPrompt(baseParams);
+
+    expect(result).toContain("ステージ遷移判定");
+    expect(result).toContain("next_stage");
+  });
+
+  it("残り時間ガイダンスが含まれる（remainingMinutes指定時）", () => {
+    const result = buildLoopModeSystemPrompt({
+      ...baseParams,
+      remainingMinutes: 15,
+    });
+
+    expect(result).toContain("残り目安時間");
+    expect(result).toContain("15分");
+  });
+
+  it("残り時間ガイダンスが空（remainingMinutes=null時）", () => {
+    const result = buildLoopModeSystemPrompt({
+      ...baseParams,
+      remainingMinutes: null,
+    });
+
+    expect(result).not.toContain("タイムマネジメント");
+  });
+
+  it("質問進捗がaskedQuestionIdsに基づいて反映される", () => {
+    const result = buildLoopModeSystemPrompt({
+      ...baseParams,
+      askedQuestionIds: new Set(["q1", "q2"]),
+    });
+
+    expect(result).toContain("3問中2問完了（残り1問）");
+  });
+
+  it("フォローアップ指針の注意事項が含まれる", () => {
+    const result = buildLoopModeSystemPrompt(baseParams);
+
+    expect(result).toContain(
+      "フォローアップ指針は、回答を得た後のフォローアップの指針です"
+    );
+  });
+
+  it("summaryステージのガイダンスが正しく生成される", () => {
+    const result = buildLoopModeSystemPrompt({
+      ...baseParams,
+      currentStage: "summary",
+    });
+
+    expect(result).toContain("要約フェーズ");
+    expect(result).not.toContain("事前定義質問の消化を急がないでください");
+  });
+
+  it("summary_completeステージのガイダンスが正しく生成される", () => {
+    const result = buildLoopModeSystemPrompt({
+      ...baseParams,
+      currentStage: "summary_complete",
+    });
+
+    expect(result).toContain("完了済み");
+  });
+});
+
+describe("calculateLoopModeNextQuestionId", () => {
+  it("常にundefinedを返す（LLMに質問選択を任せる）", () => {
+    const result = calculateLoopModeNextQuestionId({
+      messages: [],
+      questions: sampleQuestions,
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  it("メッセージがあってもundefinedを返す", () => {
+    const result = calculateLoopModeNextQuestionId({
+      messages: [
+        { role: "assistant", content: "質問です" },
+        { role: "user", content: "回答です" },
+      ],
+      questions: sampleQuestions,
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  it("質問リストが空でもundefinedを返す", () => {
+    const result = calculateLoopModeNextQuestionId({
+      messages: [],
+      questions: [],
+    });
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/web/src/features/interview-session/shared/utils/interview-logic/loop-mode.ts
+++ b/web/src/features/interview-session/shared/utils/interview-logic/loop-mode.ts
@@ -1,0 +1,152 @@
+import {
+  buildLoopModeStageGuidance,
+  buildTimeManagementGuidance,
+} from "../stage-transition-guidance";
+import type { InterviewPromptInput, NextQuestionInput } from "./types";
+
+/**
+ * Loop Mode（都度深掘りモード）のシステムプロンプトを構築する純粋関数
+ */
+export function buildLoopModeSystemPrompt(
+  params: InterviewPromptInput
+): string {
+  const {
+    bill,
+    interviewConfig,
+    questions,
+    currentStage,
+    askedQuestionIds,
+    remainingMinutes,
+  } = params;
+
+  const billName = bill?.name || "";
+  const billTitle = bill?.bill_content?.title || "";
+  const billSummary = bill?.bill_content?.summary || "";
+  const billContent = bill?.bill_content?.content || "";
+  const themes = interviewConfig?.themes || [];
+  const knowledgeSource = interviewConfig?.knowledge_source || "";
+
+  // Loop Mode: follow_up_guide を含める
+  const questionsText = questions
+    .map(
+      (q, index) =>
+        `${index + 1}. [ID: ${q.id}] ${q.question}${q.follow_up_guide ? `\n   フォローアップ指針: ${q.follow_up_guide}` : ""}${q.quick_replies ? `\n   クイックリプライ: ${q.quick_replies.join(", ")}` : ""}`
+    )
+    .join("\n");
+
+  // ステージ遷移ガイダンスを構築
+  const stageTransitionGuidance = buildLoopModeStageGuidance({
+    currentStage,
+    questions,
+    askedQuestionIds,
+  });
+
+  // タイムマネジメントガイダンスを構築
+  const remainingQuestionsCount =
+    questions.length -
+    questions.filter((q) => askedQuestionIds.has(q.id)).length;
+  const timeManagementGuidance = buildTimeManagementGuidance({
+    remainingMinutes,
+    remainingQuestions: remainingQuestionsCount,
+  });
+
+  const modeInstructions = `
+## インタビューモード: **都度深掘りモード** (Loop Mode)
+現在は、1つのテーマについて多角的に掘り下げていくフェーズです。
+
+1. **基本方針**: 事前定義された質問をトリガーにして、ユーザーの回答から背景、理由、具体的なエピソードを徹底的に引き出してください。
+2. **リアクション**: ユーザーの回答の感情を具体的に受け止め（例:「それは不安に感じられるのですね」「期待されているのですね」）、その文脈に沿った追加の質問を2〜3問重ねてください。
+3. **次のテーマへ**: そのテーマについて十分な示唆が得られた、あるいは話題が尽きたと判断した場合にのみ、次の事前定義質問に移ってください。
+
+## 深掘りテクニック
+以下のテクニックを会話の流れに応じて適宜活用してください：
+
+- **抽象⇔具体の往復**: 抽象的な回答には「具体的にはどんな場面で？」、具体的すぎる回答には「それは要するにどういうことですか？」と往復する
+- **「なぜ」を避けた深掘り**: 「なぜですか？」は詰問調になるため、「どのような背景で」「どんな経験からそう感じられましたか」「何がきっかけで」と言い換える
+- **仮定質問**: 「もしこの法案が成立したら、あなたの○○はどう変わると思いますか？」「成立しなかった場合は？」と具体的なシナリオを想像させる
+- **逆側の視点**: 賛成の方には「一方で懸念される点はありますか？」、反対の方には「期待できる点があるとすれば？」と多角的な視点を引き出す
+- **矛盾の穏やかな確認**: 前の発言と異なる点があれば「先ほど○○とおっしゃっていましたが、今のお話との関係を教えていただけますか？」と丁寧に確認する
+- **中間要約と追加確認**: 深掘りが続いたら「ここまでのお話を整理すると○○ということですね。他に補足したいことはありますか？」と認識合わせする`;
+
+  return `あなたは半構造化デプスインタビューを実施する熟練のインタビュアーです。
+  あなたの目標は、インタビュイーから深い洞察を引き出すことです。
+
+## あなたの責任
+- インタビュイーが自由に話せるようにしながら会話をリードする
+- 興味深い点を深く掘り下げるためにフォローアップの質問をする
+- 会話から専門知識のレベルを推測し、それに応じてインタビュー内容を調整する
+
+## 専門知識レベルの検出
+インタビュイーの専門知識レベルを継続的に評価します。
+
+- 初心者：簡単な言葉を使い、概念を説明し、サポートする
+- 中級：専門用語を少し使用し、中程度の深さ
+- 専門家: ドメイン固有の用語を使用し、深い技術的議論に参加する
+
+## 法案情報
+- 法案名: ${billName}
+- 法案タイトル: ${billTitle}
+- 法案要約: ${billSummary}
+- 法案詳細: ${billContent}
+
+## インタビューテーマ
+${themes.length > 0 ? themes.map((t: string) => `- ${t}`).join("\n") : "（テーマ未設定）"}
+
+## 知識ソース
+${knowledgeSource || "（知識ソース未設定）"}
+
+## 事前定義質問
+以下の質問を会話の流れに応じて適切なタイミングで使用してください。質問は順番通りに使う必要はなく、会話の流れに応じて選んでください。
+
+${questionsText || "（賛成か、反対か）"}
+
+## インタビューの進め方
+${modeInstructions}
+
+1. **事前定義質問の活用**: 会話全体の中で、リストにある質問を網羅することを目指してください。
+  ただし、会話の流れで不自然な場合や、すでに回答が得られている場合は、事前定義質問を避けること。
+
+2. **深掘りのタイミング**: 上記のモード別指示を厳守してください。
+  - 都度深掘りモード：回答の都度、深く掘り下げる
+3. **インタビューの終了判定**:
+  - 全ての事前定義質問を終え、かつ十分な深掘りが完了した時
+  - ユーザーから終了の意思表示があった時
+4. **完了時の案内**: 最後に「これまでの内容をまとめ、レポートを作成します」と伝え、要約フェーズへ進むことを案内してください。
+
+## クイックリプライについて
+- 事前定義質問そのものをこれから行う場合は、その質問のIDをレスポンスの \`question_id\` フィールドに含めてください
+- 事前定義質問にクイックリプライが設定されている場合、その質問をする際はレスポンスの \`quick_replies\` フィールドにその選択肢を含めてください
+- クイックリプライは事前定義質問に設定されているもののみを使用してください
+- 深掘り質問など、事前定義質問以外の質問をする場合は \`question_id\` を含めず、\`quick_replies\` も含めないでください
+
+## トピックタイトルについて
+- 事前定義質問をこれから行う場合は、\`topic_title\` フィールドにその質問のテーマを短く（20文字以内）で記載してください
+- 例: 「業務への影響」「家計への影響」「医療制度の変化」
+- 深掘り質問など、事前定義質問以外の質問をする場合は \`topic_title\` を含めないでください
+
+${stageTransitionGuidance}
+
+${timeManagementGuidance}
+
+## 注意事項
+- 丁寧で親しみやすい口調で話してください
+- ユーザーの回答を尊重し、押し付けがましくならないようにしてください
+- **1つのメッセージでは1つの論点だけを聞いてください。** 括弧書きや補足で別の論点を追加しないでください。
+  - 悪い例: 「どの程度関係がありますか？（どのように関係しているかも教えてください）」→ 程度と具体的内容の2つを同時に聞いている
+  - 良い例: 「どの程度関係がありますか？」→ まず程度だけを聞き、回答後に具体的内容を深掘りする
+- **フォローアップ指針は、回答を得た後のフォローアップの指針です。** 最初の質問に混ぜず、ユーザーの回答を受けてから活用してください。
+- **「なぜ」の多用を避ける**: 「なぜそう思うのですか？」ではなく「どのような背景で」「何がきっかけで」など柔らかい表現を使う
+- 法案に関する質問のみに集中してください
+`;
+}
+
+/**
+ * Loop Mode: 次の質問を強制しない（LLMに任せる）
+ *
+ * 常に undefined を返す
+ */
+export function calculateLoopModeNextQuestionId(
+  _params: NextQuestionInput
+): undefined {
+  return undefined;
+}

--- a/web/src/features/interview-session/shared/utils/interview-logic/types.ts
+++ b/web/src/features/interview-session/shared/utils/interview-logic/types.ts
@@ -1,0 +1,41 @@
+import type { BillWithContent } from "@/features/bills/shared/types";
+
+/**
+ * インタビュー設定の型（純粋関数用）
+ */
+export type InterviewConfig = {
+  themes?: string[] | null;
+  knowledge_source?: string | null;
+  [key: string]: unknown;
+} | null;
+
+/**
+ * インタビュー質問の型（純粋関数用）
+ */
+export interface InterviewQuestion {
+  id: string;
+  question: string;
+  quick_replies?: string[] | null;
+  follow_up_guide?: string | null;
+}
+
+/**
+ * システムプロンプト構築用パラメータ（純粋関数用）
+ */
+export interface InterviewPromptInput {
+  bill: BillWithContent | null;
+  interviewConfig: InterviewConfig;
+  questions: InterviewQuestion[];
+  nextQuestionId?: string;
+  currentStage: "chat" | "summary" | "summary_complete";
+  askedQuestionIds: Set<string>;
+  remainingMinutes?: number | null;
+}
+
+/**
+ * 次の質問ID算出用パラメータ（純粋関数用）
+ */
+export interface NextQuestionInput {
+  messages: Array<{ role: string; content: string }>;
+  questions: Array<{ id: string }>;
+}


### PR DESCRIPTION
## Summary
- `server/utils/interview-logic/bulk-mode.ts` と `loop-mode.ts` の純粋ロジックを `shared/utils/interview-logic/` に切り出し
- `buildBulkModeSystemPrompt`, `calculateBulkModeNextQuestionId`, `buildLoopModeSystemPrompt`, `calculateLoopModeNextQuestionId` の4つの純粋関数を作成
- bulk-mode 25テスト、loop-mode 24テスト、合計49テストを追加
- server側ファイルはsharedからの委譲パターンに変更（`server-only` ガードは維持）

## 変更内容
- **新規**: `web/src/features/interview-session/shared/utils/interview-logic/types.ts` - 純粋関数用の型定義
- **新規**: `web/src/features/interview-session/shared/utils/interview-logic/bulk-mode.ts` - Bulk Modeの純粋関数
- **新規**: `web/src/features/interview-session/shared/utils/interview-logic/bulk-mode.test.ts` - Bulk Modeテスト (25件)
- **新規**: `web/src/features/interview-session/shared/utils/interview-logic/loop-mode.ts` - Loop Modeの純粋関数
- **新規**: `web/src/features/interview-session/shared/utils/interview-logic/loop-mode.test.ts` - Loop Modeテスト (24件)
- **変更**: `web/src/features/interview-session/server/utils/interview-logic/bulk-mode.ts` - shared委譲に変更
- **変更**: `web/src/features/interview-session/server/utils/interview-logic/loop-mode.ts` - shared委譲に変更

## Test plan
- [x] `pnpm lint` 通過
- [x] `pnpm typecheck` 通過
- [x] `pnpm test` 全474テスト通過（新規49テスト含む）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized interview session logic for Bulk Mode and Loop Mode into shared utilities, improving code maintainability and consistency across the application without affecting user experience.

* **Tests**
  * Added comprehensive test suites for Bulk Mode and Loop Mode interview logic, validating system prompts, question progression, time management guidance, and stage transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->