### PR TITLE
feat: ArchiveセクションをComingSoonセクション直下に移動

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -55,15 +55,6 @@ export default async function Home() {
             <ComingSoonSection bills={comingSoonBills} />
           </main>
         </div>
-
-        {/* みらい議会とは セクション */}
-        <About />
-
-        {/* チームみらいについて セクション */}
-        <TeamMirai />
-
-        {/* 免責事項 */}
-        <BillDisclaimer />
       </Container>
 
       {/* 前回の国会セクション（Archive） */}
@@ -78,6 +69,17 @@ export default async function Home() {
           </Container>
         </div>
       )}
+
+      <Container>
+        {/* みらい議会とは セクション */}
+        <About />
+
+        {/* チームみらいについて セクション */}
+        <TeamMirai />
+
+        {/* 免責事項 */}
+        <BillDisclaimer />
+      </Container>
 
       {/* チャット機能 */}
       <HomeChatClient


### PR DESCRIPTION
## Summary
- TOPページのArchive（前回の国会）セクションを「これから掲載される法案」セクションの直下に移動
- About、チームみらい、免責事項のセクションはArchiveの後に表示されるよう順序を変更

## 変更内容
- `web/src/app/page.tsx`: セクションの表示順序を変更
  - Before: ComingSoon → About → TeamMirai → BillDisclaimer → Archive
  - After: ComingSoon → Archive → About → TeamMirai → BillDisclaimer

## Test plan
- [x] `pnpm lint` 通過
- [x] `pnpm typecheck` 通過
- [x] `pnpm test` 通過（56ファイル、635テスト全通過）
- [ ] TOPページでArchiveセクションがComingSoonセクション直下に表示されることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)