### PR TITLE
docs: CLAUDE.mdにSupabase RLS+ポリシーなしパターンのルールを追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,6 +122,7 @@ Repository レイヤーの詳細は [docs/repository-layer.md](docs/repository-l
 - ローカル開発前に `npx supabase start` を実行し、`.env.example` を `.env` にコピーして値を整えます。
 - スキーマ変更時は `supabase/migrations` のマイグレーションと `packages/supabase/types/supabase.types.ts` の再生成ファイルをセットでコミットします。
 - `pnpm seed` は `admin@example.com / admin123456` を含む検証データを投入するため、開発用途に限定してください。
+- **RLSとアクセスパターン**: マイグレーションでは必ず `alter table <テーブル名> enable row level security;` を記述してRLSを有効化すること。ただし **ポリシーは定義しない**（デフォルト全拒否）。データアクセスはすべて `createAdminClient()`（Service Role Key）経由で行い、認可ロジックはアプリケーション層（Server Actions / Loaders）で実装する。
 
 ## ドキュメント作成ルール
 - 要件定義や実装計画をまとめる際は論点を先に洗い出し、不明点を確認してから Markdown で整理します。


### PR DESCRIPTION
## Summary
- CLAUDE.mdの「Supabase & Environment Notes」セクションにRLSとアクセスパターンのルールを追加

## 仕組み化サマリ

### コード修正
- [x] PR #516のマイグレーションからRLSポリシー定義を削除（RLS有効化は維持）

### 仕組み化した項目
| 指摘 | 対応 | 追加先 |
|------|------|--------|
| Supabaseアクセスは原則Admin経由、RLSポリシーは不要 | CLAUDE.mdにルール追加 | CLAUDE.md (Supabase & Environment Notes) |

### ルール内容
- マイグレーションでは必ず `enable row level security` を記述
- ポリシーは定義しない（デフォルト全拒否）
- アクセスはすべて `createAdminClient()` 経由
- 認可ロジックはアプリケーション層で実装

## Test plan
- [x] 既存のルールと重複・矛盾なし確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)