### PR TITLE
feat: /devにインタビュー同意モーダルのプレビューを追加

### DIFF
--- a/web/src/app/dev/_lib/registry.ts
+++ b/web/src/app/dev/_lib/registry.ts
@@ -40,4 +40,14 @@ export const previewRegistry: PreviewGroup[] = [
       },
     ],
   },
+  {
+    name: "Interview",
+    items: [
+      {
+        path: "/dev/features/interview/consent-modal",
+        label: "ConsentModal",
+        description: "AIインタビュー同意モーダル",
+      },
+    ],
+  },
 ];

--- a/web/src/app/dev/features/interview/consent-modal/page.tsx
+++ b/web/src/app/dev/features/interview/consent-modal/page.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { InterviewConsentModal } from "@/features/interview-config/client/components/interview-consent-modal";
+import { ComponentShowcase } from "../../../_components/component-showcase";
+import { PreviewSection } from "../../../_components/preview-section";
+
+export default function ConsentModalPreview() {
+  const [openDefault, setOpenDefault] = useState(false);
+
+  return (
+    <>
+      <h1 className="text-3xl font-bold text-mirai-text mb-8">
+        InterviewConsentModal
+      </h1>
+
+      <ComponentShowcase
+        title="Default"
+        description="AIインタビュー同意モーダル"
+      >
+        <PreviewSection label="通常表示">
+          <Button onClick={() => setOpenDefault(true)}>モーダルを開く</Button>
+          <InterviewConsentModal
+            open={openDefault}
+            onOpenChange={setOpenDefault}
+            billId="mock-bill-001"
+          />
+        </PreviewSection>
+      </ComponentShowcase>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- 開発用UIプレビュー環境（`/dev`）にインタビュー同意モーダル（`InterviewConsentModal`）のプレビューページを追加
- レジストリに「Interview」グループを新設し、ConsentModalエントリを登録

## 変更内容
- `web/src/app/dev/features/interview/consent-modal/page.tsx`: モーダルプレビューページ（Client Component）
- `web/src/app/dev/_lib/registry.ts`: Interviewグループの追加

## Test plan
- [x] `pnpm lint` パス
- [x] `pnpm typecheck` パス（既存のmock-data型エラーのみ）
- [x] `pnpm test` 全643テストパス
- [x] Codex review パス
- [ ] `/dev/features/interview/consent-modal` でモーダルが正しく表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)