### PR TITLE
fix: Codecovのカバレッジ計測が動作するよう設定を修正

### DIFF
--- a/.github/workflows/code_check.yml
+++ b/.github/workflows/code_check.yml
@@ -2,7 +2,7 @@ name: Code Check
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
     branches: [main, develop]
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,6 @@
+codecov:
+  branch: develop
+
 coverage:
   status:
     project:


### PR DESCRIPTION
## Summary
- CIワークフロー(`code_check.yml`)の`push`トリガーに`develop`ブランチを追加。これによりPRがdevelopにマージされた際にベースカバレッジがCodecovにアップロードされるようになる
- `codecov.yml`にデフォルトブランチを`develop`に明示設定。Codecovダッシュボードがdevelopブランチのカバレッジを正しく表示するようになる

## 背景
Codecovダッシュボードで「No coverage reports found」と表示されていた原因:
1. `push`トリガーが`main`のみだったため、developにマージされてもベースカバレッジがアップロードされなかった
2. Codecovのデフォルトブランチが`main`を想定していたが、このリポジトリは`develop`がメインブランチ

## Test plan
- [ ] PRマージ後、developへのpushでCode Checkワークフローが実行されカバレッジがアップロードされることを確認
- [ ] Codecovダッシュボードでカバレッジデータが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to run on develop branch pushes in addition to main.
  * Configured coverage reporting to target the develop branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->