### PR TITLE
fix: AIインタビューボタンのfont-weightをboldに変更

### DIFF
--- a/web/src/features/bills/server/components/bill-detail/bill-detail-header.tsx
+++ b/web/src/features/bills/server/components/bill-detail/bill-detail-header.tsx
@@ -77,7 +77,7 @@ export async function BillDetailHeader({
               variant="default"
               size="sm"
               asChild
-              className="bg-mirai-light-gradient text-[13px] font-medium text-gray-800 gap-1.5 py-1 px-3"
+              className="bg-mirai-light-gradient text-[13px] font-bold text-gray-800 gap-1.5 py-1 px-3"
             >
               <Link href={getInterviewLPLink(bill.id)}>
                 <Image


### PR DESCRIPTION
## Summary
- 法案詳細ヘッダーの「AIインタビューに協力する」ボタンのfont-weightを `font-medium` から `font-bold` に変更

## Test plan
- [ ] 法案詳細ページでボタンのテキストがboldで表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the interview link button in bill details to display with bolder text for improved visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->