### PR TITLE
refactor: インタビューと記事コンテンツでキャッシュタグを分離

### DIFF
--- a/admin/src/features/bills-edit/server/actions/create-bill.ts
+++ b/admin/src/features/bills-edit/server/actions/create-bill.ts
@@ -2,7 +2,10 @@
 
 import { redirect } from "next/navigation";
 import { requireAdmin } from "@/features/auth/server/lib/auth-server";
-import { invalidateWebCache } from "@/lib/utils/cache-invalidation";
+import {
+  WEB_CACHE_TAGS,
+  invalidateWebCache,
+} from "@/lib/utils/cache-invalidation";
 import { getErrorMessage } from "@/lib/utils/get-error-message";
 import { type BillCreateInput, billCreateSchema } from "../../shared/types";
 import { createBillRecord } from "../repositories/bill-edit-repository";
@@ -26,7 +29,7 @@ export async function createBill(input: BillCreateInput) {
     await createBillRecord(insertData);
 
     // web側のキャッシュを無効化
-    await invalidateWebCache();
+    await invalidateWebCache([WEB_CACHE_TAGS.BILLS]);
   } catch (error) {
     console.error("Create bill error:", error);
     throw new Error(

--- a/admin/src/features/bills-edit/server/actions/update-bill-contents.ts
+++ b/admin/src/features/bills-edit/server/actions/update-bill-contents.ts
@@ -1,7 +1,10 @@
 "use server";
 
 import { requireAdmin } from "@/features/auth/server/lib/auth-server";
-import { invalidateWebCache } from "@/lib/utils/cache-invalidation";
+import {
+  WEB_CACHE_TAGS,
+  invalidateWebCache,
+} from "@/lib/utils/cache-invalidation";
 import { getErrorMessage } from "@/lib/utils/get-error-message";
 import {
   type BillContentsUpdateInput,
@@ -48,7 +51,7 @@ export async function updateBillContents(
     await Promise.all(upsertPromises);
 
     // web側のキャッシュを無効化
-    await invalidateWebCache();
+    await invalidateWebCache([WEB_CACHE_TAGS.BILLS]);
 
     return { success: true };
   } catch (error) {

--- a/admin/src/features/bills-edit/server/actions/update-bill-tags.ts
+++ b/admin/src/features/bills-edit/server/actions/update-bill-tags.ts
@@ -2,7 +2,10 @@
 
 import { requireAdmin } from "@/features/auth/server/lib/auth-server";
 import { calculateSetDiff } from "@/lib/utils/calculate-set-diff";
-import { invalidateWebCache } from "@/lib/utils/cache-invalidation";
+import {
+  WEB_CACHE_TAGS,
+  invalidateWebCache,
+} from "@/lib/utils/cache-invalidation";
 import { getErrorMessage } from "@/lib/utils/get-error-message";
 import {
   findBillsTagsByBillId,
@@ -32,7 +35,7 @@ export async function updateBillTags(billId: string, tagIds: string[]) {
     }
 
     // キャッシュを更新
-    await invalidateWebCache();
+    await invalidateWebCache([WEB_CACHE_TAGS.BILLS]);
 
     return { success: true };
   } catch (error) {

--- a/admin/src/features/bills-edit/server/actions/update-bill.ts
+++ b/admin/src/features/bills-edit/server/actions/update-bill.ts
@@ -1,7 +1,10 @@
 "use server";
 
 import { requireAdmin } from "@/features/auth/server/lib/auth-server";
-import { invalidateWebCache } from "@/lib/utils/cache-invalidation";
+import {
+  WEB_CACHE_TAGS,
+  invalidateWebCache,
+} from "@/lib/utils/cache-invalidation";
 import { getErrorMessage } from "@/lib/utils/get-error-message";
 import { type BillUpdateInput, billUpdateSchema } from "../../shared/types";
 import { updateBillRecord } from "../repositories/bill-edit-repository";
@@ -24,7 +27,7 @@ export async function updateBill(id: string, input: BillUpdateInput) {
     });
 
     // web側のキャッシュを無効化
-    await invalidateWebCache();
+    await invalidateWebCache([WEB_CACHE_TAGS.BILLS]);
   } catch (error) {
     console.error("Update bill error:", error);
     throw new Error(

--- a/admin/src/features/bills/server/actions/update-publish-status.ts
+++ b/admin/src/features/bills/server/actions/update-publish-status.ts
@@ -2,7 +2,10 @@
 
 import { revalidatePath } from "next/cache";
 import { requireAdmin } from "@/features/auth/server/lib/auth-server";
-import { invalidateWebCache } from "@/lib/utils/cache-invalidation";
+import {
+  WEB_CACHE_TAGS,
+  invalidateWebCache,
+} from "@/lib/utils/cache-invalidation";
 import type { BillPublishStatus } from "../../shared/types";
 import { updateBillPublishStatus } from "../repositories/bill-repository";
 
@@ -39,7 +42,7 @@ async function _updateBillPublishStatus(
     await updateBillPublishStatus(billId, publishStatus);
 
     // web側のキャッシュを無効化
-    await invalidateWebCache();
+    await invalidateWebCache([WEB_CACHE_TAGS.BILLS]);
 
     return { success: true };
   } catch (error) {

--- a/admin/src/features/diet-sessions/server/actions/create-diet-session.ts
+++ b/admin/src/features/diet-sessions/server/actions/create-diet-session.ts
@@ -1,7 +1,10 @@
 "use server";
 
 import { requireAdmin } from "@/features/auth/server/lib/auth-server";
-import { invalidateWebCache } from "@/lib/utils/cache-invalidation";
+import {
+  WEB_CACHE_TAGS,
+  invalidateWebCache,
+} from "@/lib/utils/cache-invalidation";
 import { getErrorMessage } from "@/lib/utils/get-error-message";
 import { trimOrNull } from "@/lib/utils/normalize-string";
 import type { CreateDietSessionInput } from "../../shared/types";
@@ -44,7 +47,7 @@ export async function createDietSession(input: CreateDietSessionInput) {
       end_date: input.end_date,
     });
 
-    await invalidateWebCache();
+    await invalidateWebCache([WEB_CACHE_TAGS.DIET_SESSIONS]);
     return { data };
   } catch (error) {
     console.error("Create diet session error:", error);

--- a/admin/src/features/diet-sessions/server/actions/delete-diet-session.ts
+++ b/admin/src/features/diet-sessions/server/actions/delete-diet-session.ts
@@ -1,7 +1,10 @@
 "use server";
 
 import { requireAdmin } from "@/features/auth/server/lib/auth-server";
-import { invalidateWebCache } from "@/lib/utils/cache-invalidation";
+import {
+  WEB_CACHE_TAGS,
+  invalidateWebCache,
+} from "@/lib/utils/cache-invalidation";
 import { getErrorMessage } from "@/lib/utils/get-error-message";
 import type { DeleteDietSessionInput } from "../../shared/types";
 import { deleteDietSessionRecord } from "../repositories/diet-session-repository";
@@ -12,7 +15,7 @@ export async function deleteDietSession(input: DeleteDietSessionInput) {
 
     await deleteDietSessionRecord(input.id);
 
-    await invalidateWebCache();
+    await invalidateWebCache([WEB_CACHE_TAGS.DIET_SESSIONS]);
     return { success: true };
   } catch (error) {
     console.error("Delete diet session error:", error);

--- a/admin/src/features/diet-sessions/server/actions/set-active-diet-session.ts
+++ b/admin/src/features/diet-sessions/server/actions/set-active-diet-session.ts
@@ -1,7 +1,10 @@
 "use server";
 
 import { requireAdmin } from "@/features/auth/server/lib/auth-server";
-import { invalidateWebCache } from "@/lib/utils/cache-invalidation";
+import {
+  WEB_CACHE_TAGS,
+  invalidateWebCache,
+} from "@/lib/utils/cache-invalidation";
 import { getErrorMessage } from "@/lib/utils/get-error-message";
 import {
   setActiveDietSessionRecord,
@@ -23,7 +26,10 @@ export async function setActiveDietSession(input: SetActiveDietSessionInput) {
     // Fetch the updated session to return
     const data = await findDietSessionById(input.id);
 
-    await invalidateWebCache();
+    await invalidateWebCache([
+      WEB_CACHE_TAGS.DIET_SESSIONS,
+      WEB_CACHE_TAGS.BILLS,
+    ]);
     return { data };
   } catch (error) {
     console.error("Set active diet session error:", error);

--- a/admin/src/features/diet-sessions/server/actions/update-diet-session.ts
+++ b/admin/src/features/diet-sessions/server/actions/update-diet-session.ts
@@ -1,7 +1,10 @@
 "use server";
 
 import { requireAdmin } from "@/features/auth/server/lib/auth-server";
-import { invalidateWebCache } from "@/lib/utils/cache-invalidation";
+import {
+  WEB_CACHE_TAGS,
+  invalidateWebCache,
+} from "@/lib/utils/cache-invalidation";
 import { getErrorMessage } from "@/lib/utils/get-error-message";
 import { trimOrNull } from "@/lib/utils/normalize-string";
 import type { UpdateDietSessionInput } from "../../shared/types";
@@ -44,7 +47,7 @@ export async function updateDietSession(input: UpdateDietSessionInput) {
       end_date: input.end_date,
     });
 
-    await invalidateWebCache();
+    await invalidateWebCache([WEB_CACHE_TAGS.DIET_SESSIONS]);
     return { data };
   } catch (error) {
     console.error("Update diet session error:", error);

--- a/admin/src/features/interview-config/server/actions/save-interview-questions.ts
+++ b/admin/src/features/interview-config/server/actions/save-interview-questions.ts
@@ -1,7 +1,10 @@
 "use server";
 
 import { requireAdmin } from "@/features/auth/server/lib/auth-server";
-import { invalidateWebCache } from "@/lib/utils/cache-invalidation";
+import {
+  WEB_CACHE_TAGS,
+  invalidateWebCache,
+} from "@/lib/utils/cache-invalidation";
 import { getErrorMessage } from "@/lib/utils/get-error-message";
 import {
   type InterviewQuestionsInput,
@@ -32,7 +35,7 @@ export async function saveInterviewQuestions(
 
     // 質問が空の場合はここで終了
     if (validatedQuestions.length === 0) {
-      await invalidateWebCache();
+      await invalidateWebCache([WEB_CACHE_TAGS.INTERVIEW_CONFIGS]);
       return { success: true };
     }
 
@@ -45,7 +48,7 @@ export async function saveInterviewQuestions(
     await createInterviewQuestions(questionsToInsert);
 
     // web側のキャッシュを無効化
-    await invalidateWebCache();
+    await invalidateWebCache([WEB_CACHE_TAGS.INTERVIEW_CONFIGS]);
 
     return { success: true };
   } catch (error) {

--- a/admin/src/features/interview-config/server/actions/upsert-interview-config.ts
+++ b/admin/src/features/interview-config/server/actions/upsert-interview-config.ts
@@ -1,7 +1,10 @@
 "use server";
 
 import { requireAdmin } from "@/features/auth/server/lib/auth-server";
-import { invalidateWebCache } from "@/lib/utils/cache-invalidation";
+import {
+  WEB_CACHE_TAGS,
+  invalidateWebCache,
+} from "@/lib/utils/cache-invalidation";
 import { getErrorMessage } from "@/lib/utils/get-error-message";
 import {
   type InterviewConfigInput,
@@ -54,7 +57,7 @@ export async function createInterviewConfig(
     });
 
     // web側のキャッシュを無効化
-    await invalidateWebCache();
+    await invalidateWebCache([WEB_CACHE_TAGS.INTERVIEW_CONFIGS]);
 
     return { success: true, data: { id: data.id } };
   } catch (error) {
@@ -102,7 +105,7 @@ export async function updateInterviewConfig(
     });
 
     // web側のキャッシュを無効化
-    await invalidateWebCache();
+    await invalidateWebCache([WEB_CACHE_TAGS.INTERVIEW_CONFIGS]);
 
     return { success: true, data: { id: data.id } };
   } catch (error) {
@@ -179,7 +182,7 @@ export async function duplicateInterviewConfig(
     }
 
     // web側のキャッシュを無効化
-    await invalidateWebCache();
+    await invalidateWebCache([WEB_CACHE_TAGS.INTERVIEW_CONFIGS]);
 
     return { success: true, data: { id: newConfig.id } };
   } catch (error) {
@@ -206,7 +209,7 @@ export async function deleteInterviewConfig(
     await deleteInterviewConfigRecord(configId);
 
     // web側のキャッシュを無効化
-    await invalidateWebCache();
+    await invalidateWebCache([WEB_CACHE_TAGS.INTERVIEW_CONFIGS]);
 
     return { success: true, data: { id: configId } };
   } catch (error) {

--- a/admin/src/features/mirai-stance/server/actions/create-stance.ts
+++ b/admin/src/features/mirai-stance/server/actions/create-stance.ts
@@ -1,6 +1,9 @@
 "use server";
 
-import { invalidateWebCache } from "@/lib/utils/cache-invalidation";
+import {
+  WEB_CACHE_TAGS,
+  invalidateWebCache,
+} from "@/lib/utils/cache-invalidation";
 import { getErrorMessage } from "@/lib/utils/get-error-message";
 import type { StanceInput } from "../../shared/types";
 import { createMiraiStance } from "../repositories/mirai-stance-repository";
@@ -9,7 +12,7 @@ export async function createStance(billId: string, data: StanceInput) {
   try {
     await createMiraiStance(billId, data);
 
-    invalidateWebCache();
+    invalidateWebCache([WEB_CACHE_TAGS.BILLS]);
     return { success: true };
   } catch (error) {
     console.error("Error in createStance:", error);

--- a/admin/src/features/mirai-stance/server/actions/delete-stance.ts
+++ b/admin/src/features/mirai-stance/server/actions/delete-stance.ts
@@ -1,6 +1,9 @@
 "use server";
 
-import { invalidateWebCache } from "@/lib/utils/cache-invalidation";
+import {
+  WEB_CACHE_TAGS,
+  invalidateWebCache,
+} from "@/lib/utils/cache-invalidation";
 import { getErrorMessage } from "@/lib/utils/get-error-message";
 import { deleteMiraiStance } from "../repositories/mirai-stance-repository";
 
@@ -8,7 +11,7 @@ export async function deleteStance(stanceId: string) {
   try {
     await deleteMiraiStance(stanceId);
 
-    invalidateWebCache();
+    invalidateWebCache([WEB_CACHE_TAGS.BILLS]);
     return { success: true };
   } catch (error) {
     console.error("Error in deleteStance:", error);

--- a/admin/src/features/mirai-stance/server/actions/update-stance.ts
+++ b/admin/src/features/mirai-stance/server/actions/update-stance.ts
@@ -1,6 +1,9 @@
 "use server";
 
-import { invalidateWebCache } from "@/lib/utils/cache-invalidation";
+import {
+  WEB_CACHE_TAGS,
+  invalidateWebCache,
+} from "@/lib/utils/cache-invalidation";
 import { getErrorMessage } from "@/lib/utils/get-error-message";
 import type { StanceInput } from "../../shared/types";
 import { updateMiraiStance } from "../repositories/mirai-stance-repository";
@@ -9,7 +12,7 @@ export async function updateStance(stanceId: string, data: StanceInput) {
   try {
     await updateMiraiStance(stanceId, data);
 
-    invalidateWebCache();
+    invalidateWebCache([WEB_CACHE_TAGS.BILLS]);
     return { success: true };
   } catch (error) {
     console.error("Error in updateStance:", error);

--- a/admin/src/features/tags/server/actions/create-tag.ts
+++ b/admin/src/features/tags/server/actions/create-tag.ts
@@ -1,7 +1,10 @@
 "use server";
 
 import { requireAdmin } from "@/features/auth/server/lib/auth-server";
-import { invalidateWebCache } from "@/lib/utils/cache-invalidation";
+import {
+  WEB_CACHE_TAGS,
+  invalidateWebCache,
+} from "@/lib/utils/cache-invalidation";
 import { getErrorMessage } from "@/lib/utils/get-error-message";
 import type { CreateTagInput } from "../../shared/types";
 import { mapTagDbError } from "../../shared/utils/map-tag-db-error";
@@ -25,7 +28,7 @@ export async function createTag(input: CreateTagInput) {
     }
 
     // web側のキャッシュを無効化
-    await invalidateWebCache();
+    await invalidateWebCache([WEB_CACHE_TAGS.BILLS]);
 
     return { data: result.data };
   } catch (error) {

--- a/admin/src/features/tags/server/actions/delete-tag.ts
+++ b/admin/src/features/tags/server/actions/delete-tag.ts
@@ -1,7 +1,10 @@
 "use server";
 
 import { requireAdmin } from "@/features/auth/server/lib/auth-server";
-import { invalidateWebCache } from "@/lib/utils/cache-invalidation";
+import {
+  WEB_CACHE_TAGS,
+  invalidateWebCache,
+} from "@/lib/utils/cache-invalidation";
 import { getErrorMessage } from "@/lib/utils/get-error-message";
 import type { DeleteTagInput } from "../../shared/types";
 import { mapTagDbError } from "../../shared/utils/map-tag-db-error";
@@ -18,7 +21,7 @@ export async function deleteTag(input: DeleteTagInput) {
     }
 
     // web側のキャッシュを無効化
-    await invalidateWebCache();
+    await invalidateWebCache([WEB_CACHE_TAGS.BILLS]);
 
     return { success: true };
   } catch (error) {

--- a/admin/src/features/tags/server/actions/update-tag.ts
+++ b/admin/src/features/tags/server/actions/update-tag.ts
@@ -1,7 +1,10 @@
 "use server";
 
 import { requireAdmin } from "@/features/auth/server/lib/auth-server";
-import { invalidateWebCache } from "@/lib/utils/cache-invalidation";
+import {
+  WEB_CACHE_TAGS,
+  invalidateWebCache,
+} from "@/lib/utils/cache-invalidation";
 import { getErrorMessage } from "@/lib/utils/get-error-message";
 import type { UpdateTagInput } from "../../shared/types";
 import { mapTagDbError } from "../../shared/utils/map-tag-db-error";
@@ -27,7 +30,7 @@ export async function updateTag(input: UpdateTagInput) {
     }
 
     // web側のキャッシュを無効化
-    await invalidateWebCache();
+    await invalidateWebCache([WEB_CACHE_TAGS.BILLS]);
 
     return { data: result.data };
   } catch (error) {

--- a/admin/src/lib/utils/cache-invalidation.ts
+++ b/admin/src/lib/utils/cache-invalidation.ts
@@ -2,9 +2,22 @@ import { env } from "../env";
 import { logger } from "../logger";
 
 /**
- * Invalidate all caches in the web application
+ * Web側で定義されているキャッシュタグと同じ値
+ * web/src/lib/cache-tags.ts と同期を保つこと
  */
-export async function invalidateWebCache(): Promise<void> {
+export const WEB_CACHE_TAGS = {
+  BILLS: "bills",
+  DIET_SESSIONS: "diet-sessions",
+  INTERVIEW_CONFIGS: "interview-configs",
+} as const;
+
+export type WebCacheTag = (typeof WEB_CACHE_TAGS)[keyof typeof WEB_CACHE_TAGS];
+
+/**
+ * Invalidate specific cache tags in the web application.
+ * If no tags are specified, all caches are invalidated.
+ */
+export async function invalidateWebCache(tags?: WebCacheTag[]): Promise<void> {
   if (!env.webUrl || !env.revalidateSecret) {
     console.warn(
       "Web URL or revalidate secret not configured, skipping cache invalidation"
@@ -19,6 +32,7 @@ export async function invalidateWebCache(): Promise<void> {
         "Content-Type": "application/json",
         Authorization: `Bearer ${env.revalidateSecret}`,
       },
+      body: tags ? JSON.stringify({ tags }) : undefined,
     });
 
     if (!response.ok) {

--- a/web/src/app/api/revalidate/route.ts
+++ b/web/src/app/api/revalidate/route.ts
@@ -1,6 +1,6 @@
 import { revalidateTag } from "next/cache";
 import { type NextRequest, NextResponse } from "next/server";
-import { CACHE_TAGS } from "@/lib/cache-tags";
+import { ALL_CACHE_TAGS, type CacheTag } from "@/lib/cache-tags";
 import { env } from "@/lib/env";
 
 export async function POST(request: NextRequest) {
@@ -19,13 +19,23 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    // Revalidate all cache tags
-    revalidateTag(CACHE_TAGS.BILLS);
-    revalidateTag(CACHE_TAGS.DIET_SESSIONS);
+    // tagsが指定されていれば対象のみ、なければ全タグを無効化
+    const body = await request.json().catch(() => null);
+    const requestedTags: CacheTag[] =
+      body?.tags && Array.isArray(body.tags) ? body.tags : ALL_CACHE_TAGS;
+
+    const revalidatedTags: string[] = [];
+    for (const tag of requestedTags) {
+      if ((ALL_CACHE_TAGS as readonly string[]).includes(tag)) {
+        revalidateTag(tag);
+        revalidatedTags.push(tag);
+      }
+    }
 
     return NextResponse.json({
       success: true,
       revalidated: true,
+      tags: revalidatedTags,
       timestamp: Date.now(),
     });
   } catch (error) {

--- a/web/src/features/interview-config/server/loaders/get-interview-config-admin.ts
+++ b/web/src/features/interview-config/server/loaders/get-interview-config-admin.ts
@@ -51,6 +51,6 @@ const _getCachedInterviewConfigAdmin = unstable_cache(
   ["interview-config-admin"],
   {
     revalidate: 60, // 非公開設定をプレビューするので短めに
-    tags: [CACHE_TAGS.BILLS],
+    tags: [CACHE_TAGS.INTERVIEW_CONFIGS],
   }
 );

--- a/web/src/features/interview-config/server/loaders/get-interview-config.ts
+++ b/web/src/features/interview-config/server/loaders/get-interview-config.ts
@@ -30,6 +30,6 @@ const _getCachedInterviewConfig = unstable_cache(
   ["interview-config"],
   {
     revalidate: 600, // 10分（600秒）
-    tags: [CACHE_TAGS.BILLS],
+    tags: [CACHE_TAGS.INTERVIEW_CONFIGS],
   }
 );

--- a/web/src/lib/cache-tags.ts
+++ b/web/src/lib/cache-tags.ts
@@ -4,6 +4,9 @@
 export const CACHE_TAGS = {
   BILLS: "bills",
   DIET_SESSIONS: "diet-sessions",
+  INTERVIEW_CONFIGS: "interview-configs",
 } as const;
 
 export type CacheTag = (typeof CACHE_TAGS)[keyof typeof CACHE_TAGS];
+
+export const ALL_CACHE_TAGS = Object.values(CACHE_TAGS);


### PR DESCRIPTION
## Summary

- キャッシュタグを `BILLS` / `DIET_SESSIONS` / `INTERVIEW_CONFIGS` の3つに分離
- 各admin actionから対象のキャッシュタグのみを無効化するよう変更（従来は全タグ一括無効化）
- revalidation APIがリクエストbodyの `tags` パラメータで選択的なタグ無効化に対応

### キャッシュ無効化マッピング

| 操作 | 無効化タグ |
|------|-----------|
| 法案 CRUD / タグ / みらいスタンス | `BILLS` |
| 国会会期 作成/更新/削除 | `DIET_SESSIONS` |
| アクティブセッション変更 | `DIET_SESSIONS` + `BILLS` |
| インタビュー設定 / 質問 CRUD | `INTERVIEW_CONFIGS` |

Resolves #183

## Test plan

- [x] `pnpm lint` 通過
- [x] `pnpm typecheck` 通過
- [x] `pnpm test` 全テスト通過（web: 616, admin: 138, shared: 10）
- [x] Codex CLIレビュー通過（指摘なし）
- [ ] admin でインタビュー設定を更新 → トップページの法案キャッシュが維持されることを確認
- [ ] admin で法案を更新 → インタビューページのキャッシュが維持されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)