### PR TITLE
fix: インタビュー進捗バーとテキスト行の表示順を入れ替え

### DIFF
--- a/web/src/features/interview-session/client/components/interview-progress-bar.tsx
+++ b/web/src/features/interview-session/client/components/interview-progress-bar.tsx
@@ -23,12 +23,8 @@ export function InterviewProgressBar({
 }: InterviewProgressBarProps) {
   return (
     <div className="rounded-[18px] bg-white py-[10px]">
-      <Progress
-        value={percentage}
-        className="h-[7px] rounded-full bg-[#D9D9D9] [&>[data-slot=progress-indicator]]:bg-[#2AA693]"
-      />
       {(currentTopic || showSkip || remainingMinutes != null) && (
-        <div className="mt-3 flex items-center gap-2">
+        <div className="mb-3 flex items-center gap-2">
           <div className="flex min-w-0 flex-1 items-center gap-2">
             {currentTopic && (
               <p className="min-w-0 truncate text-sm font-bold leading-[1.8] text-[#1F2937]">
@@ -53,6 +49,10 @@ export function InterviewProgressBar({
           )}
         </div>
       )}
+      <Progress
+        value={percentage}
+        className="h-[7px] rounded-full bg-[#D9D9D9] [&>[data-slot=progress-indicator]]:bg-[#2AA693]"
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- インタビュー画面のプログレスバーとテキスト行（トピック名・スキップボタン・残り時間）の上下表示順を入れ替え
- Before: プログレスバー → テキスト行
- After: テキスト行 → プログレスバー

## Test plan
- [x] `pnpm lint` パス
- [x] `pnpm typecheck` パス
- [x] `pnpm test` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Repositioned progress indicator from top to bottom of interview session content.
  * Adjusted vertical spacing margins around topic and control elements to reflect the new progress bar location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->