### PR TITLE
fix: 有識者登録成功画面の不要なmarginを削除

### DIFF
--- a/web/src/features/interview-report/client/components/expert-registration-modal.tsx
+++ b/web/src/features/interview-report/client/components/expert-registration-modal.tsx
@@ -100,7 +100,7 @@ export function ExpertRegistrationModal({
               登録ありがとうございました。
             </DialogTitle>
           </DialogHeader>
-          <p className="text-sm font-medium text-gray-800 mt-4">
+          <p className="text-sm font-medium text-gray-800">
             政策検討のために、有識者としてチームみらいから連絡をする可能性があります。登録情報は公開されません。
           </p>
           <div className="mt-6">


### PR DESCRIPTION
## Summary
- 有識者登録モーダルの成功画面で、説明テキストの `mt-4` を削除

## Test plan
- [x] `pnpm lint` 通過
- [x] `pnpm typecheck` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)