### PR TITLE
fix: /dev routesのサイドバーをモバイル対応

### DIFF
--- a/web/src/app/dev/_components/dev-sidebar.tsx
+++ b/web/src/app/dev/_components/dev-sidebar.tsx
@@ -2,17 +2,17 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { useCallback, useEffect, useState } from "react";
+import { Menu, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { previewRegistry } from "../_lib/registry";
 
-export function DevSidebar() {
+function SidebarContent({ onNavigate }: { onNavigate?: () => void }) {
   const pathname = usePathname();
 
   return (
-    <nav className="w-64 shrink-0 border-r border-mirai-border bg-white p-4 sticky top-0 h-dvh overflow-y-auto">
-      <Link href="/dev" className="text-lg font-bold mb-6 block">
-        Component Gallery
-      </Link>
+    <>
       {previewRegistry.map((group) => (
         <div key={group.name} className="mb-4">
           <h3 className="text-xs font-semibold text-mirai-text-secondary uppercase tracking-wider mb-2">
@@ -23,6 +23,7 @@ export function DevSidebar() {
               <li key={item.path}>
                 <Link
                   href={item.path}
+                  onClick={onNavigate}
                   className={cn(
                     "block px-3 py-1.5 rounded text-sm transition-colors",
                     pathname === item.path
@@ -37,6 +38,69 @@ export function DevSidebar() {
           </ul>
         </div>
       ))}
-    </nav>
+    </>
+  );
+}
+
+export function DevSidebar() {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const close = useCallback(() => setIsOpen(false), []);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") close();
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, close]);
+
+  return (
+    <>
+      {/* Mobile: hamburger button */}
+      <Button
+        variant="outline"
+        size="icon"
+        className="fixed top-3 left-3 z-50 md:hidden"
+        onClick={() => setIsOpen(true)}
+        aria-label="メニューを開く"
+      >
+        <Menu className="h-5 w-5" />
+      </Button>
+
+      {/* Mobile: overlay + drawer */}
+      {isOpen && (
+        <div className="fixed inset-0 z-50 md:hidden">
+          {/* biome-ignore lint/a11y/noStaticElementInteractions: backdrop overlay click-to-close */}
+          {/* biome-ignore lint/a11y/useKeyWithClickEvents: Escape handled via document listener */}
+          <div className="absolute inset-0 bg-black/40" onClick={close} />
+          <nav className="absolute inset-y-0 left-0 w-64 bg-white p-4 overflow-y-auto shadow-lg">
+            <div className="flex items-center justify-between mb-6">
+              <Link href="/dev" onClick={close} className="text-lg font-bold">
+                Component Gallery
+              </Link>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={close}
+                aria-label="メニューを閉じる"
+              >
+                <X className="h-5 w-5" />
+              </Button>
+            </div>
+            <SidebarContent onNavigate={close} />
+          </nav>
+        </div>
+      )}
+
+      {/* Desktop: static sidebar */}
+      <nav className="hidden md:block w-64 shrink-0 border-r border-mirai-border bg-white p-4 sticky top-0 h-dvh overflow-y-auto">
+        <Link href="/dev" className="text-lg font-bold mb-6 block">
+          Component Gallery
+        </Link>
+        <SidebarContent />
+      </nav>
+    </>
   );
 }

--- a/web/src/app/dev/_lib/mock-data.ts
+++ b/web/src/app/dev/_lib/mock-data.ts
@@ -35,6 +35,7 @@ const baseBill: BillWithContent = {
   publish_status: "published",
   shugiin_url: null,
   status_note: null,
+  status_order: 3,
   diet_session_id: "mock-session",
   created_at: "2026-02-15T00:00:00Z",
   updated_at: "2026-02-15T00:00:00Z",

--- a/web/src/app/dev/layout.tsx
+++ b/web/src/app/dev/layout.tsx
@@ -9,7 +9,7 @@ export default function DevLayout({
   return (
     <div className="flex min-h-dvh">
       <DevSidebar />
-      <div className="flex-1 p-8 overflow-y-auto">{children}</div>
+      <div className="flex-1 p-4 md:p-8 overflow-y-auto">{children}</div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- モバイル（md未満）ではサイドバーを非表示にし、ハンバーガーメニュー+ドロワーで開閉
- デスクトップ（md以上）では従来通り常時表示
- Escapeキーでドロワーを閉じる対応（documentレベルリスナー）
- レイアウトのパディングをレスポンシブ化（`p-4 md:p-8`）

## Test plan
- [x] `pnpm lint` 通過
- [x] `pnpm typecheck` 通過
- [x] `pnpm test` 全テスト通過
- [ ] モバイル幅（375px）でハンバーガーメニュー表示確認
- [ ] メニュー開閉、リンク遷移で自動クローズ確認
- [ ] デスクトップ幅でサイドバー常時表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)