### PR TITLE
fix: スキップボタンの下線をhover時のみ表示に変更

### DIFF
--- a/web/src/features/interview-session/client/components/interview-progress-bar.tsx
+++ b/web/src/features/interview-session/client/components/interview-progress-bar.tsx
@@ -36,7 +36,7 @@ export function InterviewProgressBar({
                 variant="link"
                 onClick={onSkip}
                 disabled={disabled}
-                className="ml-2 h-auto shrink-0 p-0 text-sm font-bold text-[#0F8472] hover:no-underline"
+                className="ml-2 h-auto shrink-0 p-0 text-sm font-bold text-[#0F8472] no-underline hover:underline"
               >
                 スキップする
               </Button>


### PR DESCRIPTION
## Summary
- インタビュー画面の「スキップする」ボタンのデフォルト下線を削除し、hover時のみ下線を表示するように変更

## Changes
- `no-underline hover:underline` に変更（従来は `hover:no-underline`）

## Test plan
- [ ] インタビュー画面でプログレスバーの「スキップする」ボタンにデフォルト下線がないことを確認
- [ ] hover時に下線が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)