### PR TITLE
fix: codecovのignoreに設定ファイル・test-utilsを追加

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -12,6 +12,9 @@ coverage:
         target: 80%
 
 ignore:
+  - "web/*.config.*"
+  - "web/vitest.*"
+  - "web/src/test-utils/**"
   - "web/src/components/ui/**"
   - "web/src/app/**/page.tsx"
   - "web/src/app/**/layout.tsx"


### PR DESCRIPTION
## Summary
- `web/*.config.*`（next.config.ts, postcss.config.mjs）をカバレッジ対象外に
- `web/vitest.*`（vitest.config.mts, vitest.integration.config.mts, vitest.integration.setup.ts）をカバレッジ対象外に
- `web/src/test-utils/**`（mock-language-model.ts, mock-prompt-provider.ts）をカバレッジ対象外に

## 背景
Codecovダッシュボードで設定ファイルやテストユーティリティが0%カバレッジとして表示されていた。これらはテスト対象ではないため除外する。

## Test plan
- [ ] Codecovダッシュボードで該当ファイルが表示されなくなることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)