### PR TITLE
fix: integration testもdevelopへのpushでCodecovに反映

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -2,7 +2,7 @@ name: Integration Tests
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
     branches: [main, develop]
 


### PR DESCRIPTION
## Summary
- `integration_test.yml`の`push`トリガーに`develop`ブランチを追加
- PRマージ時にintegration testのカバレッジもCodecovにアップロードされ、バッジに反映される

## 背景
#441 で単体テストのカバレッジはdevelopへのpush時にアップロードされるようになったが、integration testは`push: [main]`のままだった。Codecovバッジにintegrationカバレッジも含めるため追加。

## Test plan
- [ ] PRマージ後、developへのpushでIntegration Testsワークフローが実行されることを確認
- [ ] Codecovダッシュボードでintegrationフラグのカバレッジが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)