### PR TITLE
fix: インタビューLPのバッジ文言を「当事者・有識者の方へ」に変更

### DIFF
--- a/web/src/features/interview-config/client/components/interview-lp-page.tsx
+++ b/web/src/features/interview-config/client/components/interview-lp-page.tsx
@@ -71,7 +71,7 @@ function _InterviewLPHero({
       <div className="flex flex-col items-center gap-3">
         <div className="inline-flex items-center justify-center gap-2 px-6 py-2 mb-3 bg-primary rounded-2xl">
           <span className="text-[15px] font-medium text-white leading-tight">
-            法案の当事者の方へ
+            当事者・有識者の方へ
           </span>
         </div>
         <h1 className="text-2xl font-bold text-center leading-[1.5]">


### PR DESCRIPTION
## Summary
- インタビューLPページのヒーローセクションにあるバッジの文言を「法案の当事者の方へ」から「当事者・有識者の方へ」に変更
- Figmaデザインに合わせた文言修正

## Test plan
- [x] `pnpm lint` 通過
- [x] `pnpm typecheck` 通過
- [x] `pnpm test` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)