### PR TITLE
fix: 公開ステータスのソート順を下書き→Coming Soon→公開に修正

### DIFF
--- a/admin/src/features/bills/server/components/bill-list/bill-list.tsx
+++ b/admin/src/features/bills/server/components/bill-list/bill-list.tsx
@@ -64,7 +64,7 @@ export async function BillList({ sortConfig }: { sortConfig: BillSortConfig }) {
               <TableHead>議案名</TableHead>
               <TableHead>国会会期</TableHead>
               <SortableTableHead
-                field="publish_status"
+                field="publish_status_order"
                 currentField={sortConfig.field}
                 currentOrder={sortConfig.order}
               >

--- a/admin/src/features/bills/shared/types/index.ts
+++ b/admin/src/features/bills/shared/types/index.ts
@@ -22,7 +22,7 @@ export type BillSortField =
   | "created_at"
   | "published_at"
   | "status_order"
-  | "publish_status";
+  | "publish_status_order";
 
 export type SortOrder = "asc" | "desc";
 

--- a/admin/src/features/bills/shared/utils/parse-bill-sort-params.test.ts
+++ b/admin/src/features/bills/shared/utils/parse-bill-sort-params.test.ts
@@ -12,9 +12,9 @@ describe("parseBillSortParams", () => {
     expect(result).toEqual({ field: "status_order", order: "asc" });
   });
 
-  it("publish_statusフィールドを受け付ける", () => {
-    const result = parseBillSortParams("publish_status", "desc");
-    expect(result).toEqual({ field: "publish_status", order: "desc" });
+  it("publish_status_orderフィールドを受け付ける", () => {
+    const result = parseBillSortParams("publish_status_order", "desc");
+    expect(result).toEqual({ field: "publish_status_order", order: "desc" });
   });
 
   it("published_atフィールドを受け付ける", () => {

--- a/admin/src/features/bills/shared/utils/parse-bill-sort-params.ts
+++ b/admin/src/features/bills/shared/utils/parse-bill-sort-params.ts
@@ -4,7 +4,7 @@ const VALID_SORT_FIELDS: BillSortField[] = [
   "created_at",
   "published_at",
   "status_order",
-  "publish_status",
+  "publish_status_order",
 ];
 
 const VALID_SORT_ORDERS: SortOrder[] = ["asc", "desc"];

--- a/admin/src/features/bills/shared/utils/prepare-bill-for-duplication.test.ts
+++ b/admin/src/features/bills/shared/utils/prepare-bill-for-duplication.test.ts
@@ -21,6 +21,7 @@ const baseBill: Bill = {
   status: "introduced",
   status_note: null,
   status_order: BILL_STATUS_ORDER.introduced,
+  publish_status_order: 2,
   thumbnail_url: null,
 };
 

--- a/packages/supabase/types/supabase.types.ts
+++ b/packages/supabase/types/supabase.types.ts
@@ -84,6 +84,7 @@ export type Database = {
           name: string
           originating_house: Database["public"]["Enums"]["house_enum"]
           publish_status: Database["public"]["Enums"]["bill_publish_status"]
+          publish_status_order: number | null
           published_at: string | null
           share_thumbnail_url: string | null
           shugiin_url: string | null
@@ -101,6 +102,7 @@ export type Database = {
           name: string
           originating_house: Database["public"]["Enums"]["house_enum"]
           publish_status?: Database["public"]["Enums"]["bill_publish_status"]
+          publish_status_order?: number | null
           published_at?: string | null
           share_thumbnail_url?: string | null
           shugiin_url?: string | null
@@ -118,6 +120,7 @@ export type Database = {
           name?: string
           originating_house?: Database["public"]["Enums"]["house_enum"]
           publish_status?: Database["public"]["Enums"]["bill_publish_status"]
+          publish_status_order?: number | null
           published_at?: string | null
           share_thumbnail_url?: string | null
           shugiin_url?: string | null

--- a/supabase/migrations/20260309000000_add_publish_status_order.sql
+++ b/supabase/migrations/20260309000000_add_publish_status_order.sql
@@ -1,0 +1,13 @@
+-- billsテーブルにpublish_statusのソート順を表すgenerated columnを追加
+-- 下書き(draft)→Coming Soon(coming_soon)→公開(published) の順
+ALTER TABLE bills ADD COLUMN publish_status_order INT GENERATED ALWAYS AS (
+  CASE publish_status
+    WHEN 'draft'       THEN 0
+    WHEN 'coming_soon' THEN 1
+    WHEN 'published'   THEN 2
+  END
+) STORED;
+
+ALTER TABLE bills ENABLE ROW LEVEL SECURITY;
+
+CREATE INDEX idx_bills_publish_status_order ON bills(publish_status_order);

--- a/web/src/app/dev/_lib/mock-data.ts
+++ b/web/src/app/dev/_lib/mock-data.ts
@@ -25,6 +25,7 @@ const baseBill: BillWithContent = {
   shugiin_url: null,
   status_note: null,
   status_order: 3,
+  publish_status_order: 2,
   diet_session_id: "mock-session",
   created_at: "2026-02-15T00:00:00Z",
   updated_at: "2026-02-15T00:00:00Z",

--- a/web/src/features/interview-session/shared/utils/build-summary-system-prompt.test.ts
+++ b/web/src/features/interview-session/shared/utils/build-summary-system-prompt.test.ts
@@ -20,6 +20,7 @@ const makeBill = (
   status: "introduced",
   status_note: null,
   status_order: BILL_STATUS_ORDER.introduced,
+  publish_status_order: 2,
   thumbnail_url: null,
   created_at: new Date().toISOString(),
   updated_at: new Date().toISOString(),

--- a/web/src/features/interview-session/shared/utils/interview-logic/bulk-mode.test.ts
+++ b/web/src/features/interview-session/shared/utils/interview-logic/bulk-mode.test.ts
@@ -24,6 +24,7 @@ const makeBill = (
   status: "introduced",
   status_note: null,
   status_order: BILL_STATUS_ORDER.introduced,
+  publish_status_order: 2,
   thumbnail_url: null,
   created_at: new Date().toISOString(),
   updated_at: new Date().toISOString(),

--- a/web/src/features/interview-session/shared/utils/interview-logic/loop-mode.test.ts
+++ b/web/src/features/interview-session/shared/utils/interview-logic/loop-mode.test.ts
@@ -24,6 +24,7 @@ const makeBill = (
   status: "introduced",
   status_note: null,
   status_order: BILL_STATUS_ORDER.introduced,
+  publish_status_order: 2,
   thumbnail_url: null,
   created_at: new Date().toISOString(),
   updated_at: new Date().toISOString(),


### PR DESCRIPTION
## Summary
- 公開ステータスのソート順を論理的な順序（下書き→Coming Soon→公開）に修正
- `publish_status_order` generated column をDBに追加（`status_order` と同じパターン）
- ソートフィールドを `publish_status`（アルファベット順）から `publish_status_order`（カスタム順序）に変更

## 変更内容
- **マイグレーション**: `publish_status_order` generated column 追加（draft=0, coming_soon=1, published=2）
- **型定義**: `BillSortField` の `publish_status` → `publish_status_order`
- **UI**: `SortableTableHead` の field を `publish_status_order` に更新
- **テスト修正**: Bill モックデータに `publish_status_order` フィールド追加

## スキーマ変更
```sql
ALTER TABLE bills ADD COLUMN publish_status_order INT GENERATED ALWAYS AS (
  CASE publish_status
    WHEN 'draft'       THEN 0
    WHEN 'coming_soon' THEN 1
    WHEN 'published'   THEN 2
  END
) STORED;
```

## Test plan
- [x] `pnpm lint` 通過
- [x] `pnpm typecheck` 通過（既存の react-markdown/opentelemetry エラーのみ）
- [x] `pnpm test` 全テスト通過
- [x] Codex review 通過
- [ ] `supabase db reset` でマイグレーション適用確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved sorting for the publish status column in the bills list—bills are now organized by semantic publish status progression (Draft → Coming Soon → Published) rather than alphabetical order, providing more intuitive organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->