### PR TITLE
fix: 情報開示ページのヘッダーとの重なりを修正

### DIFF
--- a/web/src/features/interview-config/server/components/interview-disclosure-page.tsx
+++ b/web/src/features/interview-config/server/components/interview-disclosure-page.tsx
@@ -146,7 +146,7 @@ function DynamicDisclosureSection({
 export function InterviewDisclosurePage(props: InterviewDisclosurePageProps) {
   return (
     <div className="flex flex-col gap-8 pb-8 bg-mirai-light-gradient">
-      <div className="flex flex-col gap-8 px-4 pt-8 max-w-[370px] mx-auto w-full">
+      <div className="flex flex-col gap-8 px-4 pt-24 md:pt-12 max-w-[370px] mx-auto w-full">
         <StaticDisclosureSection />
         <DynamicDisclosureSection {...props} />
       </div>


### PR DESCRIPTION
## Summary
- モバイルでfixedヘッダーとコンテンツが重なる問題を修正
- プライバシーポリシー・利用規約ページと同じ `pt-24 md:pt-12` パターンを適用

## Test plan
- [x] `pnpm lint` 通過
- [x] `pnpm typecheck` 通過
- [ ] モバイル表示でヘッダーとコンテンツが重ならないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)