### PR TITLE
fix: スタンスラベル「期待」「懸念」を「期待している」「懸念している」に変更

### DIFF
--- a/web/src/features/interview-report/shared/constants.ts
+++ b/web/src/features/interview-report/shared/constants.ts
@@ -2,8 +2,8 @@
  * スタンスのラベルマッピング
  */
 export const stanceLabels: Record<string, string> = {
-  for: "期待",
-  against: "懸念",
+  for: "期待している",
+  against: "懸念している",
   neutral: "期待と懸念両方がある",
 };
 


### PR DESCRIPTION
## Summary
- インタビューレポートのスタンス表示ラベルを「期待」→「期待している」、「懸念」→「懸念している」に変更

## Test plan
- [x] `pnpm lint` 通過
- [x] `pnpm typecheck` 通過
- [x] `pnpm test` 全635テスト通過
- [x] Codex CLIレビュー通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)