### PR TITLE
chore: PR作成後のチェック項目にconflict・CI確認を追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,7 +113,10 @@ Repository レイヤーの詳細は [docs/repository-layer.md](docs/repository-l
 - PR ではスコープ概要、実行テスト記録（例: `pnpm dev`, `pnpm --filter web test`）、UI 変更時のスクリーンショットや GIF を添付します。
 - スキーマ・シード・環境変数の変更は本文で明示し、レビューフィードバックへの対応状況を追跡コメントで共有して Ready for Review に切り替えます。
 - **イシュー連携**: 特定のイシューに対応する PR を作成する場合、PR 本文に `Resolves #123` の形式で記載してください。これにより PR マージ時にイシューが自動クローズされます。複数のイシューを閉じる場合は `Resolves #123, Resolves #456` のように列挙します。
-- **PR作成後のCodeRabbitレビュー確認（必須）**: PR作成後、CodeRabbitのレビューが届くまで待ってからコメントを確認すること。レビューは通常2〜3分で届く。`gh api repos/{owner}/{repo}/pulls/{number}/comments` でコメントを取得し、空なら少し待って再取得する。重要な指摘（Major/Critical）があれば修正してpushすること。軽微な指摘（Minor）や既存コードとの一貫性を優先すべきものはスキップ可。
+- **PR作成後の状態確認（必須）**: PR作成後、以下の3点を確認すること：
+  1. **Conflict確認**: `gh pr view <番号> --json mergeable,mergeStateStatus` でマージ可能か確認。conflictがあれば解消してpushする。
+  2. **CI確認**: `gh pr checks <番号>` でCIの状態を確認。失敗があれば原因を調査し修正してpushする。CIが実行中の場合は完了まで待つ。
+  3. **CodeRabbitレビュー確認**: CodeRabbitのレビューが届くまで待ってからコメントを確認する。レビューは通常2〜3分で届く。`gh api repos/{owner}/{repo}/pulls/{number}/comments` でコメントを取得し、空なら少し待って再取得する。重要な指摘（Major/Critical）があれば修正してpushすること。軽微な指摘（Minor）や既存コードとの一貫性を優先すべきものはスキップ可。
 
 ## Supabase & Environment Notes
 - ローカル開発前に `npx supabase start` を実行し、`.env.example` を `.env` にコピーして値を整えます。


### PR DESCRIPTION
## Summary

- CLAUDE.mdの「PR作成後のCodeRabbitレビュー確認（必須）」ルールを拡張
- PR作成後に以下の3点を確認するルールに変更:
  1. **Conflict確認**: `gh pr view --json mergeable` でマージ可能か確認
  2. **CI確認**: `gh pr checks` でCI状態を確認
  3. **CodeRabbitレビュー確認**: 既存ルールを維持

## 仕組み化サマリ

### 仕組み化した項目
| 指摘 | 対応 | 追加先 |
|------|------|--------|
| PR作成後にconflict・CI状態もチェックすべき | ルール拡張 | CLAUDE.md (AGENTS.md) |

## Test plan

- [x] `pnpm lint` — 通過
- [x] `pnpm typecheck` — 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)