### PR TITLE
fix: 有識者登録バナー・モーダルのUI微調整

### DIFF
--- a/web/src/features/interview-report/client/components/expert-registration-banner.tsx
+++ b/web/src/features/interview-report/client/components/expert-registration-banner.tsx
@@ -13,7 +13,7 @@ export function ExpertRegistrationBanner({
   return (
     <div className="bg-mirai-light-gradient rounded-2xl border border-[#2AA693] p-6 flex flex-col gap-6">
       <div className="flex flex-col gap-4">
-        <span className="inline-flex items-center justify-center rounded-2xl bg-[#2AA693] text-white px-4 py-2 text-[15px] font-medium w-fit">
+        <span className="inline-flex items-center justify-center rounded-2xl bg-[#2AA693] text-white px-4 py-2 text-sm font-medium w-fit">
           法案の有識者の方へ
         </span>
         <div className="flex flex-col gap-2.5">

--- a/web/src/features/interview-report/client/components/expert-registration-modal.tsx
+++ b/web/src/features/interview-report/client/components/expert-registration-modal.tsx
@@ -122,11 +122,11 @@ export function ExpertRegistrationModal({
           </DialogTitle>
         </DialogHeader>
 
-        <p className="text-sm text-gray-800 mt-2">
+        <p className="text-sm text-gray-800 mt-2 font-medium">
           政策検討のために、有識者としてチームみらいから連絡をする可能性があります。登録情報は公開されません。
         </p>
 
-        <div className="flex flex-col gap-3 mt-6">
+        <div className="flex flex-col gap-3 mt-2">
           <div className="flex flex-col gap-2">
             <label
               htmlFor="expert-name"
@@ -191,14 +191,10 @@ export function ExpertRegistrationModal({
               id="expert-privacy"
               checked={privacyAgreed}
               onChange={(e) => setPrivacyAgreed(e.target.checked)}
-              className="size-5 rounded-full accent-[#0f8472]"
+              className="size-5 rounded-full accent-primary"
             />
             <label htmlFor="expert-privacy" className="text-xs text-gray-800">
-              <Link
-                href="/privacy"
-                target="_blank"
-                className="text-primary-accent underline"
-              >
+              <Link href="/privacy" target="_blank" className="underline">
                 プライバシーポリシー
               </Link>
               に同意する


### PR DESCRIPTION
## Summary
- バナーのバッジテキストサイズを `text-[15px]` → `text-sm` に統一
- モーダルの説明文に `font-medium` を追加し視認性を向上
- フォーム部分の上マージンを `mt-6` → `mt-2` に縮小しコンパクトに
- チェックボックスの `accent-[#0f8472]` → `accent-primary` でテーマカラーを統一
- プライバシーポリシーリンクの `text-primary-accent` クラスを削除し簡素化

## Test plan
- [x] `pnpm lint` 通過
- [x] `pnpm typecheck` 通過
- [x] Codex レビュー通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)