### PR TITLE
fix: 会話ログページでAIメッセージのJSONが生表示される問題を修正

### DIFF
--- a/web/src/features/interview-report/server/components/report-chat-log-page.tsx
+++ b/web/src/features/interview-report/server/components/report-chat-log-page.tsx
@@ -107,10 +107,28 @@ interface ChatMessageProps {
   };
 }
 
+/**
+ * メッセージのcontentからテキスト部分を抽出する。
+ * AIメッセージはJSON形式（{text, quick_replies, ...}）で保存されているため、
+ * textフィールドを取り出す。JSONでない場合はそのまま返す。
+ */
+function getMessageDisplayText(content: string): string {
+  try {
+    const parsed = JSON.parse(content);
+    if (typeof parsed === "object" && parsed !== null && "text" in parsed) {
+      return parsed.text ?? content;
+    }
+  } catch {
+    // JSONでない場合はそのままテキストとして扱う
+  }
+  return content;
+}
+
 function ChatMessage({ message }: ChatMessageProps) {
   const isAssistant = message.role === "assistant";
 
   if (isAssistant) {
+    const displayText = getMessageDisplayText(message.content);
     // AI message: icon on top left with gray background, then plain text below
     return (
       <div className="flex flex-col items-start gap-2">
@@ -118,7 +136,7 @@ function ChatMessage({ message }: ChatMessageProps) {
           <Bot size={24} className="text-gray-600" />
         </div>
         <p className="text-sm font-medium leading-relaxed whitespace-pre-wrap text-gray-800">
-          {message.content}
+          {displayText}
         </p>
       </div>
     );


### PR DESCRIPTION
## Summary
- 会話ログページ（`report-chat-log-page.tsx`）で、AIメッセージの`content`がJSON文字列のまま表示されていた問題を修正
- AIメッセージは`{"text":"...", "quick_replies":[...], ...}`形式で保存されているが、表示時にパースされていなかった
- `getMessageDisplayText`関数を追加し、assistantメッセージのみ`text`フィールドを抽出して表示するよう修正（ユーザーメッセージはそのまま表示）

## 修正内容
- `ChatMessage`コンポーネント内に`getMessageDisplayText`ヘルパー関数を追加
- JSONパース → `text`フィールド抽出、パース失敗時は元のcontentをそのまま表示
- assistantメッセージのみに適用（ユーザーメッセージの内容は変更しない）

## Test plan
- [x] `pnpm lint` パス
- [x] `pnpm typecheck` パス
- [x] `pnpm test` パス（52ファイル、603テスト全パス）
- [ ] 会話ログページでAIメッセージがテキストとして正しく表示されることを確認
- [ ] ユーザーメッセージが従来通り表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)