### PR TITLE
refactor: OpinionsListから「背景」ラベルを削除

### DIFF
--- a/web/src/features/interview-report/server/components/report-chat-log-page.tsx
+++ b/web/src/features/interview-report/server/components/report-chat-log-page.tsx
@@ -81,7 +81,7 @@ export async function ReportChatLogPage({ reportId }: ReportChatLogPageProps) {
           </div>
 
           {/* Opinions Section */}
-          <OpinionsList opinions={opinions} showBackground={false} />
+          <OpinionsList opinions={opinions} />
 
           {/* Back to Bill Button */}
           <div className="flex flex-col gap-3">

--- a/web/src/features/interview-report/server/components/report-complete-page.tsx
+++ b/web/src/features/interview-report/server/components/report-complete-page.tsx
@@ -145,7 +145,6 @@ export async function ReportCompletePage({
             <OpinionsList
               opinions={opinions}
               title="💬主な意見"
-              showBackground={true}
               footer={
                 <Link
                   href={getInterviewChatLogLink(reportId)}

--- a/web/src/features/interview-report/shared/components/opinions-list.tsx
+++ b/web/src/features/interview-report/shared/components/opinions-list.tsx
@@ -8,14 +8,12 @@ export interface Opinion {
 interface OpinionsListProps {
   opinions: Opinion[];
   title?: string;
-  showBackground?: boolean;
   footer?: ReactNode;
 }
 
 export function OpinionsList({
   opinions,
   title = "💬意見の要約",
-  showBackground = true,
   footer,
 }: OpinionsListProps) {
   if (opinions.length === 0) {
@@ -41,14 +39,7 @@ export function OpinionsList({
                 {opinion.title}
               </p>
             </div>
-            {showBackground ? (
-              <div className="flex flex-col gap-1">
-                <p className="text-sm font-bold text-gray-500">背景</p>
-                <p className="text-sm text-gray-800">{opinion.content}</p>
-              </div>
-            ) : (
-              <p className="text-sm text-gray-600">{opinion.content}</p>
-            )}
+            <p className="text-sm text-gray-600">{opinion.content}</p>
           </div>
         ))}
         {footer}


### PR DESCRIPTION
## Summary
- レポートページの意見リストで、各意見ごとに繰り返し表示されていた「背景」ラベルを削除
- 不要になった `showBackground` prop を `OpinionsList` コンポーネントから削除
- 呼び出し元（report-complete-page, report-chat-log-page）のprop指定も合わせて削除

## Test plan
- [x] `pnpm lint` パス
- [x] `pnpm typecheck` パス
- [x] `pnpm test` 全616テストパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)