### PR TITLE
fix: インタビュートピックラベルにバッジスタイルを追加

### DIFF
--- a/web/src/features/interview-session/client/components/interview-progress-bar.tsx
+++ b/web/src/features/interview-session/client/components/interview-progress-bar.tsx
@@ -27,7 +27,7 @@ export function InterviewProgressBar({
         <div className="mb-3 flex items-center gap-2">
           <div className="flex min-w-0 flex-1 items-center gap-2">
             {currentTopic && (
-              <div className="inline-flex max-w-full rounded-lg bg-gradient-to-br from-[#E2F6F3] to-[#EEF6E2] px-4 py-0.5">
+              <div className="inline-flex max-w-full rounded-lg bg-mirai-light-gradient px-4 py-0.5">
                 <p className="min-w-0 truncate text-sm font-bold leading-[1.8] text-[#1F2937]">
                   {currentTopic}
                 </p>


### PR DESCRIPTION
## Summary
- インタビュー画面のトピックラベルにグラデーション背景バッジを追加（Figmaデザイン準拠）
- スキップボタンを右端に配置するレイアウト変更
- gap/margin/paddingをFigmaデザインに合わせて調整

## 変更内容
- トピック名をグラデーション背景（`#E2F6F3` → `#EEF6E2`）のピル型バッジで表示
- スキップボタンとタイマーを右側にまとめて配置
- トピック行とプログレスバーの間隔を12px→8pxに調整
- 外側パディングを`py-[10px]`から`pt-[10px] pb-3`に変更
- 長いトピック名のtruncation動作を維持（`max-w-full`）

## Test plan
- [x] `pnpm lint` パス
- [x] `pnpm typecheck` パス
- [x] `pnpm test` 全616テストパス
- [ ] インタビュー画面でトピックラベルのバッジ表示を確認
- [ ] 長いトピック名でtruncationが正常に動作することを確認
- [ ] スキップボタンが右端に配置されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined interview progress bar spacing and padding adjustments for improved visual layout.
  * Enhanced current topic presentation with a styled gradient badge container.
  * Updated spacing between elements and skip button positioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->