### PR TITLE
fix: インタビュートピック上部の不要なpaddingを削除

### DIFF
--- a/web/src/features/interview-session/client/components/interview-chat-client.tsx
+++ b/web/src/features/interview-session/client/components/interview-chat-client.tsx
@@ -142,7 +142,7 @@ export function InterviewChatClient({
     <div className="h-dvh md:h-[calc(100dvh-96px)] bg-[#EEEEEE]">
       <div className="flex flex-col h-full pt-24 md:pt-4 bg-white md:rounded-t-[36px] md:px-12">
         {showProgressBar && progress && (
-          <div className="px-4 pb-1 pt-2">
+          <div className="px-4 pb-1">
             <InterviewProgressBar
               percentage={progress.percentage}
               currentTopic={progress.currentTopic}


### PR DESCRIPTION
## Summary
- インタビュー画面のトピックラベル上部にあった不要な `pt-2` paddingを削除

## Test plan
- [x] `pnpm lint` 通過
- [x] `pnpm typecheck` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted spacing in the interview progress area for a more compact visual layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->