### PR TITLE
refactor: トップページ各セクションのパディングをpy-10に統一

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -11,8 +11,8 @@ import { PreviousSessionSection } from "@/features/bills/server/components/previ
 import { loadHomeData } from "@/features/bills/server/loaders/load-home-data";
 import type { BillWithContent } from "@/features/bills/shared/types";
 import { HomeChatClient } from "@/features/chat/client/components/home-chat-client";
-import { getCurrentDietSession } from "@/features/diet-sessions/server/loaders/get-current-diet-session";
 import { CurrentDietSession } from "@/features/diet-sessions/client/components/current-diet-session";
+import { getCurrentDietSession } from "@/features/diet-sessions/server/loaders/get-current-diet-session";
 import { getJapanTime } from "@/lib/utils/date";
 
 export default async function Home() {
@@ -42,8 +42,8 @@ export default async function Home() {
       <CurrentDietSession session={currentSession} />
 
       {/* 議案一覧セクション */}
-      <Container className="pb-20">
-        <div className="py-8">
+      <Container className="">
+        <div className="py-10">
           <main className="flex flex-col gap-16">
             {/* 注目の法案セクション */}
             <FeaturedBillSection bills={featuredBills} />
@@ -59,7 +59,7 @@ export default async function Home() {
 
       {/* 前回の国会セクション（Archive） */}
       {previousSessionData && (
-        <div className="bg-mirai-surface-muted py-9">
+        <div className="bg-mirai-surface-muted py-10">
           <Container>
             <PreviousSessionSection
               session={previousSessionData.session}

--- a/web/src/components/top/about.tsx
+++ b/web/src/components/top/about.tsx
@@ -4,7 +4,7 @@ import { LinkButton } from "./link-button";
 
 export function About() {
   return (
-    <div className="py-8">
+    <div className="py-10">
       <div className="flex flex-col gap-4">
         {/* ヘッダー */}
         <div className="flex flex-col gap-4">

--- a/web/src/components/top/team-mirai.tsx
+++ b/web/src/components/top/team-mirai.tsx
@@ -14,7 +14,7 @@ const TEAM_MIRAI_SNS_ORDER = [
 
 export function TeamMirai() {
   return (
-    <div className="py-8">
+    <div className="py-10">
       <div className="flex flex-col gap-6">
         {/* ヘッダー */}
         <div className="flex flex-col gap-4">

--- a/web/src/features/bills/client/components/bill-detail/bill-disclaimer.tsx
+++ b/web/src/features/bills/client/components/bill-detail/bill-disclaimer.tsx
@@ -4,7 +4,7 @@ import { ManualRuby } from "@/lib/rubyful/manual-ruby";
 
 export function BillDisclaimer() {
   return (
-    <div className="space-y-6 pt-4">
+    <div className="space-y-6 pt-4 pb-10">
       {/* データの出典について */}
       <div className="space-y-3">
         <h3 className="text-sm font-bold text-black">掲載コンテンツについて</h3>


### PR DESCRIPTION
## Summary
- トップページの各セクション（議案一覧、前回の国会、About、チームみらい、免責事項）のパディングを `py-10` に統一
- `Container` の不要な `pb-20` クラスを除去し `className=""` に変更
- `BillDisclaimer` に `pb-10` を追加してセクション下部の余白を確保
- import文のアルファベット順ソート（Biome lint対応）

## 変更内容
| ファイル | 変更内容 |
|---|---|
| `web/src/app/page.tsx` | `Container className="pb-20"` → `className=""`、`py-8` → `py-10`、`py-9` → `py-10`、import順修正 |
| `web/src/components/top/about.tsx` | `py-8` → `py-10` |
| `web/src/components/top/team-mirai.tsx` | `py-8` → `py-10` |
| `web/src/features/bills/client/components/bill-detail/bill-disclaimer.tsx` | `pt-4` → `pt-4 pb-10` |

## Test plan
- [x] `pnpm lint` パス
- [x] `pnpm typecheck` パス
- [x] `pnpm test` 全テストパス（783テスト）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Improved vertical spacing and padding consistency across the application interface for better visual balance and readability throughout various components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->