### PR TITLE
fix: 有識者登録バナー・モーダルのUIをFigmaデザインに合わせて調整

### DIFF
--- a/web/src/features/interview-report/client/components/expert-registration-banner.tsx
+++ b/web/src/features/interview-report/client/components/expert-registration-banner.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { MessageSquare } from "lucide-react";
-import { Badge } from "@/components/ui/badge";
+import { MessageSquareMore } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
 interface ExpertRegistrationBannerProps {
@@ -12,16 +11,22 @@ export function ExpertRegistrationBanner({
   onRegisterClick,
 }: ExpertRegistrationBannerProps) {
   return (
-    <div className="bg-mirai-light-gradient rounded-2xl p-6 flex flex-col gap-4">
-      <Badge variant="light">法案の有識者の方へ</Badge>
-      <h3 className="text-lg font-bold text-gray-800">
-        有識者リストにご登録ください
-      </h3>
-      <p className="text-sm text-gray-800">
-        現場の知見を法案に活かすため、登録をいただいた方には、今後チームみらいから追加のインタビューをお願いする場合があります。
-      </p>
+    <div className="bg-mirai-light-gradient rounded-2xl border border-[#2AA693] p-6 flex flex-col gap-6">
+      <div className="flex flex-col gap-4">
+        <span className="inline-flex items-center justify-center rounded-2xl bg-[#2AA693] text-white px-4 py-2 text-[15px] font-medium w-fit">
+          法案の有識者の方へ
+        </span>
+        <div className="flex flex-col gap-2.5">
+          <h3 className="text-lg font-bold text-gray-800">
+            有識者リストにご登録ください
+          </h3>
+          <p className="text-[15px] text-gray-800">
+            現場の知見を法案に活かすため、登録をいただいた方には、今後チームみらいから追加のインタビューをお願いする場合があります。
+          </p>
+        </div>
+      </div>
       <Button variant="outline" onClick={onRegisterClick} className="w-full">
-        <MessageSquare className="size-5" />
+        <MessageSquareMore className="size-6" />
         有識者リストに登録する
       </Button>
     </div>

--- a/web/src/features/interview-report/client/components/expert-registration-modal.tsx
+++ b/web/src/features/interview-report/client/components/expert-registration-modal.tsx
@@ -126,11 +126,11 @@ export function ExpertRegistrationModal({
           政策検討のために、有識者としてチームみらいから連絡をする可能性があります。登録情報は公開されません。
         </p>
 
-        <div className="flex flex-col gap-4 mt-6">
-          <div className="flex flex-col gap-1.5">
+        <div className="flex flex-col gap-3 mt-6">
+          <div className="flex flex-col gap-2">
             <label
               htmlFor="expert-name"
-              className="text-sm font-bold text-gray-800"
+              className="text-sm font-medium text-gray-800"
             >
               お名前
             </label>
@@ -138,7 +138,7 @@ export function ExpertRegistrationModal({
               id="expert-name"
               value={name}
               onChange={(e) => setName(e.target.value)}
-              className="bg-gray-100 h-12"
+              className="bg-gray-100 h-[42px]"
               aria-invalid={!!errors.name}
             />
             {errors.name && (
@@ -146,10 +146,10 @@ export function ExpertRegistrationModal({
             )}
           </div>
 
-          <div className="flex flex-col gap-1.5">
+          <div className="flex flex-col gap-2">
             <label
               htmlFor="expert-affiliation"
-              className="text-sm font-bold text-gray-800"
+              className="text-sm font-medium text-gray-800"
             >
               ご所属・肩書
             </label>
@@ -157,7 +157,7 @@ export function ExpertRegistrationModal({
               id="expert-affiliation"
               value={affiliation}
               onChange={(e) => setAffiliation(e.target.value)}
-              className="bg-gray-100 h-12"
+              className="bg-gray-100 h-[42px]"
               aria-invalid={!!errors.affiliation}
             />
             {errors.affiliation && (
@@ -165,10 +165,10 @@ export function ExpertRegistrationModal({
             )}
           </div>
 
-          <div className="flex flex-col gap-1.5">
+          <div className="flex flex-col gap-2">
             <label
               htmlFor="expert-email"
-              className="text-sm font-bold text-gray-800"
+              className="text-sm font-medium text-gray-800"
             >
               メールアドレス
             </label>
@@ -177,7 +177,7 @@ export function ExpertRegistrationModal({
               type="email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
-              className="bg-gray-100 h-12"
+              className="bg-gray-100 h-[42px]"
               aria-invalid={!!errors.email}
             />
             {errors.email && (
@@ -185,15 +185,15 @@ export function ExpertRegistrationModal({
             )}
           </div>
 
-          <div className="flex items-start gap-2 mt-2">
+          <div className="flex items-center gap-2 mt-2">
             <input
               type="checkbox"
               id="expert-privacy"
               checked={privacyAgreed}
               onChange={(e) => setPrivacyAgreed(e.target.checked)}
-              className="mt-0.5 size-5 rounded-full accent-[#0f8472]"
+              className="size-5 rounded-full accent-[#0f8472]"
             />
-            <label htmlFor="expert-privacy" className="text-sm text-gray-800">
+            <label htmlFor="expert-privacy" className="text-xs text-gray-800">
               <Link
                 href="/privacy"
                 target="_blank"


### PR DESCRIPTION
## Summary
- 有識者登録バナー: ボーダー追加、バッジを塗りつぶしスタイルに変更、テキスト構造とスペーシングをFigmaに準拠、アイコンをMessageSquareMoreに変更
- 有識者登録モーダル: ラベルのfont-weightをmediumに変更、フォームフィールドのgapとinput高さをFigmaに合わせて調整、プライバシーテキストサイズを調整

## Test plan
- [x] `pnpm lint` 通過
- [x] `pnpm typecheck` 通過
- [x] `pnpm test` 全630テスト通過
- [x] Codexレビュー通過
- [ ] ブラウザでバナー・モーダルの表示がFigmaデザインと一致することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)