### PR TITLE
fix: 法案提出前の賛否デフォルトテキストを修正

### DIFF
--- a/web/src/features/bills/client/components/bill-detail/mirai-stance-card.tsx
+++ b/web/src/features/bills/client/components/bill-detail/mirai-stance-card.tsx
@@ -17,7 +17,7 @@ export function MiraiStanceCard({ stance, billStatus }: MiraiStanceCardProps) {
 
   const styles = getStanceStyles(stance, isPreparing);
   const comment = isPreparing
-    ? "法案提出後に賛否を表明します。"
+    ? "法案提出後、党内で検討のうえ賛否を表明します。"
     : stance?.comment;
 
   return (


### PR DESCRIPTION
## Summary
- 法案提出前の賛否表示テキストを「法案提出後に賛否を表明します。」から「法案提出後、党内で検討のうえ賛否を表明します。」に変更
- 提出後すぐに賛否が出せるわけではないため、より正確な表現に修正

## Changes
- `web/src/features/bills/client/components/bill-detail/mirai-stance-card.tsx` のデフォルトコメントテキストを修正

## Test plan
- [x] `pnpm lint` パス
- [x] `pnpm typecheck` パス
- [x] `pnpm test` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the preparation state message displayed in the bill detail view to include additional context regarding internal party review procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->