### PR TITLE
feat: 法案に対する当事者の意見一覧ページを追加

### DIFF
--- a/web/src/app/(main)/bills/[id]/opinions/page.tsx
+++ b/web/src/app/(main)/bills/[id]/opinions/page.tsx
@@ -1,0 +1,27 @@
+import type { Metadata } from "next";
+import { getBillById } from "@/features/bills/server/loaders/get-bill-by-id";
+import { PublicOpinionsPage } from "@/features/interview-report/server/components/public-opinions-page";
+
+interface OpinionsPageProps {
+  params: Promise<{
+    id: string;
+  }>;
+}
+
+export async function generateMetadata({
+  params,
+}: OpinionsPageProps): Promise<Metadata> {
+  const { id } = await params;
+  const bill = await getBillById(id);
+  const title = bill?.bill_content?.title || bill?.name || "法案";
+
+  return {
+    title: `当事者の意見 - ${title}`,
+    description: `${title}に対する当事者の意見一覧`,
+  };
+}
+
+export default async function OpinionsPage({ params }: OpinionsPageProps) {
+  const { id } = await params;
+  return <PublicOpinionsPage billId={id} />;
+}

--- a/web/src/features/bills/server/components/bill-detail/bill-detail-layout.tsx
+++ b/web/src/features/bills/server/components/bill-detail/bill-detail-layout.tsx
@@ -67,6 +67,7 @@ export async function BillDetailLayout({
         {publicReportsResult.totalCount > 0 && (
           <div className="my-8">
             <BillInterviewOpinionsSection
+              billId={bill.id}
               reports={publicReportsResult.reports}
               totalCount={publicReportsResult.totalCount}
             />

--- a/web/src/features/interview-report/client/components/public-opinions-list.tsx
+++ b/web/src/features/interview-report/client/components/public-opinions-list.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { cn } from "@/lib/utils";
+import { ReportCard } from "../../shared/components/report-card";
+import type { PublicInterviewReport } from "../../server/loaders/get-public-reports-by-bill-id";
+import {
+  type StanceFilter,
+  countReportsByStance,
+  filterReportsByStance,
+  stanceFilterLabels,
+  stanceFilterOrder,
+} from "../../shared/utils/stance-filter";
+
+function _FilterChip({
+  label,
+  count,
+  isActive,
+  onClick,
+}: {
+  label: string;
+  count: number;
+  isActive: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "inline-flex items-center gap-1 px-3 py-1.5 rounded-[50px] h-[29px] text-sm font-bold transition-colors",
+        isActive
+          ? "bg-mirai-gradient text-mirai-text"
+          : "bg-white text-gray-300"
+      )}
+    >
+      <span>{label}</span>
+      <span className="text-xs font-bold">{count}</span>
+    </button>
+  );
+}
+
+interface PublicOpinionsListProps {
+  reports: PublicInterviewReport[];
+}
+
+export function PublicOpinionsList({ reports }: PublicOpinionsListProps) {
+  const [activeFilter, setActiveFilter] = useState<StanceFilter>("all");
+
+  const counts = useMemo(() => countReportsByStance(reports), [reports]);
+  const filteredReports = useMemo(
+    () => filterReportsByStance(reports, activeFilter),
+    [reports, activeFilter]
+  );
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* セクションヘッダー */}
+      <div className="flex items-center gap-4">
+        <h2 className="text-[22px] font-bold leading-[1.636] text-mirai-text">
+          <span className="mr-1">💬</span>法案に対する当事者の意見
+        </h2>
+        <span className="text-[22px] font-bold leading-[1.636] text-mirai-text">
+          {reports.length}件
+        </span>
+      </div>
+
+      {/* フィルター */}
+      <div className="flex gap-3 overflow-x-auto">
+        {stanceFilterOrder.map((filter) => (
+          <_FilterChip
+            key={filter}
+            label={stanceFilterLabels[filter]}
+            count={counts[filter]}
+            isActive={activeFilter === filter}
+            onClick={() => setActiveFilter(filter)}
+          />
+        ))}
+      </div>
+
+      {/* レポートカード一覧 */}
+      <div className="flex flex-col gap-4">
+        {filteredReports.map((report) => (
+          <ReportCard key={report.id} report={report} />
+        ))}
+        {filteredReports.length === 0 && (
+          <p className="text-center text-mirai-text-muted py-8">
+            該当する意見はありません
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/features/interview-report/server/components/bill-interview-opinions-section.tsx
+++ b/web/src/features/interview-report/server/components/bill-interview-opinions-section.tsx
@@ -1,91 +1,19 @@
 import "server-only";
 
-import Image from "next/image";
 import Link from "next/link";
-import { cn } from "@/lib/utils";
-import {
-  type InterviewReportRole,
-  formatRoleLabel,
-  roleIcons,
-  stanceLabels,
-  stanceTextColors,
-} from "../../shared/constants";
-import { formatRelativeTime } from "../../shared/utils/format-relative-time";
+import { ChevronRight } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { ReportCard } from "../../shared/components/report-card";
 import type { PublicInterviewReport } from "../loaders/get-public-reports-by-bill-id";
 
-const SUMMARY_MAX_LENGTH = 80;
-
-function _ReportCard({ report }: { report: PublicInterviewReport }) {
-  const stanceLabel = report.stance
-    ? stanceLabels[report.stance] || report.stance
-    : null;
-  const stanceTextColor = report.stance
-    ? stanceTextColors[report.stance] || ""
-    : "";
-  const RoleIcon = report.role
-    ? roleIcons[report.role as InterviewReportRole]
-    : null;
-  const roleLabel = formatRoleLabel(report.role, report.role_title);
-  const relativeTime = formatRelativeTime(report.created_at);
-
-  const summary = report.summary || "";
-  const truncatedSummary =
-    summary.length > SUMMARY_MAX_LENGTH
-      ? `${summary.slice(0, SUMMARY_MAX_LENGTH)}...`
-      : summary;
-
-  return (
-    <Link
-      href={`/report/${report.id}/chat-log`}
-      className="block bg-white rounded-lg p-4 hover:bg-gray-50 transition-colors"
-    >
-      {/* ヘッダー: スタンスアイコン + スタンスラベル + 役割 + 日時 */}
-      <div className="flex items-center gap-2">
-        {report.stance && (
-          <Image
-            src={`/icons/stance-${report.stance}.png`}
-            alt={stanceLabel || ""}
-            width={38}
-            height={38}
-            className="rounded-full flex-shrink-0"
-          />
-        )}
-        <div className="flex flex-col gap-0.5 min-w-0 flex-1">
-          {stanceLabel && (
-            <span className={cn("text-base font-bold", stanceTextColor)}>
-              {stanceLabel}
-            </span>
-          )}
-          <div className="flex items-center gap-2">
-            {roleLabel && (
-              <div className="flex items-center gap-0.5 text-mirai-text-subtle">
-                {RoleIcon && <RoleIcon size={16} className="flex-shrink-0" />}
-                <span className="text-xs">{roleLabel}</span>
-              </div>
-            )}
-            <span className="text-[13px] text-mirai-text-muted leading-[1.2]">
-              {relativeTime}
-            </span>
-          </div>
-        </div>
-      </div>
-
-      {/* 本文 */}
-      {truncatedSummary && (
-        <p className="mt-2 text-[13px] leading-[1.692] text-black">
-          {truncatedSummary}
-        </p>
-      )}
-    </Link>
-  );
-}
-
 interface BillInterviewOpinionsSectionProps {
+  billId: string;
   reports: PublicInterviewReport[];
   totalCount: number;
 }
 
 export function BillInterviewOpinionsSection({
+  billId,
   reports,
   totalCount,
 }: BillInterviewOpinionsSectionProps) {
@@ -108,9 +36,21 @@ export function BillInterviewOpinionsSection({
       {/* レポートカード一覧 */}
       <div className="flex flex-col gap-4">
         {reports.map((report) => (
-          <_ReportCard key={report.id} report={report} />
+          <ReportCard key={report.id} report={report} />
         ))}
       </div>
+
+      {/* もっと読むリンク */}
+      {totalCount > reports.length && (
+        <div className="flex justify-center">
+          <Button variant="outline" asChild>
+            <Link href={`/bills/${billId}/opinions`}>
+              もっと読む
+              <ChevronRight size={16} />
+            </Link>
+          </Button>
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/features/interview-report/server/components/public-opinions-page.tsx
+++ b/web/src/features/interview-report/server/components/public-opinions-page.tsx
@@ -1,0 +1,71 @@
+import "server-only";
+
+import Image from "next/image";
+import { notFound } from "next/navigation";
+import { Container } from "@/components/layouts/container";
+import { getBillById } from "@/features/bills/server/loaders/get-bill-by-id";
+import { InterviewLandingSection } from "@/features/interview-config/client/components/interview-landing-section";
+import { getInterviewConfig } from "@/features/interview-config/server/loaders/get-interview-config";
+import { PublicOpinionsList } from "../../client/components/public-opinions-list";
+import { getAllPublicReportsByBillId } from "../loaders/get-all-public-reports-by-bill-id";
+
+interface PublicOpinionsPageProps {
+  billId: string;
+}
+
+export async function PublicOpinionsPage({ billId }: PublicOpinionsPageProps) {
+  const [bill, reports, interviewConfig] = await Promise.all([
+    getBillById(billId),
+    getAllPublicReportsByBillId(billId),
+    getInterviewConfig(billId),
+  ]);
+
+  if (!bill) {
+    notFound();
+  }
+
+  const billTitle = bill.bill_content?.title || bill.name;
+
+  return (
+    <div className="min-h-dvh bg-mirai-surface">
+      {/* ヒーロー画像 */}
+      {bill.thumbnail_url && (
+        <div className="relative w-full h-[285px]">
+          <Image
+            src={bill.thumbnail_url}
+            alt={billTitle}
+            fill
+            className="object-cover"
+          />
+        </div>
+      )}
+
+      <Container>
+        {/* 法案タイトル */}
+        <div className="py-6">
+          <h1 className="text-2xl font-bold leading-[1.5] text-black">
+            {billTitle}
+          </h1>
+          {bill.name !== billTitle && (
+            <p className="mt-2 text-xs font-medium leading-[1.67] text-mirai-text-muted">
+              {bill.name}
+            </p>
+          )}
+        </div>
+
+        {/* 意見一覧（フィルター付き） */}
+        <PublicOpinionsList reports={reports} />
+
+        {/* AIインタビューCTAバナー */}
+        {interviewConfig != null && (
+          <div className="my-8">
+            <InterviewLandingSection
+              billId={billId}
+              estimatedDuration={interviewConfig.estimated_duration}
+            />
+          </div>
+        )}
+      </Container>
+    </div>
+  );
+}

--- a/web/src/features/interview-report/server/loaders/get-all-public-reports-by-bill-id.ts
+++ b/web/src/features/interview-report/server/loaders/get-all-public-reports-by-bill-id.ts
@@ -1,0 +1,36 @@
+import "server-only";
+
+import { unstable_cache } from "next/cache";
+import { CACHE_TAGS } from "@/lib/cache-tags";
+import type { PublicInterviewReport } from "./get-public-reports-by-bill-id";
+import { findPublicReportsByBillId } from "../repositories/interview-report-repository";
+
+const REVALIDATE_SECONDS = 600;
+const MAX_REPORTS = 1000;
+
+/**
+ * 議案IDから全ての公開インタビューレポートを取得
+ */
+export async function getAllPublicReportsByBillId(
+  billId: string
+): Promise<PublicInterviewReport[]> {
+  return unstable_cache(
+    async () => {
+      const rawReports = await findPublicReportsByBillId(billId, MAX_REPORTS);
+      return rawReports.map((r) => ({
+        id: r.id,
+        stance: r.stance,
+        role: r.role,
+        role_title: r.role_title,
+        summary: r.summary,
+        total_score: r.total_score,
+        created_at: r.created_at,
+      }));
+    },
+    [`all-public-reports-${billId}`],
+    {
+      tags: [CACHE_TAGS.PUBLIC_INTERVIEW_REPORTS],
+      revalidate: REVALIDATE_SECONDS,
+    }
+  )();
+}

--- a/web/src/features/interview-report/shared/components/report-card.tsx
+++ b/web/src/features/interview-report/shared/components/report-card.tsx
@@ -1,0 +1,88 @@
+import Image from "next/image";
+import Link from "next/link";
+import { cn } from "@/lib/utils";
+import {
+  type InterviewReportRole,
+  formatRoleLabel,
+  roleIcons,
+  stanceLabels,
+  stanceTextColors,
+} from "../constants";
+import { formatRelativeTime } from "../utils/format-relative-time";
+
+export interface ReportCardData {
+  id: string;
+  stance: string | null;
+  role: string | null;
+  role_title: string | null;
+  summary: string | null;
+  created_at: string;
+}
+
+interface ReportCardProps {
+  report: ReportCardData;
+  summaryMaxLength?: number;
+}
+
+export function ReportCard({ report, summaryMaxLength = 80 }: ReportCardProps) {
+  const stanceLabel = report.stance
+    ? stanceLabels[report.stance] || report.stance
+    : null;
+  const stanceTextColor = report.stance
+    ? stanceTextColors[report.stance] || ""
+    : "";
+  const RoleIcon = report.role
+    ? roleIcons[report.role as InterviewReportRole]
+    : null;
+  const roleLabel = formatRoleLabel(report.role, report.role_title);
+  const relativeTime = formatRelativeTime(report.created_at);
+
+  const summary = report.summary || "";
+  const truncatedSummary =
+    summary.length > summaryMaxLength
+      ? `${summary.slice(0, summaryMaxLength)}...`
+      : summary;
+
+  return (
+    <Link
+      href={`/report/${report.id}/chat-log`}
+      className="block bg-white rounded-lg p-4 hover:bg-gray-50 transition-colors"
+    >
+      <div className="flex items-center gap-2">
+        {report.stance && (
+          <Image
+            src={`/icons/stance-${report.stance}.png`}
+            alt={stanceLabel || ""}
+            width={38}
+            height={38}
+            className="rounded-full flex-shrink-0"
+          />
+        )}
+        <div className="flex flex-col gap-0.5 min-w-0 flex-1">
+          {stanceLabel && (
+            <span className={cn("text-base font-bold", stanceTextColor)}>
+              {stanceLabel}
+            </span>
+          )}
+          <div className="flex items-center gap-2">
+            {roleLabel && (
+              <div className="flex items-center gap-0.5 text-mirai-text-subtle">
+                {RoleIcon && <RoleIcon size={16} className="flex-shrink-0" />}
+                <span className="text-xs">{roleLabel}</span>
+              </div>
+            )}
+            <span className="text-[13px] text-mirai-text-muted leading-[1.2]">
+              {relativeTime}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      {truncatedSummary && (
+        <p className="mt-2 text-[13px] leading-[1.692] text-black">
+          {truncatedSummary}
+        </p>
+      )}
+    </Link>
+  );
+}

--- a/web/src/features/interview-report/shared/utils/stance-filter.test.ts
+++ b/web/src/features/interview-report/shared/utils/stance-filter.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import type { ReportCardData } from "../components/report-card";
+import { countReportsByStance, filterReportsByStance } from "./stance-filter";
+
+const reports: ReportCardData[] = [
+  {
+    id: "1",
+    stance: "for",
+    role: null,
+    role_title: null,
+    summary: "期待",
+    created_at: "2026-01-01T00:00:00Z",
+  },
+  {
+    id: "2",
+    stance: "against",
+    role: null,
+    role_title: null,
+    summary: "懸念",
+    created_at: "2026-01-02T00:00:00Z",
+  },
+  {
+    id: "3",
+    stance: "neutral",
+    role: null,
+    role_title: null,
+    summary: "両方",
+    created_at: "2026-01-03T00:00:00Z",
+  },
+  {
+    id: "4",
+    stance: "for",
+    role: null,
+    role_title: null,
+    summary: "期待2",
+    created_at: "2026-01-04T00:00:00Z",
+  },
+];
+
+describe("filterReportsByStance", () => {
+  it("allフィルターは全レポートを返す", () => {
+    expect(filterReportsByStance(reports, "all")).toHaveLength(4);
+  });
+
+  it("forフィルターは期待レポートのみ返す", () => {
+    const result = filterReportsByStance(reports, "for");
+    expect(result).toHaveLength(2);
+    expect(result.every((r) => r.stance === "for")).toBe(true);
+  });
+
+  it("againstフィルターは懸念レポートのみ返す", () => {
+    const result = filterReportsByStance(reports, "against");
+    expect(result).toHaveLength(1);
+    expect(result[0].stance).toBe("against");
+  });
+
+  it("neutralフィルターは両方レポートのみ返す", () => {
+    const result = filterReportsByStance(reports, "neutral");
+    expect(result).toHaveLength(1);
+    expect(result[0].stance).toBe("neutral");
+  });
+});
+
+describe("countReportsByStance", () => {
+  it("スタンスごとの件数を正しく計算する", () => {
+    const counts = countReportsByStance(reports);
+    expect(counts).toEqual({
+      all: 4,
+      for: 2,
+      against: 1,
+      neutral: 1,
+    });
+  });
+
+  it("空配列は全て0を返す", () => {
+    const counts = countReportsByStance([]);
+    expect(counts).toEqual({
+      all: 0,
+      for: 0,
+      against: 0,
+      neutral: 0,
+    });
+  });
+});

--- a/web/src/features/interview-report/shared/utils/stance-filter.ts
+++ b/web/src/features/interview-report/shared/utils/stance-filter.ts
@@ -1,0 +1,50 @@
+import type { ReportCardData } from "../components/report-card";
+
+export type StanceFilter = "all" | "for" | "against" | "neutral";
+
+export const stanceFilterLabels: Record<StanceFilter, string> = {
+  all: "ALL",
+  for: "期待",
+  against: "懸念",
+  neutral: "期待&懸念",
+};
+
+export const stanceFilterOrder: StanceFilter[] = [
+  "all",
+  "for",
+  "against",
+  "neutral",
+];
+
+/**
+ * スタンスフィルターに基づいてレポートをフィルタリング
+ */
+export function filterReportsByStance(
+  reports: ReportCardData[],
+  filter: StanceFilter
+): ReportCardData[] {
+  if (filter === "all") return reports;
+  return reports.filter((r) => r.stance === filter);
+}
+
+/**
+ * スタンスごとの件数を計算
+ */
+export function countReportsByStance(
+  reports: ReportCardData[]
+): Record<StanceFilter, number> {
+  const counts: Record<StanceFilter, number> = {
+    all: reports.length,
+    for: 0,
+    against: 0,
+    neutral: 0,
+  };
+
+  for (const report of reports) {
+    if (report.stance === "for") counts.for++;
+    else if (report.stance === "against") counts.against++;
+    else if (report.stance === "neutral") counts.neutral++;
+  }
+
+  return counts;
+}


### PR DESCRIPTION
## Summary
- `/bills/[id]/opinions` ルートに当事者の意見一覧ページを追加
- スタンス別フィルター機能（ALL/期待/懸念/期待&懸念）を実装
- 法案詳細セクションの `ReportCard` を `shared/components/` に抽出して共有化
- 法案詳細の意見セクションに「もっと読む」ボタンを追加（レポート数 > 3件の場合に表示）
- 意見一覧ページ下部にAIインタビューCTAバナーを表示

## 主な変更
| ファイル | 内容 |
|---------|------|
| `app/(main)/bills/[id]/opinions/page.tsx` | 新規ルートページ（メタデータ生成含む） |
| `server/components/public-opinions-page.tsx` | 意見一覧のServer Component（ヒーロー画像・タイトル・CTA） |
| `client/components/public-opinions-list.tsx` | フィルター付き意見リストのClient Component |
| `shared/components/report-card.tsx` | ReportCard共有コンポーネント（既存セクションからの抽出） |
| `shared/utils/stance-filter.ts` | スタンスフィルターのロジック＋テスト |
| `server/loaders/get-all-public-reports-by-bill-id.ts` | 全件取得用ローダー（キャッシュ付き） |
| `bill-interview-opinions-section.tsx` | 共有ReportCard使用に変更＋「もっと読む」追加 |
| `bill-detail-layout.tsx` | billIdプロップ追加 |

## Test plan
- [x] `pnpm lint` 通過
- [x] `pnpm typecheck` 通過
- [x] `pnpm test` 全655テスト通過（stance-filter.test.ts 6テスト含む）
- [x] Codex review 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)