### PR TITLE
fix: dev routesにtitle tagとrobots noindexを設定

### DIFF
--- a/web/src/app/dev/_lib/mock-data.ts
+++ b/web/src/app/dev/_lib/mock-data.ts
@@ -35,6 +35,7 @@ const baseBill: BillWithContent = {
   publish_status: "published",
   shugiin_url: null,
   status_note: null,
+  status_order: 3,
   diet_session_id: "mock-session",
   created_at: "2026-02-15T00:00:00Z",
   updated_at: "2026-02-15T00:00:00Z",

--- a/web/src/app/dev/layout.tsx
+++ b/web/src/app/dev/layout.tsx
@@ -1,5 +1,11 @@
+import type { Metadata } from "next";
 import type { ReactNode } from "react";
 import { DevSidebar } from "./_components/dev-sidebar";
+
+export const metadata: Metadata = {
+  title: "Component Gallery | Dev Preview",
+  robots: { index: false, follow: false },
+};
 
 export default function DevLayout({
   children,


### PR DESCRIPTION
## Summary

- dev layoutに `Component Gallery | Dev Preview` のtitleを設定
- `robots: noindex, nofollow` を設定（検索エンジンにインデックスされないように）
- mock-dataに `status_order` フィールドを追加（スキーマ変更への対応）

## Test plan

- [x] `pnpm lint` パス
- [x] `pnpm typecheck` パス
- [ ] `/dev` ページのtitleタグが `Component Gallery | Dev Preview` になること

🤖 Generated with [Claude Code](https://claude.com/claude-code)