### PR TITLE
fix: インタビューCTAボタンの背景色をlight gradientに変更

### DIFF
--- a/web/src/features/bills/server/components/bill-detail/bill-detail-header.tsx
+++ b/web/src/features/bills/server/components/bill-detail/bill-detail-header.tsx
@@ -77,7 +77,7 @@ export async function BillDetailHeader({
               variant="default"
               size="sm"
               asChild
-              className="text-[13px] font-medium text-gray-800 gap-1.5 py-1 px-3"
+              className="bg-mirai-light-gradient text-[13px] font-medium text-gray-800 gap-1.5 py-1 px-3"
             >
               <Link href={getInterviewLPLink(bill.id)}>
                 <Image


### PR DESCRIPTION
## Summary
- 法案詳細ヘッダーの「AIインタビューに協力する」ボタンの背景色を `bg-mirai-gradient` から `bg-mirai-light-gradient` に変更
- Figmaデザインとの背景色の不一致を修正

## Test plan
- [x] `pnpm lint` 通過
- [x] `pnpm typecheck` 通過
- [ ] 法案詳細ページでボタンの背景色がlight gradientになっていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)