### PR TITLE
fix: デフォルトのfont-weightを500に変更

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -173,7 +173,7 @@
   }
 
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground font-medium;
   }
 }
 


### PR DESCRIPTION
## Summary
- サイト全体のデフォルト `font-weight` を `400`（ブラウザデフォルト）から `500`（medium）に変更
- `globals.css` の `body` スタイルに `font-medium` を追加

## Changes
- `web/src/app/globals.css`: `body` の `@apply` に `font-medium` を追加

## Test plan
- [x] `pnpm lint` 通過
- [x] `pnpm typecheck` 通過
- [x] `pnpm test` 通過（56ファイル、635テスト全通過）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the default font weight for improved text readability across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->