### PR TITLE
fix: タイマーアラートの文言修正・ボタン順序変更

### DIFF
--- a/web/src/features/interview-session/client/components/time-up-prompt.tsx
+++ b/web/src/features/interview-session/client/components/time-up-prompt.tsx
@@ -19,19 +19,19 @@ export function TimeUpPrompt({
   return (
     <div className="mx-4 rounded-lg border border-gray-200 bg-gray-50 p-4">
       <p className="mb-3 text-sm font-medium text-gray-700">
-        目安時間が終了しました。レポート作成に進みますか？
+        目安時間を超過しましたが、インタビューを続けてもよいですか？
       </p>
       <div className="flex gap-2">
-        <Button size="sm" onClick={onEndInterview} disabled={disabled}>
-          レポート作成に進む
+        <Button size="sm" onClick={onContinue} disabled={disabled}>
+          インタビューを続ける
         </Button>
         <Button
           variant="outline"
           size="sm"
-          onClick={onContinue}
+          onClick={onEndInterview}
           disabled={disabled}
         >
-          インタビューを続ける
+          終了してレポートを作成
         </Button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- タイマーアラートの文言を「目安時間を超過しましたが、インタビューを続けてもよいですか？」に変更
- 「インタビューを続ける」をprimary（デフォルト）ボタンに変更
- 「終了してレポートを作成」をoutline（secondary）ボタンに変更

## Test plan
- [x] `pnpm lint` 通過
- [x] `pnpm typecheck` 通過
- [x] Codex review 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the time-up prompt to ask users if they want to continue the interview after exceeding the allotted time, rather than simply indicating time has ended.
  * Clarified button labels: primary action continues the interview, secondary action ends the session and generates the report.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->