### PR TITLE
fix: 会話ログページのパンくずリストでレポートをリンクにする

### DIFF
--- a/web/src/features/interview-report/server/components/report-chat-log-page.tsx
+++ b/web/src/features/interview-report/server/components/report-chat-log-page.tsx
@@ -91,6 +91,7 @@ export async function ReportChatLogPage({ reportId }: ReportChatLogPageProps) {
           {/* Breadcrumb Navigation */}
           <ReportBreadcrumb
             billId={report.bill_id}
+            reportId={reportId}
             additionalItems={[{ label: "すべての会話ログ" }]}
           />
         </div>

--- a/web/src/features/interview-report/shared/components/report-breadcrumb.tsx
+++ b/web/src/features/interview-report/shared/components/report-breadcrumb.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import {
   getBillDetailLink,
   getInterviewLPLink,
+  getInterviewReportCompleteLink,
 } from "@/features/interview-config/shared/utils/interview-links";
 
 interface BreadcrumbItem {
@@ -12,18 +13,23 @@ interface BreadcrumbItem {
 
 interface ReportBreadcrumbProps {
   billId: string;
+  reportId?: string;
   additionalItems?: BreadcrumbItem[];
 }
 
 export function ReportBreadcrumb({
   billId,
+  reportId,
   additionalItems = [],
 }: ReportBreadcrumbProps) {
   const baseItems: BreadcrumbItem[] = [
     { label: "TOP", href: "/" },
     { label: "法案詳細", href: getBillDetailLink(billId) },
     { label: "AIインタビュー", href: getInterviewLPLink(billId) },
-    { label: "レポート" },
+    {
+      label: "レポート",
+      href: reportId ? getInterviewReportCompleteLink(reportId) : undefined,
+    },
   ];
 
   const allItems = [...baseItems, ...additionalItems];


### PR DESCRIPTION
## Summary
- 会話ログページ（`/report/{reportId}/chat-log`）のパンくずリストで「レポート」の項目をレポート完了ページへのリンクに変更
- `ReportBreadcrumb` コンポーネントにオプショナルな `reportId` プロパティを追加し、指定時に「レポート」をクリック可能にした
- レポート完了ページ側のパンくずでは従来通りリンクなしのテキスト表示（現在のページのため）

## Test plan
- [x] `pnpm lint` パス
- [x] `pnpm typecheck` パス
- [x] `pnpm test` パス（全テスト通過）

🤖 Generated with [Claude Code](https://claude.com/claude-code)