### PR TITLE
fix: インタビュー初回トピックを「はじめに」に固定

### DIFF
--- a/web/src/features/interview-session/server/services/generate-initial-question.ts
+++ b/web/src/features/interview-session/server/services/generate-initial-question.ts
@@ -7,6 +7,7 @@ import { getInterviewQuestions } from "@/features/interview-config/server/loader
 import { DEFAULT_INTERVIEW_CHAT_MODEL } from "@/lib/ai/models";
 import { interviewChatTextSchema } from "../../shared/schemas";
 import type { InterviewMessage } from "../../shared/types";
+import { overrideInitialTopicTitle } from "../../shared/utils/override-initial-topic-title";
 import { createInterviewMessage } from "../repositories/interview-session-repository";
 import { buildInterviewSystemPrompt } from "../utils/build-interview-system-prompt";
 
@@ -82,11 +83,14 @@ export async function generateInitialQuestion({
       return null;
     }
 
+    // 初回メッセージのtopic_titleを「はじめに」に強制上書き
+    const content = overrideInitialTopicTitle(generatedText);
+
     // 生成した質問を保存
     return await createInterviewMessage({
       sessionId,
       role: "assistant",
-      content: generatedText,
+      content,
     });
   } catch (error) {
     console.error("Failed to generate initial question:", error);

--- a/web/src/features/interview-session/shared/utils/override-initial-topic-title.test.ts
+++ b/web/src/features/interview-session/shared/utils/override-initial-topic-title.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { overrideInitialTopicTitle } from "./override-initial-topic-title";
+
+describe("overrideInitialTopicTitle", () => {
+  it("topic_titleを「はじめに」に上書きする", () => {
+    const input = JSON.stringify({
+      text: "こんにちは！",
+      topic_title: "経済政策",
+      question_id: "q1",
+      quick_replies: ["賛成", "反対"],
+      next_stage: "chat",
+    });
+
+    const result = JSON.parse(overrideInitialTopicTitle(input));
+    expect(result.topic_title).toBe("はじめに");
+    expect(result.text).toBe("こんにちは！");
+    expect(result.question_id).toBe("q1");
+  });
+
+  it("topic_titleがnullでも「はじめに」に上書きする", () => {
+    const input = JSON.stringify({
+      text: "こんにちは！",
+      topic_title: null,
+      next_stage: "chat",
+    });
+
+    const result = JSON.parse(overrideInitialTopicTitle(input));
+    expect(result.topic_title).toBe("はじめに");
+  });
+
+  it("topic_titleが存在しない場合も追加する", () => {
+    const input = JSON.stringify({
+      text: "こんにちは！",
+      next_stage: "chat",
+    });
+
+    const result = JSON.parse(overrideInitialTopicTitle(input));
+    expect(result.topic_title).toBe("はじめに");
+  });
+
+  it("JSONでない文字列はそのまま返す", () => {
+    const input = "これはただのテキスト";
+    expect(overrideInitialTopicTitle(input)).toBe(input);
+  });
+
+  it("他のフィールドを変更しない", () => {
+    const input = JSON.stringify({
+      text: "インタビューを始めます",
+      topic_title: "導入",
+      question_id: "q1",
+      quick_replies: ["はい", "いいえ"],
+      next_stage: "chat",
+    });
+
+    const result = JSON.parse(overrideInitialTopicTitle(input));
+    expect(result.text).toBe("インタビューを始めます");
+    expect(result.question_id).toBe("q1");
+    expect(result.quick_replies).toEqual(["はい", "いいえ"]);
+    expect(result.next_stage).toBe("chat");
+  });
+});

--- a/web/src/features/interview-session/shared/utils/override-initial-topic-title.ts
+++ b/web/src/features/interview-session/shared/utils/override-initial-topic-title.ts
@@ -1,0 +1,18 @@
+/**
+ * 初回メッセージのtopic_titleを「はじめに」に強制上書きする純粋関数
+ *
+ * LLMが生成したJSON文字列をパースし、topic_titleを上書きして再シリアライズする。
+ * パースに失敗した場合はそのまま返す。
+ */
+export function overrideInitialTopicTitle(generatedText: string): string {
+  try {
+    const parsed = JSON.parse(generatedText);
+    if (typeof parsed === "object" && parsed !== null) {
+      parsed.topic_title = "はじめに";
+      return JSON.stringify(parsed);
+    }
+  } catch {
+    // JSONでない場合はそのまま返す
+  }
+  return generatedText;
+}


### PR DESCRIPTION
## Summary
- インタビュー開始時の初回メッセージの `topic_title` を必ず「はじめに」に固定するように変更
- LLMの出力に依存せず、コード側でJSON文字列をパースして `topic_title` を強制上書き
- 純粋関数 `overrideInitialTopicTitle` を `shared/utils/` に切り出し、テストも追加

## Test plan
- [x] `pnpm lint` パス
- [x] `pnpm typecheck` パス
- [x] `pnpm test` 全635テストパス（新規5テスト含む）
- [x] Codex レビュー通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)