### PR TITLE
fix: インタビュー設定一覧のテーマカラムのレイアウト崩れを修正

### DIFF
--- a/admin/src/features/interview-config/client/components/interview-config-list.tsx
+++ b/admin/src/features/interview-config/client/components/interview-config-list.tsx
@@ -146,14 +146,15 @@ export function InterviewConfigList({
                         {getModeLabel(config.mode)}
                       </Badge>
                     </TableCell>
-                    <TableCell className="max-w-[200px]">
+                    <TableCell className="max-w-[400px]">
                       {config.themes && config.themes.length > 0 ? (
-                        <div className="flex flex-wrap gap-1">
+                        <div className="flex flex-col gap-1">
                           {config.themes.map((theme) => (
                             <Badge
                               key={theme}
                               variant="secondary"
-                              className="text-xs"
+                              className="text-xs max-w-full truncate"
+                              title={theme}
                             >
                               {theme}
                             </Badge>


### PR DESCRIPTION
## Summary
- インタビュー設定一覧画面で、テーマが長いとテーブルのレイアウトが崩れる問題を修正
- テーマBadgeを縦並び（`flex-col`）に変更し、`truncate`で長いテキストを省略表示
- `title`属性を追加し、ホバーで全文を確認可能に

## Changes
- `max-w-[200px]` → `max-w-[400px]`: テーマカラムの最大幅を広げて読みやすく
- `flex flex-wrap` → `flex flex-col`: 横並びから縦並びに変更
- Badgeに `max-w-full truncate` を追加: 長いテキストを省略表示
- `title={theme}` を追加: ホバーで全文確認

## Test plan
- [x] `pnpm lint` 通過
- [x] `pnpm typecheck` 通過
- [x] `pnpm test` 全テスト通過（832 passed）

🤖 Generated with [Claude Code](https://claude.com/claude-code)