### PR TITLE
fix: blockquote内の連続行が改行されない問題を修正

### DIFF
--- a/web/src/lib/markdown/index.ts
+++ b/web/src/lib/markdown/index.ts
@@ -36,8 +36,10 @@ const sanitizeSchema = {
  * @returns React Element（部分水和対応）
  */
 export async function parseMarkdown(markdown: string): Promise<ReactElement> {
-  // Markdown → mdast
-  const mdast = unified().use(remarkParse).use(remarkBreaks).parse(markdown);
+  // Markdown → mdast（remarkBreaksでソフト改行をbreak nodeに変換）
+  const remarkProcessor = unified().use(remarkParse).use(remarkBreaks);
+  const parsed = remarkProcessor.parse(markdown);
+  const mdast = (await remarkProcessor.run(parsed)) as typeof parsed;
 
   // mdast → hast（rehypeプラグイン適用）
   const hast = await unified()

--- a/web/src/lib/markdown/remark-breaks.test.ts
+++ b/web/src/lib/markdown/remark-breaks.test.ts
@@ -1,0 +1,93 @@
+import rehypeStringify from "rehype-stringify";
+import remarkBreaks from "remark-breaks";
+import remarkParse from "remark-parse";
+import remarkRehype from "remark-rehype";
+import { unified } from "unified";
+import { describe, expect, it } from "vitest";
+
+/**
+ * remarkBreaksが正しく適用されることを検証するテスト。
+ * .parse()だけではトランスフォーマーが実行されないため、
+ * .run()も呼び出す必要がある。
+ */
+describe("remarkBreaks", () => {
+  it("blockquote内の連続行が<br>で改行される", async () => {
+    const input = `> いつも使う児童生徒は「授業内容がよく分かっている」
+> １年間デジタル教科書を使うと学力調査の得点が向上した
+> アクセシビリティ機能により学習上の困難さを低減`;
+
+    const processor = unified()
+      .use(remarkParse)
+      .use(remarkBreaks)
+      .use(remarkRehype)
+      .use(rehypeStringify);
+
+    const result = await processor.process(input);
+    const output = result.toString();
+
+    expect(output).toContain("<br>");
+    expect(output).toContain("<blockquote>");
+  });
+
+  it("通常テキストの連続行も<br>で改行される", async () => {
+    const input = `1行目
+2行目
+3行目`;
+
+    const processor = unified()
+      .use(remarkParse)
+      .use(remarkBreaks)
+      .use(remarkRehype)
+      .use(rehypeStringify);
+
+    const result = await processor.process(input);
+    const output = result.toString();
+
+    expect(output).toContain("<br>");
+  });
+
+  it("parse()のみではremarkBreaksが適用されない（従来の問題）", () => {
+    const input = `> 1行目
+> 2行目`;
+
+    // parse()だけではトランスフォーマーは実行されない
+    const processor = unified().use(remarkParse).use(remarkBreaks);
+    const mdast = processor.parse(input);
+
+    // mdastにはbreakノードが含まれない（softBreakのまま）
+    const blockquote = mdast.children[0];
+    expect(blockquote.type).toBe("blockquote");
+    if (blockquote.type === "blockquote") {
+      const paragraph = blockquote.children[0];
+      if (paragraph.type === "paragraph") {
+        const hasBreak = paragraph.children.some(
+          (child: { type: string }) => child.type === "break"
+        );
+        expect(hasBreak).toBe(false);
+      }
+    }
+  });
+
+  it("run()を呼ぶとremarkBreaksが適用される（修正後の動作）", async () => {
+    const input = `> 1行目
+> 2行目`;
+
+    const processor = unified().use(remarkParse).use(remarkBreaks);
+    const parsed = processor.parse(input);
+    // biome-ignore lint/suspicious/noExplicitAny: mdast node types need runtime type narrowing
+    const mdast = (await processor.run(parsed)) as any;
+
+    // run()後はbreakノードが含まれる
+    const blockquote = mdast.children[0];
+    expect(blockquote.type).toBe("blockquote");
+    if (blockquote.type === "blockquote") {
+      const paragraph = blockquote.children[0];
+      if (paragraph.type === "paragraph") {
+        const hasBreak = paragraph.children.some(
+          (child: { type: string }) => child.type === "break"
+        );
+        expect(hasBreak).toBe(true);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- blockquote内の連続する `>` 行がスペース区切りのテキストとして表示され、改行されない問題を修正
- `remarkBreaks` プラグインが `.parse()` のみに登録されていたが、`.parse()` はトランスフォーマーを実行しないため、ソフト改行が `<br>` に変換されていなかった
- `.run()` を追加することで `remarkBreaks` のトランスフォーマーが正しく適用されるように修正

## 原因
`unified().use(remarkParse).use(remarkBreaks).parse(markdown)` の `.parse()` はパーサーのみ実行し、トランスフォーマー（remarkBreaks）は実行しない。そのため blockquote 内のソフト改行が break ノードに変換されず、HTML の `<br>` タグが生成されなかった。

## 修正内容
```diff
- const mdast = unified().use(remarkParse).use(remarkBreaks).parse(markdown);
+ const remarkProcessor = unified().use(remarkParse).use(remarkBreaks);
+ const parsed = remarkProcessor.parse(markdown);
+ const mdast = (await remarkProcessor.run(parsed)) as typeof parsed;
```

## Test plan
- [x] `pnpm lint` 通過
- [x] `pnpm typecheck` 通過
- [x] `pnpm test` 全639テスト通過
- [x] 新規テスト `remark-breaks.test.ts` で以下を検証:
  - `.parse()` のみでは remarkBreaks が適用されないこと（従来の問題）
  - `.run()` を呼ぶと remarkBreaks が適用されること（修正後の動作）
  - blockquote 内の連続行が `<br>` に変換されること
  - 通常テキストの連続行も `<br>` に変換されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>