### PR TITLE
fix: 登録完了画面の説明文のfont-weightをFigmaに合わせて調整

### DIFF
--- a/web/src/features/interview-report/client/components/expert-registration-modal.tsx
+++ b/web/src/features/interview-report/client/components/expert-registration-modal.tsx
@@ -100,7 +100,7 @@ export function ExpertRegistrationModal({
               登録ありがとうございました。
             </DialogTitle>
           </DialogHeader>
-          <p className="text-sm text-gray-800 mt-4">
+          <p className="text-sm font-medium text-gray-800 mt-4">
             政策検討のために、有識者としてチームみらいから連絡をする可能性があります。登録情報は公開されません。
           </p>
           <div className="mt-6">


### PR DESCRIPTION
## Summary
- 有識者登録完了画面の説明文に `font-medium` (fontWeight: 500) を追加し、Figmaデザインと一致させる

## Test plan
- [x] `pnpm lint` 通過
- [x] `pnpm typecheck` 通過
- [x] `pnpm test` 全630テスト通過
- [ ] ブラウザで登録完了画面の表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)