### PR TITLE
fix: PC角丸の背景色問題を修正

### DIFF
--- a/web/src/features/interview-session/client/components/interview-chat-client.tsx
+++ b/web/src/features/interview-session/client/components/interview-chat-client.tsx
@@ -129,126 +129,128 @@ export function InterviewChatClient({
   const showStreamingMessage = object && !isStreamingMessageCommitted;
 
   return (
-    <div className="flex flex-col h-dvh md:h-[calc(100dvh-96px)] pt-24 md:pt-4 bg-white md:rounded-t-[36px] md:px-12">
-      {showProgressBar && progress && (
-        <div className="px-4 pb-1 pt-2">
-          <InterviewProgressBar
-            percentage={progress.percentage}
-            currentTopic={progress.currentTopic}
-            showSkip={progress.showSkip}
-            onSkip={handleSkipTopic}
+    <div className="h-dvh md:h-[calc(100dvh-96px)] md:bg-[#F7F4F0]">
+      <div className="flex flex-col h-full pt-24 md:pt-4 bg-white md:rounded-t-[36px] md:px-12">
+        {showProgressBar && progress && (
+          <div className="px-4 pb-1 pt-2">
+            <InterviewProgressBar
+              percentage={progress.percentage}
+              currentTopic={progress.currentTopic}
+              showSkip={progress.showSkip}
+              onSkip={handleSkipTopic}
+              disabled={isLoading}
+              remainingMinutes={timerMinutes}
+            />
+          </div>
+        )}
+        <Conversation className="flex-1 overflow-y-auto">
+          <ConversationContent className="flex flex-col gap-4">
+            {/* 初期表示メッセージ */}
+            {messages.length === 0 && !object && (
+              <div className="flex flex-col gap-4">
+                <p className="text-sm font-bold leading-[1.8] text-[#1F2937]">
+                  法案についてのAIインタビューを開始します。
+                </p>
+                <p className="text-sm text-gray-600">
+                  あなたの意見や経験をお聞かせください。
+                </p>
+              </div>
+            )}
+
+            {/* メッセージ一覧を表示 */}
+            {messages.map((message) => (
+              <InterviewMessage
+                key={message.id}
+                message={{
+                  id: message.id,
+                  role: message.role,
+                  parts: [{ type: "text" as const, text: message.content }],
+                }}
+                isStreaming={false}
+                report={message.report}
+              />
+            ))}
+
+            {/* ストリーミング中のAIレスポンスを表示 */}
+            {showStreamingMessage && (
+              <InterviewMessage
+                key="streaming-assistant"
+                message={{
+                  id: "streaming-assistant",
+                  role: "assistant",
+                  parts: [{ type: "text" as const, text: object.text ?? "" }],
+                }}
+                isStreaming={isLoading}
+                report={streamingReportData}
+              />
+            )}
+
+            {/* ローディング表示 */}
+            {isLoading && !object && (
+              <span className="text-sm text-gray-500">考え中...</span>
+            )}
+
+            {/* エラー表示 */}
+            <InterviewErrorDisplay
+              error={error}
+              canRetry={canRetry}
+              onRetry={handleRetry}
+              isRetrying={isLoading}
+            />
+
+            {/* クイックリプライボタン */}
+            {stage === "chat" && (
+              <>
+                {!isLoading && currentQuickReplies.length > 0 && (
+                  <QuickReplyButtons
+                    replies={currentQuickReplies}
+                    onSelect={handleChatQuickReply}
+                  />
+                )}
+                {isLoading && streamingQuickReplies.length > 0 && (
+                  <QuickReplyButtons
+                    replies={streamingQuickReplies}
+                    onSelect={handleChatQuickReply}
+                    disabled
+                  />
+                )}
+              </>
+            )}
+          </ConversationContent>
+        </Conversation>
+
+        {/* 時間超過プロンプト */}
+        {showTimeUpPrompt && (
+          <TimeUpPrompt
+            onEndInterview={handleEndInterview}
+            onContinue={handleContinueInterview}
             disabled={isLoading}
-            remainingMinutes={timerMinutes}
           />
-        </div>
-      )}
-      <Conversation className="flex-1 overflow-y-auto">
-        <ConversationContent className="flex flex-col gap-4">
-          {/* 初期表示メッセージ */}
-          {messages.length === 0 && !object && (
-            <div className="flex flex-col gap-4">
-              <p className="text-sm font-bold leading-[1.8] text-[#1F2937]">
-                法案についてのAIインタビューを開始します。
-              </p>
-              <p className="text-sm text-gray-600">
-                あなたの意見や経験をお聞かせください。
-              </p>
-            </div>
-          )}
+        )}
 
-          {/* メッセージ一覧を表示 */}
-          {messages.map((message) => (
-            <InterviewMessage
-              key={message.id}
-              message={{
-                id: message.id,
-                role: message.role,
-                parts: [{ type: "text" as const, text: message.content }],
-              }}
-              isStreaming={false}
-              report={message.report}
-            />
-          ))}
-
-          {/* ストリーミング中のAIレスポンスを表示 */}
-          {showStreamingMessage && (
-            <InterviewMessage
-              key="streaming-assistant"
-              message={{
-                id: "streaming-assistant",
-                role: "assistant",
-                parts: [{ type: "text" as const, text: object.text ?? "" }],
-              }}
-              isStreaming={isLoading}
-              report={streamingReportData}
+        {/* 入力エリア */}
+        <div className="px-6 pb-4 pt-2">
+          {(stage === "summary" || stage === "summary_complete") && (
+            <InterviewSummaryInput
+              sessionId={sessionId}
+              input={input}
+              onInputChange={setInput}
+              onSubmit={handleSubmit}
+              isLoading={isLoading}
+              error={error}
             />
           )}
 
-          {/* ローディング表示 */}
-          {isLoading && !object && (
-            <span className="text-sm text-gray-500">考え中...</span>
-          )}
-
-          {/* エラー表示 */}
-          <InterviewErrorDisplay
-            error={error}
-            canRetry={canRetry}
-            onRetry={handleRetry}
-            isRetrying={isLoading}
-          />
-
-          {/* クイックリプライボタン */}
           {stage === "chat" && (
-            <>
-              {!isLoading && currentQuickReplies.length > 0 && (
-                <QuickReplyButtons
-                  replies={currentQuickReplies}
-                  onSelect={handleChatQuickReply}
-                />
-              )}
-              {isLoading && streamingQuickReplies.length > 0 && (
-                <QuickReplyButtons
-                  replies={streamingQuickReplies}
-                  onSelect={handleChatQuickReply}
-                  disabled
-                />
-              )}
-            </>
+            <InterviewChatInput
+              input={input}
+              onInputChange={setInput}
+              onSubmit={handleChatSubmit}
+              placeholder="AIに質問に回答する"
+              isResponding={isLoading}
+            />
           )}
-        </ConversationContent>
-      </Conversation>
-
-      {/* 時間超過プロンプト */}
-      {showTimeUpPrompt && (
-        <TimeUpPrompt
-          onEndInterview={handleEndInterview}
-          onContinue={handleContinueInterview}
-          disabled={isLoading}
-        />
-      )}
-
-      {/* 入力エリア */}
-      <div className="px-6 pb-4 pt-2">
-        {(stage === "summary" || stage === "summary_complete") && (
-          <InterviewSummaryInput
-            sessionId={sessionId}
-            input={input}
-            onInputChange={setInput}
-            onSubmit={handleSubmit}
-            isLoading={isLoading}
-            error={error}
-          />
-        )}
-
-        {stage === "chat" && (
-          <InterviewChatInput
-            input={input}
-            onInputChange={setInput}
-            onSubmit={handleChatSubmit}
-            placeholder="AIに質問に回答する"
-            isResponding={isLoading}
-          />
-        )}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- #446 で追加したPC角丸（`md:rounded-t-[36px]`）の外側に親要素の背景色 `#F7F4F0` が見えてしまう問題を修正
- 角丸の外側に同じ背景色を持つラッパー `div` を追加して、角丸の隙間が自然に見えるように対応

## Test plan
- [ ] PC表示でインタビューチャット画面の角丸部分に不自然な背景色が表示されないことを確認
- [ ] スマホ表示に影響がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved interview chat UI layout and message display organization.
  * Enhanced error handling and feedback within the chat interface.
  * Fixed streaming message rendering in conversations.

* **Refactor**
  * Restructured chat interface for better modularity and responsiveness.
  * Optimized quick reply button handling and time-up prompt display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->