### PR TITLE
fix: 主な意見マージン変更をインタビューページのみに適用

### DIFF
--- a/web/src/features/interview-report/shared/components/opinions-list.tsx
+++ b/web/src/features/interview-report/shared/components/opinions-list.tsx
@@ -25,7 +25,7 @@ export function OpinionsList({
   return (
     <div className="flex flex-col gap-4">
       <h2 className="text-xl font-bold text-gray-800">{title}</h2>
-      <div className="bg-white rounded-2xl p-6 flex flex-col gap-12">
+      <div className="bg-white rounded-2xl p-6 flex flex-col gap-6">
         {opinions.map((opinion, index) => (
           <div
             key={`opinion-${index}-${opinion.title.slice(0, 20)}`}

--- a/web/src/features/interview-session/client/components/interview-summary.tsx
+++ b/web/src/features/interview-session/client/components/interview-summary.tsx
@@ -51,7 +51,7 @@ export function InterviewSummary({ report }: Props) {
         {opinions.length > 0 && (
           <div className="space-y-1">
             <p className="font-bold text-primary-accent">💬主な意見</p>
-            <ul className="space-y-2">
+            <ul className="space-y-4">
               {opinions.map((op, index) => (
                 <li
                   key={`${op.title}-${op.content}`}


### PR DESCRIPTION
## Summary
- #446 で `OpinionsList`（共有コンポーネント）の `gap-6` → `gap-12` に変更したが、本来の対象はインタビューページ内のレポート表示だった
- `OpinionsList`（レポートページ用）を `gap-6` に戻す
- `interview-summary.tsx`（インタビューページ内）の主な意見リストを `space-y-2` → `space-y-4` に変更

## Test plan
- [ ] レポートページの主な意見リストのマージンが元通り（`gap-6`）であること
- [ ] インタビューページ内のレポート表示の主な意見リストのマージンが広がっている（`space-y-4`）こと

🤖 Generated with [Claude Code](https://claude.com/claude-code)