### PR TITLE
fix: レポート未生成時に「同意して提出」ボタンを表示しない

### DIFF
--- a/web/src/app/preview/bills/[id]/interview/chat/page.tsx
+++ b/web/src/app/preview/bills/[id]/interview/chat/page.tsx
@@ -88,6 +88,7 @@ export default async function InterviewPreviewChatPage({
           estimatedDuration={interviewConfig.estimated_duration}
           sessionStartedAt={session.started_at}
           hasRated={session.rating != null}
+          previewToken={token}
         />
       </>
     );

--- a/web/src/features/interview-session/client/components/interview-chat-client.tsx
+++ b/web/src/features/interview-session/client/components/interview-chat-client.tsx
@@ -32,6 +32,7 @@ interface InterviewChatClientProps {
   estimatedDuration?: number | null;
   sessionStartedAt?: string;
   hasRated?: boolean;
+  previewToken?: string;
 }
 
 export function InterviewChatClient({
@@ -43,6 +44,7 @@ export function InterviewChatClient({
   estimatedDuration,
   sessionStartedAt,
   hasRated,
+  previewToken,
 }: InterviewChatClientProps) {
   const {
     input,
@@ -137,6 +139,9 @@ export function InterviewChatClient({
 
   // ストリーミング中のメッセージを表示するかどうか
   const showStreamingMessage = object && !isStreamingMessageCommitted;
+
+  // メッセージ内にレポートが存在するかどうか
+  const hasReport = messages.some((m) => m.report != null);
 
   return (
     <div className="h-dvh md:h-[calc(100dvh-96px)] bg-mirai-surface-light">
@@ -251,6 +256,9 @@ export function InterviewChatClient({
           {(stage === "summary" || stage === "summary_complete") && (
             <InterviewSummaryInput
               sessionId={sessionId}
+              billId={billId}
+              hasReport={hasReport}
+              previewToken={previewToken}
               input={input}
               onInputChange={setInput}
               onSubmit={handleSubmit}

--- a/web/src/features/interview-session/client/components/interview-summary-input.tsx
+++ b/web/src/features/interview-session/client/components/interview-summary-input.tsx
@@ -1,14 +1,19 @@
 "use client";
 
+import Link from "next/link";
 import { useState } from "react";
 import type { PromptInputMessage } from "@/components/ai-elements/prompt-input";
 import { Button } from "@/components/ui/button";
+import { getBillDetailLink } from "@/features/interview-config/shared/utils/interview-links";
 import { InterviewPublicConsentModal } from "@/features/interview-report/client/components/interview-public-consent-modal";
 import { useInterviewCompletion } from "../hooks/use-interview-completion";
 import { InterviewChatInput } from "./interview-chat-input";
 
 interface InterviewSummaryInputProps {
   sessionId: string;
+  billId: string;
+  hasReport: boolean;
+  previewToken?: string;
   input: string;
   onInputChange: (value: string) => void;
   onSubmit: (message: PromptInputMessage) => void;
@@ -18,6 +23,9 @@ interface InterviewSummaryInputProps {
 
 export function InterviewSummaryInput({
   sessionId,
+  billId,
+  hasReport,
+  previewToken,
   input,
   onInputChange,
   onSubmit,
@@ -33,22 +41,35 @@ export function InterviewSummaryInput({
     <>
       {!isLoading && (
         <div className="mb-3 flex flex-col gap-2">
-          <Button onClick={() => setIsModalOpen(true)} disabled={isCompleting}>
-            {isCompleting ? "送信中..." : "レポート内容に同意して提出"}
-          </Button>
+          {hasReport ? (
+            <Button
+              onClick={() => setIsModalOpen(true)}
+              disabled={isCompleting}
+            >
+              {isCompleting ? "送信中..." : "レポート内容に同意して提出"}
+            </Button>
+          ) : (
+            <Button variant="outline" asChild>
+              <Link href={getBillDetailLink(billId, previewToken)}>
+                インタビューを終了する
+              </Link>
+            </Button>
+          )}
           {completeError && (
             <p className="text-sm text-red-500">{completeError}</p>
           )}
         </div>
       )}
-      <InterviewChatInput
-        input={input}
-        onInputChange={onInputChange}
-        onSubmit={onSubmit}
-        placeholder="レポートの修正要望があれば入力してください"
-        isResponding={isLoading}
-        error={error}
-      />
+      {hasReport && (
+        <InterviewChatInput
+          input={input}
+          onInputChange={onInputChange}
+          onSubmit={onSubmit}
+          placeholder="レポートの修正要望があれば入力してください"
+          isResponding={isLoading}
+          error={error}
+        />
+      )}
       <InterviewPublicConsentModal
         open={isModalOpen}
         onOpenChange={setIsModalOpen}


### PR DESCRIPTION
## Summary
- インタビューがすぐ終了してレポートが生成されなかった場合に「レポート内容に同意して提出」ボタンが表示され、クリックすると "No report found in conversation messages" エラーになる問題を修正
- レポートが存在しない場合は「インタビューを終了する」ボタンを表示し、法案詳細ページに遷移するように変更
- プレビューモードでの `previewToken` の伝播にも対応

## 変更内容
- `InterviewSummaryInput`: `hasReport` / `billId` / `previewToken` propsを追加し、レポート有無で表示を切り替え
- `InterviewChatClient`: メッセージ内のレポート有無を `hasReport` として算出し、`previewToken` と共に子コンポーネントへ伝播
- プレビューページ: `InterviewChatClient` に `previewToken` を渡すよう修正

## Test plan
- [x] `pnpm lint` パス
- [x] `pnpm typecheck` パス
- [x] `pnpm test` パス (635 tests passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)