### PR TITLE
feat: チャット継続時にタイムアップアラートを自動非表示にする

### DIFF
--- a/web/src/features/interview-session/client/components/interview-chat-client.tsx
+++ b/web/src/features/interview-session/client/components/interview-chat-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import {
   Conversation,
   ConversationContent,
@@ -78,6 +78,31 @@ export function InterviewChatClient({
       : null;
   const showTimeUpPrompt =
     isTimeUp && !timeUpDismissed && stage === "chat" && !isLoading;
+
+  // チャット操作時にタイムアップアラートを自動非表示にする
+  const dismissTimeUpIfNeeded = useCallback(() => {
+    if (isTimeUp && !timeUpDismissed) {
+      setTimeUpDismissed(true);
+    }
+  }, [isTimeUp, timeUpDismissed]);
+
+  const handleChatSubmit = useCallback(
+    (params: { text?: string }) => {
+      if (params.text) {
+        dismissTimeUpIfNeeded();
+      }
+      handleSubmit(params);
+    },
+    [dismissTimeUpIfNeeded, handleSubmit]
+  );
+
+  const handleChatQuickReply = useCallback(
+    (text: string) => {
+      dismissTimeUpIfNeeded();
+      handleQuickReply(text);
+    },
+    [dismissTimeUpIfNeeded, handleQuickReply]
+  );
 
   const handleSkipTopic = () => {
     handleSubmit({ text: "次のテーマに進みたいです" });
@@ -175,7 +200,7 @@ export function InterviewChatClient({
           {!isLoading && stage === "chat" && currentQuickReplies.length > 0 && (
             <QuickReplyButtons
               replies={currentQuickReplies}
-              onSelect={handleQuickReply}
+              onSelect={handleChatQuickReply}
               disabled={isLoading}
             />
           )}
@@ -208,7 +233,7 @@ export function InterviewChatClient({
           <InterviewChatInput
             input={input}
             onInputChange={setInput}
-            onSubmit={handleSubmit}
+            onSubmit={handleChatSubmit}
             placeholder="AIに質問に回答する"
             isResponding={isLoading}
           />


### PR DESCRIPTION
## Summary
- 目安時間終了アラート表示中にユーザーがチャットメッセージを送信またはクイックリプライを選択した場合、アラートを自動的に非表示にする
- 空入力での誤dismissを防ぐため、テキストがある場合のみ非表示処理を実行

## 変更内容
`interview-chat-client.tsx` のみ変更:
- `dismissTimeUpIfNeeded` コールバックを追加し、`isTimeUp && !timeUpDismissed` の場合にアラートを非表示にする
- `handleChatSubmit` / `handleChatQuickReply` ラッパーで、チャット送信・クイックリプライ選択時にアラートを自動dismiss
- `InterviewChatInput` と `QuickReplyButtons` に渡すハンドラーをラッパーに差し替え

## Test plan
- [x] `pnpm lint` 通過
- [x] `pnpm typecheck` 通過
- [x] `pnpm test` 全425テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)