### PR TITLE
fix: プレビューセクションの背景削除とモーダルアイコン位置微調整

### DIFF
--- a/web/src/app/dev/_components/preview-section.tsx
+++ b/web/src/app/dev/_components/preview-section.tsx
@@ -11,9 +11,7 @@ export function PreviewSection({ label, children }: PreviewSectionProps) {
       <h3 className="text-sm font-medium text-mirai-text-secondary mb-2">
         {label}
       </h3>
-      <div className="p-4 bg-mirai-surface-light rounded-lg border border-mirai-border">
-        {children}
-      </div>
+      <div className="p-4">{children}</div>
     </div>
   );
 }

--- a/web/src/features/interview-report/client/components/interview-public-consent-modal.tsx
+++ b/web/src/features/interview-report/client/components/interview-public-consent-modal.tsx
@@ -26,7 +26,7 @@ function CheckListItem({ children }: { children: ReactNode }) {
         alt=""
         width={20}
         height={20}
-        className="flex-shrink-0 mt-0.5"
+        className="flex-shrink-0 mt-1"
       />
       <p className="text-sm font-medium leading-relaxed">{children}</p>
     </div>

--- a/web/src/features/interview-report/client/components/make-private-modal.tsx
+++ b/web/src/features/interview-report/client/components/make-private-modal.tsx
@@ -26,7 +26,7 @@ function CheckListItem({ children }: { children: ReactNode }) {
         alt=""
         width={20}
         height={20}
-        className="flex-shrink-0 mt-0.5"
+        className="flex-shrink-0 mt-1"
       />
       <p className="text-sm font-medium leading-relaxed">{children}</p>
     </div>

--- a/web/src/features/interview-report/client/components/make-public-modal.tsx
+++ b/web/src/features/interview-report/client/components/make-public-modal.tsx
@@ -26,7 +26,7 @@ function CheckListItem({ children }: { children: ReactNode }) {
         alt=""
         width={20}
         height={20}
-        className="flex-shrink-0 mt-0.5"
+        className="flex-shrink-0 mt-1"
       />
       <p className="text-sm font-medium leading-relaxed">{children}</p>
     </div>


### PR DESCRIPTION
## Summary
- `/dev` プレビューセクションの背景色・ボーダーを削除し、コンテンツをそのまま表示するようシンプル化
- インタビュー公開設定モーダル3種（同意・公開・非公開）のチェックリストアイコンの上マージンを `mt-0.5` → `mt-1` に微調整

## Test plan
- [x] `pnpm lint` 通過
- [x] `pnpm typecheck` 通過
- [x] `pnpm test` 全643テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined vertical alignment of icons throughout interview consent and privacy management modals for improved visual consistency
  * Adjusted spacing in checklist items across consent, privacy, and public disclosure modals
  * Simplified preview section styling by removing background color and border effects for a cleaner appearance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->