### PR TITLE
fix: インタビュー評価ウィジェットのUI改善と表示閾値変更

### DIFF
--- a/web/src/features/interview-session/client/components/interview-chat-client.tsx
+++ b/web/src/features/interview-session/client/components/interview-chat-client.tsx
@@ -13,8 +13,8 @@ import { InterviewChatInput } from "./interview-chat-input";
 import { InterviewErrorDisplay } from "./interview-error-display";
 import { InterviewMessage } from "./interview-message";
 import { InterviewProgressBar } from "./interview-progress-bar";
-import { InterviewSummaryInput } from "./interview-summary-input";
 import { InterviewRatingWidget } from "./interview-rating-widget";
+import { InterviewSummaryInput } from "./interview-summary-input";
 import { QuickReplyButtons } from "./quick-reply-buttons";
 import { TimeUpPrompt } from "./time-up-prompt";
 

--- a/web/src/features/interview-session/client/components/interview-rating-widget.tsx
+++ b/web/src/features/interview-session/client/components/interview-rating-widget.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
 import { Star, X } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { submitInterviewRating } from "../../server/actions/submit-interview-rating";
 
@@ -46,36 +46,29 @@ export function InterviewRatingWidget({
   }, [isSubmitted, onDismiss]);
 
   return (
-    <div className="relative mx-4 rounded-xl bg-[#EDEDED] px-6 py-4">
+    <div className="relative mx-4 rounded-xl bg-gray-100 px-6 py-4">
       <div className="flex flex-col gap-2.5">
-        <p className="text-[13px] font-medium leading-none text-[#1F2937]">
+        <p className="text-[13px] font-medium leading-none text-[#1F2937] text-center">
           {isSubmitted
             ? "回答ありがとうございました！"
             : "AIはあなたの考えを十分に引き出せていますか"}
         </p>
-        {!isSubmitted && (
+        {
           <div className="flex justify-center gap-[15px]">
             {[1, 2, 3, 4, 5].map((star) => (
-              <Button
+              <Star
                 key={star}
-                variant="ghost"
-                size="icon"
+                size={24}
                 onClick={() => handleRate(star)}
-                className="h-auto w-auto p-0 hover:bg-transparent"
-                aria-label={`${star}星`}
-              >
-                <Star
-                  size={25}
-                  className={
-                    selectedRating !== null && star <= selectedRating
-                      ? "fill-[#FF9500] text-[#FF9500]"
-                      : "fill-white text-[#8E9092] stroke-[0.5]"
-                  }
-                />
-              </Button>
+                className={
+                  selectedRating !== null && star <= selectedRating
+                    ? "fill-[#FF9500] text-[#FF9500]"
+                    : "fill-white text-[#8E9092] stroke-[0.5]"
+                }
+              />
             ))}
           </div>
-        )}
+        }
       </div>
       <Button
         variant="ghost"

--- a/web/src/features/interview-session/client/hooks/use-interview-rating.ts
+++ b/web/src/features/interview-session/client/hooks/use-interview-rating.ts
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { InterviewProgress } from "../../shared/utils/calc-interview-progress";
 
-const RATING_WIDGET_THRESHOLD = 70;
+const RATING_WIDGET_THRESHOLD = 65;
 
 interface UseInterviewRatingProps {
   mode?: "loop" | "bulk";


### PR DESCRIPTION
## Summary
- 評価ウィジェットの背景色をハードコード(`#EDEDED`)からTailwindクラス(`bg-gray-100`)に変更
- テキストを中央揃えに変更
- 星アイコンのサイズを24pxに調整し、レンダリングを簡略化
- 評価ウィジェットの表示閾値を70%から65%に引き下げ
- import順をアルファベット順に整列

## Test plan
- [x] `pnpm lint` — passed (既存warning 1件のみ)
- [x] `pnpm typecheck` — passed
- [x] `pnpm test` — 56 files, 635 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Updated rating widget background color and text alignment for improved visual appearance.

* **New Features**
  * Rating widget now appears at 65% interview progress instead of 70%.
  * Rating stars are now always visible and interactive throughout the interview session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->