### PR TITLE
fix: general_citizenのラベルを「一般的な関心」に変更

### DIFF
--- a/admin/src/features/interview-reports/shared/constants.ts
+++ b/admin/src/features/interview-reports/shared/constants.ts
@@ -17,7 +17,7 @@ export const roleLabels: Record<InterviewReportRole, string> = {
   subject_expert: "専門的な有識者",
   work_related: "業務に関係",
   daily_life_affected: "暮らしに影響",
-  general_citizen: "一市民として関心",
+  general_citizen: "一般的な関心",
 };
 
 import { formatRoleLabel as formatRoleLabelPure } from "./utils/format-role-label";

--- a/admin/src/features/interview-reports/shared/utils/format-role-label.test.ts
+++ b/admin/src/features/interview-reports/shared/utils/format-role-label.test.ts
@@ -5,7 +5,7 @@ const roleLabels: Record<string, string> = {
   subject_expert: "専門的な有識者",
   work_related: "業務に関係",
   daily_life_affected: "暮らしに影響",
-  general_citizen: "一市民として関心",
+  general_citizen: "一般的な関心",
 };
 
 describe("formatRoleLabel", () => {
@@ -41,7 +41,7 @@ describe("formatRoleLabel", () => {
 
   it("roleTitleがundefinedの場合", () => {
     expect(formatRoleLabel("general_citizen", undefined, roleLabels)).toBe(
-      "一市民として関心"
+      "一般的な関心"
     );
   });
 });

--- a/web/src/features/interview-report/shared/constants.test.ts
+++ b/web/src/features/interview-report/shared/constants.test.ts
@@ -7,7 +7,7 @@ describe("formatRoleLabel", () => {
     expect(formatRoleLabel("subject_expert")).toBe("専門的な有識者");
     expect(formatRoleLabel("work_related")).toBe("業務に関係");
     expect(formatRoleLabel("daily_life_affected")).toBe("暮らしに影響");
-    expect(formatRoleLabel("general_citizen")).toBe("一市民として関心");
+    expect(formatRoleLabel("general_citizen")).toBe("一般的な関心");
   });
 
   it("returns role string as-is when role is not in roleLabels", () => {

--- a/web/src/features/interview-report/shared/constants.ts
+++ b/web/src/features/interview-report/shared/constants.ts
@@ -26,7 +26,7 @@ export const roleLabels: Record<InterviewReportRole, string> = {
   subject_expert: "専門的な有識者",
   work_related: "業務に関係",
   daily_life_affected: "暮らしに影響",
-  general_citizen: "一市民として関心",
+  general_citizen: "一般的な関心",
 };
 
 /**

--- a/web/src/features/interview-session/shared/schemas.ts
+++ b/web/src/features/interview-session/shared/schemas.ts
@@ -56,7 +56,7 @@ export const interviewReportSchema = z
       ])
       .nullable()
       .describe(
-        "インタビュイーの立場タイプ（subject_expert:専門的な有識者, work_related:業務に関係, daily_life_affected:暮らしに影響, general_citizen:一市民として関心）"
+        "インタビュイーの立場タイプ（subject_expert:専門的な有識者, work_related:業務に関係, daily_life_affected:暮らしに影響, general_citizen:一般的な関心）"
       ),
     role_description: z
       .string()

--- a/web/src/features/interview-session/shared/utils/build-summary-system-prompt.ts
+++ b/web/src/features/interview-session/shared/utils/build-summary-system-prompt.ts
@@ -62,7 +62,7 @@ ${conversationLog}
   - subject_expert: 専門的な有識者
   - work_related: 業務に関係
   - daily_life_affected: 暮らしに影響
-  - general_citizen: 一市民として関心
+  - general_citizen: 一般的な関心
 
 ### 4. role_description（立場の詳細説明）
 - 立場・属性の詳細説明（例：「10年間アジア航路を担当しており、フォワーダーとして豊富な実務経験を持つ」）


### PR DESCRIPTION
## Summary
- `general_citizen` の役割ラベルを「一市民として関心」から「一般的な関心」に変更
- web/admin両方のconstants、テスト、zodスキーマのdescription、プロンプトを一括更新

## 変更ファイル
- `web/src/features/interview-report/shared/constants.ts`
- `web/src/features/interview-report/shared/constants.test.ts`
- `admin/src/features/interview-reports/shared/constants.ts`
- `admin/src/features/interview-reports/shared/utils/format-role-label.test.ts`
- `web/src/features/interview-session/shared/schemas.ts`
- `web/src/features/interview-session/shared/utils/build-summary-system-prompt.ts`

## Test plan
- [x] `pnpm lint` 通過
- [x] `pnpm typecheck` 通過
- [x] `pnpm test` 全テスト通過（テスト期待値も更新済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)