### PR TITLE
refactor: is_public_by_userをinterview_reportテーブルに移動

### DIFF
--- a/packages/seed/main/data.ts
+++ b/packages/seed/main/data.ts
@@ -265,7 +265,7 @@ export function createInterviewSessions(
   for (let i = 0; i < 20; i++) {
     const baseOffset = i * 86400000 * 3; // 3日ずつずらす
 
-    // パターン1: 完了 + レポートあり（賛成）- 最初の5件は公開
+    // パターン1: 完了 + レポートあり（賛成）
     sessions.push({
       interview_config_id: interviewConfigId,
       user_id: `00000000-0000-0000-0000-${String(i * 5 + 1).padStart(12, "0")}`,
@@ -273,10 +273,9 @@ export function createInterviewSessions(
       completed_at: new Date(
         now.getTime() - baseOffset - 3000000
       ).toISOString(),
-      is_public_by_user: i < 5, // 最初の5件は公開
     });
 
-    // パターン2: 完了 + レポートあり（反対）- 最初の5件は公開
+    // パターン2: 完了 + レポートあり（反対）
     sessions.push({
       interview_config_id: interviewConfigId,
       user_id: `00000000-0000-0000-0000-${String(i * 5 + 2).padStart(12, "0")}`,
@@ -284,10 +283,9 @@ export function createInterviewSessions(
       completed_at: new Date(
         now.getTime() - baseOffset - 6600000
       ).toISOString(),
-      is_public_by_user: i < 5, // 最初の5件は公開
     });
 
-    // パターン3: 完了 + レポートあり（中立）- 最初の5件は公開
+    // パターン3: 完了 + レポートあり（中立）
     sessions.push({
       interview_config_id: interviewConfigId,
       user_id: `00000000-0000-0000-0000-${String(i * 5 + 3).padStart(12, "0")}`,
@@ -295,7 +293,6 @@ export function createInterviewSessions(
       completed_at: new Date(
         now.getTime() - baseOffset - 10200000
       ).toISOString(),
-      is_public_by_user: i < 5, // 最初の5件は公開
     });
 
     // パターン4: 完了したけどレポート未作成
@@ -306,7 +303,6 @@ export function createInterviewSessions(
       completed_at: new Date(
         now.getTime() - baseOffset - 13800000
       ).toISOString(),
-      is_public_by_user: false,
     });
 
     // パターン5: 進行中（未完了、レポートなし）
@@ -315,7 +311,6 @@ export function createInterviewSessions(
       user_id: `00000000-0000-0000-0000-${String(i * 5 + 5).padStart(12, "0")}`,
       started_at: new Date(now.getTime() - baseOffset - 1800000).toISOString(),
       completed_at: null,
-      is_public_by_user: false,
     });
   }
 
@@ -423,9 +418,11 @@ export function createInterviewReports(
   sessionIds.forEach((sessionId, index) => {
     const patternIndex = index % 5;
     if (patternIndex < 3) {
+      const loopIndex = Math.floor(index / 5);
       reports.push({
         interview_session_id: sessionId,
         ...reportTemplates[patternIndex],
+        is_public_by_user: loopIndex < 5, // 最初の5件は公開
       });
     }
   });
@@ -456,7 +453,6 @@ export function createDemoSession(
     user_id: "00000000-0000-0000-0000-000000000000",
     started_at: new Date(now.getTime() - 3600000).toISOString(),
     completed_at: new Date(now.getTime() - 3000000).toISOString(),
-    is_public_by_user: true,
   };
 }
 
@@ -514,6 +510,7 @@ export function createDemoReport(): InterviewReportInsert {
           "省庁のレスポンスの速さや、官僚の長時間労働が削減され、よりよい人材が官僚になっていく事を期待している。",
       },
     ],
+    is_public_by_user: true,
   };
 }
 
@@ -529,7 +526,6 @@ export function createAdditionalDemoSessions(
       user_id: "00000000-0000-0000-0000-000000000010",
       started_at: new Date(now.getTime() - 7200000).toISOString(),
       completed_at: new Date(now.getTime() - 6600000).toISOString(),
-      is_public_by_user: true,
     },
     {
       id: DEMO_SESSION_ID_DAILY,
@@ -537,15 +533,13 @@ export function createAdditionalDemoSessions(
       user_id: "00000000-0000-0000-0000-000000000011",
       started_at: new Date(now.getTime() - 10800000).toISOString(),
       completed_at: new Date(now.getTime() - 10200000).toISOString(),
-      is_public_by_user: true,
     },
     {
       id: DEMO_SESSION_ID_CITIZEN,
       interview_config_id: interviewConfigId,
       user_id: "00000000-0000-0000-0000-000000000012",
       started_at: new Date(now.getTime() - 14400000).toISOString(),
-      completed_at: new Date(now.getTime() - 13800000).toISOString(),
-      is_public_by_user: true,
+      completed_at: new Date(now.getTime() - 10200000).toISOString(),
     },
   ];
 }
@@ -655,6 +649,7 @@ export function createAdditionalDemoReports(): InterviewReportInsert[] {
             "運送会社を経営しているが、燃料費が経営を圧迫している。暫定税率廃止で少しでも負担が減れば助かる。",
         },
       ],
+      is_public_by_user: true,
     },
     {
       id: DEMO_REPORT_ID_DAILY,
@@ -671,6 +666,7 @@ export function createAdditionalDemoReports(): InterviewReportInsert[] {
             "通勤や買い物、子供の送り迎えなど毎日車を使っている。公共交通機関がほとんどない地域なのでガソリン代が下がると助かる。",
         },
       ],
+      is_public_by_user: true,
     },
     {
       id: DEMO_REPORT_ID_CITIZEN,
@@ -686,6 +682,7 @@ export function createAdditionalDemoReports(): InterviewReportInsert[] {
             "ガソリン車から電気自動車への移行も進めつつ、当面の生活支援として減税があってもいいと考える。",
         },
       ],
+      is_public_by_user: true,
     },
   ];
 }

--- a/packages/supabase/types/supabase.types.ts
+++ b/packages/supabase/types/supabase.types.ts
@@ -448,6 +448,7 @@ export type Database = {
           id: string
           interview_session_id: string
           is_public_by_admin: boolean
+          is_public_by_user: boolean
           opinions: Json | null
           role: Database["public"]["Enums"]["interview_report_role_enum"] | null
           role_description: string | null
@@ -463,6 +464,7 @@ export type Database = {
           id?: string
           interview_session_id: string
           is_public_by_admin?: boolean
+          is_public_by_user?: boolean
           opinions?: Json | null
           role?:
             | Database["public"]["Enums"]["interview_report_role_enum"]
@@ -480,6 +482,7 @@ export type Database = {
           id?: string
           interview_session_id?: string
           is_public_by_admin?: boolean
+          is_public_by_user?: boolean
           opinions?: Json | null
           role?:
             | Database["public"]["Enums"]["interview_report_role_enum"]
@@ -509,7 +512,6 @@ export type Database = {
           created_at: string
           id: string
           interview_config_id: string
-          is_public_by_user: boolean
           langfuse_session_id: string | null
           rating: number | null
           started_at: string
@@ -522,7 +524,6 @@ export type Database = {
           created_at?: string
           id?: string
           interview_config_id: string
-          is_public_by_user?: boolean
           langfuse_session_id?: string | null
           rating?: number | null
           started_at?: string
@@ -535,7 +536,6 @@ export type Database = {
           created_at?: string
           id?: string
           interview_config_id?: string
-          is_public_by_user?: boolean
           langfuse_session_id?: string | null
           rating?: number | null
           started_at?: string

--- a/supabase/migrations/20260301083150_move_is_public_by_user_to_interview_report.sql
+++ b/supabase/migrations/20260301083150_move_is_public_by_user_to_interview_report.sql
@@ -1,0 +1,18 @@
+-- Move is_public_by_user from interview_sessions to interview_report
+-- This column belongs on the report as it represents user consent for report publication
+
+-- Step 1: Add is_public_by_user to interview_report
+ALTER TABLE interview_report
+ADD COLUMN is_public_by_user BOOLEAN NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN interview_report.is_public_by_user IS 'Whether the user has consented to making their interview report public';
+
+-- Step 2: Migrate existing data from interview_sessions to interview_report
+UPDATE interview_report
+SET is_public_by_user = interview_sessions.is_public_by_user
+FROM interview_sessions
+WHERE interview_report.interview_session_id = interview_sessions.id;
+
+-- Step 3: Drop the column from interview_sessions
+ALTER TABLE interview_sessions
+DROP COLUMN is_public_by_user;

--- a/web/src/app/api/interview/complete/route.ts
+++ b/web/src/app/api/interview/complete/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { updateSessionPublicSetting } from "@/features/interview-report/server/repositories/interview-report-repository";
+import { updateReportPublicSetting } from "@/features/interview-report/server/repositories/interview-report-repository";
 import { completeInterviewSession } from "@/features/interview-session/server/services/complete-interview-session";
 import { verifySessionOwnership } from "@/features/interview-session/server/utils/verify-session-ownership";
 
@@ -21,7 +21,7 @@ export async function POST(req: Request) {
     });
 
     if (typeof isPublic === "boolean") {
-      await updateSessionPublicSetting(sessionId, isPublic);
+      await updateReportPublicSetting(report.id, isPublic);
     }
 
     return NextResponse.json({ report });

--- a/web/src/features/interview-report/server/actions/update-public-setting.ts
+++ b/web/src/features/interview-report/server/actions/update-public-setting.ts
@@ -1,7 +1,10 @@
 "use server";
 
 import { verifySessionOwnership } from "@/features/interview-session/server/utils/verify-session-ownership";
-import { updateSessionPublicSetting } from "../repositories/interview-report-repository";
+import {
+  findReportBySessionId,
+  updateReportPublicSetting,
+} from "../repositories/interview-report-repository";
 
 interface UpdatePublicSettingResult {
   success: boolean;
@@ -9,7 +12,7 @@ interface UpdatePublicSettingResult {
 }
 
 /**
- * インタビューセッションの公開設定を更新する
+ * インタビューレポートの公開設定を更新する
  */
 export async function updatePublicSetting(
   sessionId: string,
@@ -22,7 +25,8 @@ export async function updatePublicSetting(
   }
 
   try {
-    await updateSessionPublicSetting(sessionId, isPublic);
+    const report = await findReportBySessionId(sessionId);
+    await updateReportPublicSetting(report.id, isPublic);
     return { success: true };
   } catch {
     return { success: false, error: "公開設定の更新に失敗しました" };

--- a/web/src/features/interview-report/server/loaders/get-interview-report-by-id.ts
+++ b/web/src/features/interview-report/server/loaders/get-interview-report-by-id.ts
@@ -11,7 +11,6 @@ export type InterviewReportWithSessionInfo = InterviewReport & {
   bill_id: string;
   session_started_at: string;
   session_completed_at: string | null;
-  is_public_by_user: boolean;
 };
 
 /**
@@ -44,7 +43,6 @@ export async function getInterviewReportById(
     user_id: string;
     started_at: string;
     completed_at: string | null;
-    is_public_by_user: boolean;
     interview_configs: { bill_id: string } | null;
   } | null;
 
@@ -57,7 +55,7 @@ export async function getInterviewReportById(
   const isOwner = isSessionOwner(session.user_id, userId);
   const isAllowed = options?.onlyOwner
     ? isOwner
-    : session.is_public_by_user || isOwner;
+    : report.is_public_by_user || isOwner;
 
   if (!isAllowed) {
     console.error("Unauthorized access to interview report");
@@ -77,6 +75,5 @@ export async function getInterviewReportById(
     bill_id: session.interview_configs.bill_id,
     session_started_at: session.started_at,
     session_completed_at: session.completed_at,
-    is_public_by_user: session.is_public_by_user,
   };
 }

--- a/web/src/features/interview-report/server/loaders/get-report-with-messages.ts
+++ b/web/src/features/interview-report/server/loaders/get-report-with-messages.ts
@@ -17,7 +17,6 @@ export type ReportWithMessages = {
     bill_id: string;
     session_started_at: string;
     session_completed_at: string | null;
-    is_public_by_user: boolean;
   };
   messages: InterviewMessage[];
   bill: {
@@ -52,7 +51,6 @@ export async function getReportWithMessages(
     user_id: string;
     started_at: string;
     completed_at: string | null;
-    is_public_by_user: boolean;
     interview_configs: { bill_id: string } | null;
   } | null;
 
@@ -63,7 +61,7 @@ export async function getReportWithMessages(
 
   // Authorization check: public OR owner
   const isOwner = userId ? isSessionOwner(session.user_id, userId) : false;
-  const isPublic = session.is_public_by_user;
+  const isPublic = report.is_public_by_user;
 
   if (!isPublic && !isOwner) {
     console.error("Unauthorized access to interview report chat log");
@@ -96,7 +94,6 @@ export async function getReportWithMessages(
       bill_id: session.interview_configs.bill_id,
       session_started_at: session.started_at,
       session_completed_at: session.completed_at,
-      is_public_by_user: session.is_public_by_user,
     },
     messages: messages || [],
     bill: {

--- a/web/src/features/interview-report/server/repositories/interview-report-repository.ts
+++ b/web/src/features/interview-report/server/repositories/interview-report-repository.ts
@@ -10,7 +10,7 @@ export async function findReportWithSessionById(reportId: string) {
   const { data, error } = await supabase
     .from("interview_report")
     .select(
-      "*, interview_sessions(user_id, started_at, completed_at, is_public_by_user, interview_configs(bill_id))"
+      "*, interview_sessions(user_id, started_at, completed_at, interview_configs(bill_id))"
     )
     .eq("id", reportId)
     .single();
@@ -77,17 +77,17 @@ export async function findBillWithContentById(billId: string) {
 }
 
 /**
- * セッションの公開設定を更新
+ * レポートの公開設定を更新
  */
-export async function updateSessionPublicSetting(
-  sessionId: string,
+export async function updateReportPublicSetting(
+  reportId: string,
   isPublic: boolean
 ) {
   const supabase = createAdminClient();
   const { error } = await supabase
-    .from("interview_sessions")
+    .from("interview_report")
     .update({ is_public_by_user: isPublic })
-    .eq("id", sessionId);
+    .eq("id", reportId);
 
   if (error) {
     throw new Error(`Failed to update public setting: ${error.message}`);


### PR DESCRIPTION
## Summary
- `is_public_by_user`カラムを`interview_sessions`テーブルから`interview_report`テーブルに移動
- マイグレーションで既存データを自動移行（session→report）
- リポジトリ層・ローダー・アクション・APIルート・シードデータを一括更新

## Why
ユーザーの公開同意フラグはセッションではなくレポートに属するべき（`is_public_by_admin`と同じテーブルに配置）

## Changes
- **Migration**: `interview_sessions`から`interview_report`へカラム移動（データ移行込み）
- **Repository**: `updateSessionPublicSetting` → `updateReportPublicSetting`（reportId指定に変更）
- **Loaders**: session経由の参照からreport直接参照に変更
- **Action**: sessionId経由でreportを取得してから更新する方式に変更
- **API route**: `completeInterviewSession`の返り値から`report.id`を使用
- **Seed data**: `is_public_by_user`をsessionデータからreportデータに移動
- **Types**: Supabase型定義を再生成

## Test plan
- [x] `pnpm typecheck` 通過
- [x] `pnpm lint` 通過
- [x] `pnpm test` 全テスト通過
- [x] `supabase db reset` でマイグレーション正常適用
- [x] Codex CLIレビュー通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured public visibility controls by relocating the visibility flag from interview sessions to interview reports across the data layer.

* **Chores**
  * Added database migration to move public visibility setting from sessions to reports.
  * Updated type definitions and data loaders to align with new visibility flag location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->