### PR TITLE
fix: 日時表示をAsia/Tokyoタイムゾーン指定に修正

### DIFF
--- a/admin/src/features/interview-reports/server/components/session-detail.tsx
+++ b/admin/src/features/interview-reports/server/components/session-detail.tsx
@@ -50,7 +50,9 @@ export function SessionDetail({ session, billId }: SessionDetailProps) {
               <div className="text-sm text-gray-500">開始時刻</div>
               <div className="flex items-center gap-1 text-sm">
                 <Clock className="h-4 w-4 text-gray-400" />
-                {new Date(session.started_at).toLocaleString("ja-JP")}
+                {new Date(session.started_at).toLocaleString("ja-JP", {
+                  timeZone: "Asia/Tokyo",
+                })}
               </div>
             </div>
             <div>
@@ -171,7 +173,9 @@ export function SessionDetail({ session, billId }: SessionDetailProps) {
                         {message.content}
                       </TableCell>
                       <TableCell className="text-gray-500 text-sm">
-                        {new Date(message.created_at).toLocaleString("ja-JP")}
+                        {new Date(message.created_at).toLocaleString("ja-JP", {
+                          timeZone: "Asia/Tokyo",
+                        })}
                       </TableCell>
                     </TableRow>
                   ))}

--- a/admin/src/features/interview-reports/server/components/session-list.tsx
+++ b/admin/src/features/interview-reports/server/components/session-list.tsx
@@ -138,6 +138,7 @@ export function SessionList({
                         day: "2-digit",
                         hour: "2-digit",
                         minute: "2-digit",
+                        timeZone: "Asia/Tokyo",
                       })}
                     </div>
                   </TableCell>

--- a/web/src/features/interview-report/shared/utils/report-utils.test.ts
+++ b/web/src/features/interview-report/shared/utils/report-utils.test.ts
@@ -15,20 +15,21 @@ describe("formatDateTime", () => {
     expect(formatDateTime("")).toBe("-");
   });
 
-  it("formats a date string correctly", () => {
-    // 2025-01-15T14:30:00 in local time
-    const date = new Date(2025, 0, 15, 14, 30, 0);
-    expect(formatDateTime(date.toISOString())).toBe("2025年1月15日  14:30");
+  it("formats a UTC date string in JST", () => {
+    // UTC 05:30 -> JST 14:30
+    expect(formatDateTime("2025-01-15T05:30:00Z")).toBe("2025年1月15日  14:30");
   });
 
   it("pads hours and minutes with leading zeros", () => {
-    const date = new Date(2025, 2, 5, 3, 5, 0);
-    expect(formatDateTime(date.toISOString())).toBe("2025年3月5日  03:05");
+    // UTC 18:05 (前日) -> JST 03:05 (翌日)
+    expect(formatDateTime("2025-03-04T18:05:00Z")).toBe("2025年3月5日  03:05");
   });
 
-  it("handles midnight correctly", () => {
-    const date = new Date(2025, 11, 31, 0, 0, 0);
-    expect(formatDateTime(date.toISOString())).toBe("2025年12月31日  00:00");
+  it("handles midnight JST correctly", () => {
+    // UTC 15:00 -> JST 00:00 (翌日)
+    expect(formatDateTime("2025-12-30T15:00:00Z")).toBe(
+      "2025年12月31日  00:00"
+    );
   });
 });
 

--- a/web/src/features/interview-report/shared/utils/report-utils.ts
+++ b/web/src/features/interview-report/shared/utils/report-utils.ts
@@ -1,15 +1,21 @@
 /**
- * 日時フォーマット
+ * 日時フォーマット（日本時間）
  */
 export function formatDateTime(dateString: string | null): string {
   if (!dateString) return "-";
   const date = new Date(dateString);
-  const year = date.getFullYear();
-  const month = date.getMonth() + 1;
-  const day = date.getDate();
-  const hours = date.getHours().toString().padStart(2, "0");
-  const minutes = date.getMinutes().toString().padStart(2, "0");
-  return `${year}年${month}月${day}日  ${hours}:${minutes}`;
+  const formatter = new Intl.DateTimeFormat("ja-JP", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    timeZone: "Asia/Tokyo",
+  });
+  const parts = formatter.formatToParts(date);
+  const get = (type: Intl.DateTimeFormatPartTypes) =>
+    parts.find((p) => p.type === type)?.value ?? "";
+  return `${get("year")}年${get("month")}月${get("day")}日  ${get("hour")}:${get("minute")}`;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Server Componentで実行される日時フォーマットがサーバーのタイムゾーン（UTC）で表示されていた問題を修正
- `web` の `formatDateTime()` を `Intl.DateTimeFormat` + `timeZone: "Asia/Tokyo"` に書き換え
- `admin` の `session-list.tsx` / `session-detail.tsx` の `toLocaleString()` に `timeZone: "Asia/Tokyo"` を追加
- テストをUTC入力→JST期待値に書き換え、タイムゾーン非依存に改善

## 対象ファイル
- `web/src/features/interview-report/shared/utils/report-utils.ts`
- `web/src/features/interview-report/shared/utils/report-utils.test.ts`
- `admin/src/features/interview-reports/server/components/session-list.tsx`
- `admin/src/features/interview-reports/server/components/session-detail.tsx`

## Test plan
- [x] `pnpm lint` 通過
- [x] `pnpm typecheck` 通過
- [x] `pnpm test` 全603テスト通過
- [x] Codex CLIレビュー通過（指摘なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)