### PR TITLE
fix: デフォルトのfont-weightを400に戻す

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -173,7 +173,7 @@
   }
 
   body {
-    @apply bg-background text-foreground font-medium;
+    @apply bg-background text-foreground;
   }
 }
 


### PR DESCRIPTION
## Summary
- bodyのデフォルトfont-weightを500（`font-medium`）から400（デフォルト）に戻す
- #482 で追加された `font-medium` を削除

## 変更内容
`web/src/app/globals.css` のbodyスタイルから `font-medium` を削除。

## Test plan
- [x] `pnpm lint` 通過
- [x] `pnpm typecheck` 通過
- [x] `pnpm test` 全56ファイル、635テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)