### PR TITLE
style: インタビュー画面のUI調整（角丸・パディング・マージン）

### DIFF
--- a/web/src/features/interview-report/shared/components/opinions-list.tsx
+++ b/web/src/features/interview-report/shared/components/opinions-list.tsx
@@ -25,7 +25,7 @@ export function OpinionsList({
   return (
     <div className="flex flex-col gap-4">
       <h2 className="text-xl font-bold text-gray-800">{title}</h2>
-      <div className="bg-white rounded-2xl p-6 flex flex-col gap-6">
+      <div className="bg-white rounded-2xl p-6 flex flex-col gap-12">
         {opinions.map((opinion, index) => (
           <div
             key={`opinion-${index}-${opinion.title.slice(0, 20)}`}

--- a/web/src/features/interview-session/client/components/interview-chat-client.tsx
+++ b/web/src/features/interview-session/client/components/interview-chat-client.tsx
@@ -129,7 +129,7 @@ export function InterviewChatClient({
   const showStreamingMessage = object && !isStreamingMessageCommitted;
 
   return (
-    <div className="flex flex-col h-dvh md:h-[calc(100dvh-96px)] pt-24 md:pt-4 bg-white">
+    <div className="flex flex-col h-dvh md:h-[calc(100dvh-96px)] pt-24 md:pt-4 bg-white md:rounded-t-[36px] md:px-12">
       {showProgressBar && progress && (
         <div className="px-4 pb-1 pt-2">
           <InterviewProgressBar

--- a/web/src/features/interview-session/client/components/interview-progress-bar.tsx
+++ b/web/src/features/interview-session/client/components/interview-progress-bar.tsx
@@ -40,7 +40,7 @@ export function InterviewProgressBar({
                 variant="link"
                 onClick={onSkip}
                 disabled={disabled}
-                className="h-auto shrink-0 p-0 text-sm font-bold text-[#0F8472] hover:no-underline"
+                className="ml-2 h-auto shrink-0 p-0 text-sm font-bold text-[#0F8472] hover:no-underline"
               >
                 スキップする
               </Button>


### PR DESCRIPTION
## Summary
Figmaデザインに合わせてインタビュー画面のUIを微調整します。

- **PCメインエリア角丸**: `md:rounded-t-[36px]` を追加（Figmaの `borderRadius: 36px 36px 0px 0px` に対応）
- **PCメインエリアPadding**: `md:px-12` (48px) を追加（Figmaの `padding: 24px 48px` に対応）
- **スキップボタン左マージン倍増**: `ml-2` を追加してスキップボタンの左側の間隔を倍に
- **主な意見リストアイテムマージン倍増**: `gap-6` → `gap-12` で意見カード間の間隔を倍に

## 変更ファイル
- `web/src/features/interview-session/client/components/interview-chat-client.tsx`
- `web/src/features/interview-session/client/components/interview-progress-bar.tsx`
- `web/src/features/interview-report/shared/components/opinions-list.tsx`

## Test plan
- [ ] PC表示でインタビューチャット画面のメインエリアが角丸・パディング付きで表示される
- [ ] スマホ表示では角丸・パディングが適用されない（既存のまま）
- [ ] プログレスバーのスキップボタンの左マージンが広くなっている
- [ ] レポート画面の主な意見リストのアイテム間マージンが広くなっている

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style
* Refined spacing between opinion elements in interview reports for improved visual clarity and readability
* Enhanced responsive design of the interview chat interface with improved padding and rounded corner styling on medium-sized and larger screens
* Adjusted skip button spacing in interview progress controls for better visual alignment and balance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->