### PR TITLE
feat: インタビューLPのアイコンをlucide-reactに変更

### DIFF
--- a/web/src/features/interview-config/client/components/interview-lp-page.tsx
+++ b/web/src/features/interview-config/client/components/interview-lp-page.tsx
@@ -1,4 +1,5 @@
-import { ArrowRight, Undo2 } from "lucide-react";
+import { ArrowRight, Ear, Landmark, MessagesSquare, Undo2 } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
@@ -16,23 +17,20 @@ interface InterviewLPPageProps {
   previewToken?: string;
 }
 
-const FEATURES = [
+const FEATURES: { icon: LucideIcon; text: string }[] = [
   {
-    icon: "/icons/interview-icon-1.svg",
-    iconWidth: 20,
+    icon: Ear,
     text: "AIがあなたの課題感や\nご経験をお聞きします",
   },
   {
-    icon: "/icons/interview-icon-2.svg",
-    iconWidth: 16,
+    icon: MessagesSquare,
     text: "ご意見はチームみらいの\n政策検討に活かします",
   },
   {
-    icon: "/icons/interview-icon-3.svg",
-    iconWidth: 24,
+    icon: Landmark,
     text: "あなたの声がチームみらいを通じて国会に届けられる可能性があります",
   },
-] as const;
+];
 
 function _InterviewLPHeader({ bill }: { bill: BillWithContent }) {
   return (
@@ -91,13 +89,7 @@ function _InterviewLPHero({
         {FEATURES.map((feature) => (
           <div key={feature.text} className="flex items-center gap-4">
             <div className="flex-shrink-0 w-[54px] h-[54px] bg-white rounded-[30px] flex items-center justify-center">
-              <Image
-                src={feature.icon}
-                alt=""
-                width={feature.iconWidth}
-                height={28}
-                className="object-contain"
-              />
+              <feature.icon className="size-7 text-[#2AA693]" />
             </div>
             <span className="text-[15px] font-medium text-black leading-[1.73] whitespace-pre-line">
               {feature.text}


### PR DESCRIPTION
## Summary
- インタビューLPの3つのフィーチャーアイコンをカスタムSVGファイルからlucide-reactアイコンに変更
  - `interview-icon-1.svg` → `Ear`（耳アイコン：リスニング）
  - `interview-icon-2.svg` → `MessagesSquare`（吹き出しアイコン：会話）
  - `interview-icon-3.svg` → `Landmark`（建物アイコン：国会議事堂）
- Figmaデザイン（node 7956-7132）に合わせた変更

## Test plan
- [x] `pnpm lint` パス
- [x] `pnpm typecheck` パス
- [x] `pnpm test` パス（54ファイル、616テスト全パス）
- [ ] インタビューLPページでアイコンが正しく表示されることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)