### PR TITLE
fix: インタビューページのフッターをchat画面のみ非表示にする

### DIFF
--- a/web/src/components/layouts/footer/footer.tsx
+++ b/web/src/components/layouts/footer/footer.tsx
@@ -3,13 +3,13 @@
 import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { isInterviewSection } from "@/lib/page-layout-utils";
+import { isInterviewPage } from "@/lib/page-layout-utils";
 import { policyLinks, primaryLinks } from "./footer.config";
 
 export function Footer() {
   const pathname = usePathname();
 
-  if (isInterviewSection(pathname)) {
+  if (isInterviewPage(pathname)) {
     return null;
   }
 


### PR DESCRIPTION
## Summary
- フッターの非表示条件を `isInterviewSection`（インタビューセクション全体）から `isInterviewPage`（chatページのみ）に変更
- インタビューLP・情報開示ページではフッターが表示されるようになる
- chat画面（`/bills/[id]/interview/chat`）では引き続きフッター非表示

## Test plan
- [x] `pnpm lint` 通過
- [x] `pnpm typecheck` 通過
- [x] `pnpm test` 全635テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)