### PR TITLE
fix: インタビュー情報開示ページの視認性を改善

### DIFF
--- a/web/src/features/interview-config/server/components/interview-disclosure-page.tsx
+++ b/web/src/features/interview-config/server/components/interview-disclosure-page.tsx
@@ -13,14 +13,14 @@ interface InterviewDisclosurePageProps {
 function StaticDisclosureSection() {
   return (
     <div className="flex flex-col gap-3">
-      <h1 className="text-2xl font-bold text-black leading-[1.5]">
+      <h1 className="text-2xl font-bold text-black leading-[1.5] my-4">
         AIインタビューに関する情報開示
       </h1>
       <div className="bg-white rounded-2xl p-6 space-y-4">
         <h2 className="text-[22px] font-bold text-black leading-[1.64]">
           AIインタビューの透明性および技術仕様に関する開示事項
         </h2>
-        <div className="text-xs leading-[1.83] text-black space-y-4">
+        <div className="text-sm leading-[1.83] text-black space-y-4">
           <div>
             <p className="font-bold">
               AIインタビューの透明性と技術仕様について
@@ -107,20 +107,20 @@ function DynamicDisclosureSection({
         </p>
 
         <div className="space-y-2">
-          <p className="text-xs font-bold text-black">使用モデル</p>
-          <p className="text-xs leading-[1.83] text-black">
+          <p className="text-sm font-bold text-black">使用モデル</p>
+          <p className="text-sm leading-[1.83] text-black">
             対話エンジンには以下のモデルを採用しています。
           </p>
-          <p className="text-xs leading-[1.83] text-black">
+          <p className="text-sm leading-[1.83] text-black">
             モデル名称： {chatModel}
           </p>
         </div>
 
         <div className="space-y-2">
-          <p className="text-xs font-bold text-black">
+          <p className="text-sm font-bold text-black">
             インタビュー用プロンプト（指示書）
           </p>
-          <pre className="text-xs leading-[1.83] text-black whitespace-pre-wrap break-words">
+          <pre className="text-sm leading-[1.83] text-black whitespace-pre-wrap break-words">
             {systemPrompt}
           </pre>
         </div>
@@ -128,13 +128,13 @@ function DynamicDisclosureSection({
 
       <div className="bg-white rounded-2xl p-6 space-y-4">
         <div className="space-y-2">
-          <p className="text-xs font-bold text-black">
+          <p className="text-sm font-bold text-black">
             要約・レポート生成用プロンプト（指示書）
           </p>
-          <p className="text-xs leading-[1.83] text-black">
+          <p className="text-sm leading-[1.83] text-black">
             インタビュー終了後、回答内容をレポートにまとめる際にAIに与えられるプロンプトです。
           </p>
-          <pre className="text-xs leading-[1.83] text-black whitespace-pre-wrap break-words">
+          <pre className="text-sm leading-[1.83] text-black whitespace-pre-wrap break-words">
             {summaryPrompt}
           </pre>
         </div>
@@ -146,7 +146,7 @@ function DynamicDisclosureSection({
 export function InterviewDisclosurePage(props: InterviewDisclosurePageProps) {
   return (
     <div className="flex flex-col gap-8 pb-8 bg-mirai-light-gradient">
-      <div className="flex flex-col gap-8 px-4 pt-24 md:pt-12 max-w-[370px] mx-auto w-full">
+      <div className="flex flex-col gap-8 px-4 pt-24 md:pt-12 max-w-[600px] mx-auto w-full">
         <StaticDisclosureSection />
         <DynamicDisclosureSection {...props} />
       </div>


### PR DESCRIPTION
## Summary
- フォントサイズを `text-xs` から `text-sm` に拡大して可読性を向上
- 見出しに `my-4` マージンを追加してセクション間の余白を確保
- コンテナ幅を `max-w-[370px]` から `max-w-[600px]` に拡大して長文の読みやすさを改善

## Test plan
- [x] `pnpm lint` 通過
- [x] `pnpm typecheck` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the interview disclosure page layout with enhanced spacing and readability. Increased vertical margins and font sizes for headers and labels to make content more visually prominent. Expanded the content container width for a more spacious presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->