### PR TITLE
fix: 星評価ウィジェットのUIをFigmaデザインに合わせて調整しchatエリアとの重なりを修正

### DIFF
--- a/web/src/features/interview-session/client/components/interview-chat-client.tsx
+++ b/web/src/features/interview-session/client/components/interview-chat-client.tsx
@@ -153,7 +153,7 @@ export function InterviewChatClient({
             />
           </div>
         )}
-        <Conversation className="flex-1 overflow-y-auto">
+        <Conversation className="min-h-0 flex-1 overflow-y-auto">
           <ConversationContent className="flex flex-col gap-4">
             {/* 初期表示メッセージ */}
             {messages.length === 0 && !object && (
@@ -229,10 +229,12 @@ export function InterviewChatClient({
 
         {/* 評価ウィジェット */}
         {showRating && (
-          <InterviewRatingWidget
-            sessionId={sessionId}
-            onDismiss={handleRatingDismiss}
-          />
+          <div className="shrink-0 py-2">
+            <InterviewRatingWidget
+              sessionId={sessionId}
+              onDismiss={handleRatingDismiss}
+            />
+          </div>
         )}
 
         {/* 時間超過プロンプト */}

--- a/web/src/features/interview-session/client/components/interview-rating-widget.tsx
+++ b/web/src/features/interview-session/client/components/interview-rating-widget.tsx
@@ -46,44 +46,45 @@ export function InterviewRatingWidget({
   }, [isSubmitted, onDismiss]);
 
   return (
-    <div className="mx-4 flex items-center gap-3 rounded-[18px] bg-[#F3F4F6] px-5 py-4">
-      <div className="flex min-w-0 flex-1 flex-col items-center gap-2">
-        <p className="text-sm font-bold text-[#1F2937]">
+    <div className="relative mx-4 rounded-xl bg-[#EDEDED] px-6 py-4">
+      <div className="flex flex-col gap-2.5">
+        <p className="text-[13px] font-medium leading-none text-[#1F2937]">
           {isSubmitted
             ? "回答ありがとうございました！"
             : "AIはあなたの考えを十分に引き出せていますか"}
         </p>
-        <div className="flex gap-2">
-          {[1, 2, 3, 4, 5].map((star) => (
-            <Button
-              key={star}
-              variant="ghost"
-              size="icon"
-              onClick={() => !isSubmitted && handleRate(star)}
-              disabled={isSubmitted}
-              className="h-auto w-auto p-0 hover:bg-transparent disabled:cursor-default disabled:opacity-100"
-              aria-label={`${star}星`}
-            >
-              <Star
-                size={32}
-                className={
-                  selectedRating !== null && star <= selectedRating
-                    ? "fill-[#F59E0B] text-[#F59E0B]"
-                    : "fill-none text-[#D1D5DB] stroke-[1.5]"
-                }
-              />
-            </Button>
-          ))}
-        </div>
+        {!isSubmitted && (
+          <div className="flex justify-center gap-[15px]">
+            {[1, 2, 3, 4, 5].map((star) => (
+              <Button
+                key={star}
+                variant="ghost"
+                size="icon"
+                onClick={() => handleRate(star)}
+                className="h-auto w-auto p-0 hover:bg-transparent"
+                aria-label={`${star}星`}
+              >
+                <Star
+                  size={25}
+                  className={
+                    selectedRating !== null && star <= selectedRating
+                      ? "fill-[#FF9500] text-[#FF9500]"
+                      : "fill-white text-[#8E9092] stroke-[0.5]"
+                  }
+                />
+              </Button>
+            ))}
+          </div>
+        )}
       </div>
       <Button
         variant="ghost"
         size="icon"
         onClick={onDismiss}
-        className="shrink-0 text-[#9CA3AF] hover:bg-transparent hover:text-[#6B7280]"
+        className="absolute right-2 top-2 h-[22px] w-[22px] p-0 text-[#9F9B9B] hover:bg-transparent hover:text-[#6B7280]"
         aria-label="閉じる"
       >
-        <X size={24} />
+        <X size={11} strokeWidth={2} />
       </Button>
     </div>
   );


### PR DESCRIPTION
## Summary
- 星評価ウィジェットのスタイルをFigmaデザインに統一（背景色 #EDEDED、角丸12px、縦配置レイアウト、閉じるボタン右上absolute配置）
- 星の色をデザイン指定に変更（選択時: #FF9500、未選択: 白塗り+#8E9092枠）
- `Conversation`に`min-h-0`を追加し、ウィジェット表示時のchatエリアとの重なり（flex shrink問題）を修正

## Test plan
- [x] `pnpm lint` 通過
- [x] `pnpm typecheck` 通過
- [x] `pnpm test` 全テスト通過（630 passed）
- [ ] インタビューチャットでプログレス70%到達時にウィジェットが正しく表示されることを確認
- [ ] ウィジェット表示時にchatエリアのメッセージと重ならないことを確認
- [ ] 星をタップして評価できること、閉じるボタンで非表示にできることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)