### PR TITLE
feat: インタビューLPの予定時間をconfigから動的表示

### DIFF
--- a/web/src/features/bills/server/components/bill-detail/bill-detail-layout.tsx
+++ b/web/src/features/bills/server/components/bill-detail/bill-detail-layout.tsx
@@ -53,7 +53,10 @@ export async function BillDetailLayout({
       <Container>
         {interviewConfig != null && (
           <div className="my-8">
-            <InterviewLandingSection billId={bill.id} />
+            <InterviewLandingSection
+              billId={bill.id}
+              estimatedDuration={interviewConfig.estimated_duration}
+            />
           </div>
         )}
         {showMiraiStance && (

--- a/web/src/features/interview-config/client/components/interview-landing-section.tsx
+++ b/web/src/features/interview-config/client/components/interview-landing-section.tsx
@@ -2,16 +2,21 @@ import { ArrowRight, Check } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
+import { formatEstimatedDuration } from "@/features/interview-config/shared/utils/format-estimated-duration";
 
 interface InterviewLandingSectionProps {
   billId: string;
+  estimatedDuration: number | null;
 }
 
-const CHECK_POINTS = [
-  "所要時間は約5分〜",
-  "AIがあなたのご意見を深掘り",
-  "チームみらいの政策検討に活用",
-] as const;
+function getCheckPoints(estimatedDuration: number | null): string[] {
+  const durationText = formatEstimatedDuration(estimatedDuration);
+  return [
+    durationText ? `所要時間は${durationText}` : null,
+    "AIがあなたのご意見を深掘り",
+    "チームみらいの政策検討に活用",
+  ].filter((text): text is string => text !== null);
+}
 
 function _InterviewBadge() {
   return (
@@ -34,10 +39,15 @@ function _CheckPoint({ text }: { text: string }) {
   );
 }
 
-function _CheckPointsList() {
+function _CheckPointsList({
+  estimatedDuration,
+}: {
+  estimatedDuration: number | null;
+}) {
+  const checkPoints = getCheckPoints(estimatedDuration);
   return (
     <div className="flex flex-col gap-2">
-      {CHECK_POINTS.map((text) => (
+      {checkPoints.map((text) => (
         <_CheckPoint key={text} text={text} />
       ))}
     </div>
@@ -71,6 +81,7 @@ function _InterviewIllustration() {
 
 export function InterviewLandingSection({
   billId,
+  estimatedDuration,
 }: InterviewLandingSectionProps) {
   return (
     <div className="relative overflow-hidden rounded-xl bg-white p-6 mx-auto">
@@ -86,7 +97,7 @@ export function InterviewLandingSection({
             お聞かせください
           </h2>
 
-          <_CheckPointsList />
+          <_CheckPointsList estimatedDuration={estimatedDuration} />
 
           <div className="pt-2">
             <_InterviewCTAButton billId={billId} />

--- a/web/src/features/interview-config/client/components/interview-lp-page.tsx
+++ b/web/src/features/interview-config/client/components/interview-lp-page.tsx
@@ -10,6 +10,7 @@ import {
   getBillDetailLink,
   getInterviewDisclosureLink,
 } from "@/features/interview-config/shared/utils/interview-links";
+import { formatEstimatedDuration } from "@/features/interview-config/shared/utils/format-estimated-duration";
 import { InterviewActionButtons } from "./interview-action-buttons";
 
 interface InterviewLPPageProps {
@@ -169,14 +170,24 @@ function _InterviewOverviewSection({
   );
 }
 
-function _InterviewDurationSection() {
+function _InterviewDurationSection({
+  estimatedDuration,
+}: {
+  estimatedDuration: number | null;
+}) {
+  const durationText = formatEstimatedDuration(estimatedDuration);
+
+  if (!durationText) {
+    return null;
+  }
+
   return (
     <div className="w-full max-w-[370px] mx-auto bg-white rounded-2xl p-6 space-y-2">
       <h2 className="text-[22px] font-bold text-black leading-[1.64]">
         予定時間
       </h2>
       <p className="text-[22px] font-bold text-primary-accent leading-[1.64]">
-        約5分〜
+        {durationText}
       </p>
     </div>
   );
@@ -307,7 +318,9 @@ export function InterviewLPPage({
           billName={bill.bill_content?.title ?? bill.name}
           previewToken={previewToken}
         />
-        <_InterviewDurationSection />
+        <_InterviewDurationSection
+          estimatedDuration={interviewConfig.estimated_duration}
+        />
         <_InterviewThemesSection themes={interviewConfig.themes} />
         <_InterviewNoticeSection />
         <_InterviewDisclosureLink

--- a/web/src/features/interview-config/shared/utils/format-estimated-duration.test.ts
+++ b/web/src/features/interview-config/shared/utils/format-estimated-duration.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { formatEstimatedDuration } from "./format-estimated-duration";
+
+describe("formatEstimatedDuration", () => {
+  it("nullの場合はnullを返す", () => {
+    expect(formatEstimatedDuration(null)).toBeNull();
+  });
+
+  it("5分の場合は「約5分〜」を返す", () => {
+    expect(formatEstimatedDuration(5)).toBe("約5分〜");
+  });
+
+  it("10分の場合は「約10分〜」を返す", () => {
+    expect(formatEstimatedDuration(10)).toBe("約10分〜");
+  });
+
+  it("15分の場合は「約15分〜」を返す", () => {
+    expect(formatEstimatedDuration(15)).toBe("約15分〜");
+  });
+});

--- a/web/src/features/interview-config/shared/utils/format-estimated-duration.ts
+++ b/web/src/features/interview-config/shared/utils/format-estimated-duration.ts
@@ -1,0 +1,13 @@
+/**
+ * estimated_duration（分）を表示用テキストにフォーマットする。
+ * - 値がある場合: "約5分〜"
+ * - nullの場合: null を返す（表示しない判断を呼び出し側に委ねる）
+ */
+export function formatEstimatedDuration(
+  estimatedDuration: number | null
+): string | null {
+  if (estimatedDuration === null) {
+    return null;
+  }
+  return `約${estimatedDuration}分〜`;
+}


### PR DESCRIPTION
## Summary
- インタビューLPの「予定時間」セクションで、ハードコードされていた「約5分〜」を`interview_configs.estimated_duration`カラムの値から動的に生成するように変更
- `estimated_duration`がnullの場合、LP上の予定時間セクションおよび法案詳細ページのチェックポイントの所要時間行を非表示にする
- フォーマットロジックを`formatEstimatedDuration`純粋関数としてshared/utilsに切り出し、テストを追加

## 変更ファイル
- `interview-lp-page.tsx`: `_InterviewDurationSection`にconfigの`estimated_duration`を渡して動的表示、nullの場合は非表示
- `interview-landing-section.tsx`: `estimatedDuration` propを追加、チェックポイントの「所要時間は約5分〜」を動的生成
- `bill-detail-layout.tsx`: `InterviewLandingSection`に`estimatedDuration`を渡す
- `format-estimated-duration.ts`: 新規ユーティリティ関数
- `format-estimated-duration.test.ts`: テスト追加

## Test plan
- [x] `pnpm lint` パス
- [x] `pnpm typecheck` パス
- [x] `pnpm test` 全639テストパス（新規テスト4件含む）
- [x] Codexレビューパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)