### PR TITLE
chore: PR作成後のCodeRabbitレビュー確認ルールを追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,7 +113,7 @@ Repository レイヤーの詳細は [docs/repository-layer.md](docs/repository-l
 - PR ではスコープ概要、実行テスト記録（例: `pnpm dev`, `pnpm --filter web test`）、UI 変更時のスクリーンショットや GIF を添付します。
 - スキーマ・シード・環境変数の変更は本文で明示し、レビューフィードバックへの対応状況を追跡コメントで共有して Ready for Review に切り替えます。
 - **イシュー連携**: 特定のイシューに対応する PR を作成する場合、PR 本文に `Resolves #123` の形式で記載してください。これにより PR マージ時にイシューが自動クローズされます。複数のイシューを閉じる場合は `Resolves #123, Resolves #456` のように列挙します。
-- **PR作成後のCodeRabbitレビュー確認（必須）**: PR作成後、CodeRabbitのレビューコメントを `gh api repos/{owner}/{repo}/pulls/{number}/comments` で取得し、重要な指摘（Major/Critical）があれば修正してpushすること。軽微な指摘（Minor）や既存コードとの一貫性を優先すべきものはスキップ可。
+- **PR作成後のCodeRabbitレビュー確認（必須）**: PR作成後、CodeRabbitのレビューが届くまで待ってからコメントを確認すること。レビューは通常2〜3分で届く。`gh api repos/{owner}/{repo}/pulls/{number}/comments` でコメントを取得し、空なら少し待って再取得する。重要な指摘（Major/Critical）があれば修正してpushすること。軽微な指摘（Minor）や既存コードとの一貫性を優先すべきものはスキップ可。
 
 ## Supabase & Environment Notes
 - ローカル開発前に `npx supabase start` を実行し、`.env.example` を `.env` にコピーして値を整えます。


### PR DESCRIPTION
## Summary
- CLAUDE.mdのCommit & Pull Requestガイドラインに、PR作成後にCodeRabbitのレビューコメントを自動チェックするルールを追加

## 仕組み化サマリ

### 仕組み化した項目
| 指摘 | 対応 | 追加先 |
|------|------|--------|
| PR作成後にCodeRabbitコメントを手動確認していた | CLAUDE.mdにルール追加 | CLAUDE.md (Commit & Pull Request Guidelines) |

### 追加ルール
PR作成後、`gh api repos/{owner}/{repo}/pulls/{number}/comments` でCodeRabbitのコメントを取得し、Major/Criticalな指摘があれば修正してpushする。

## Test plan
- [x] CLAUDE.mdの変更内容が既存ルールと矛盾しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)