### PR TITLE
Add total score column to interview session list table

### DIFF
--- a/admin/src/features/interview-reports/server/components/session-list.tsx
+++ b/admin/src/features/interview-reports/server/components/session-list.tsx
@@ -80,6 +80,7 @@ export function SessionList({
               <TableHead className="w-20 text-center">公開</TableHead>
               <TableHead className="w-28">スタンス</TableHead>
               <TableHead className="w-28">役割</TableHead>
+              <TableHead className="w-20 text-right">スコア</TableHead>
               <TableHead className="w-44">開始時刻</TableHead>
               <TableHead className="w-24">時間</TableHead>
               <TableHead className="w-24 text-right">メッセージ数</TableHead>
@@ -128,6 +129,11 @@ export function SessionList({
                   </TableCell>
                   <TableCell className="text-gray-600 text-sm">
                     {session.interview_report?.role || "-"}
+                  </TableCell>
+                  <TableCell className="text-right font-medium">
+                    {session.interview_report?.total_score != null
+                      ? session.interview_report.total_score
+                      : "-"}
                   </TableCell>
                   <TableCell className="text-gray-600">
                     <div className="flex items-center gap-1">


### PR DESCRIPTION
## Summary
Added a new "スコア" (Score) column to the session list table in the interview reports feature to display the total score for each interview session.

## Key Changes
- Added a new table header "スコア" with right-aligned text styling and fixed width (w-20)
- Added a new table cell that displays `session.interview_report?.total_score` with proper null handling (shows "-" when score is unavailable)
- Applied appropriate styling with right alignment and medium font weight to match the table's design patterns

## Implementation Details
- The score column is positioned between the "役割" (Role) and "開始時刻" (Start Time) columns
- Includes null-safe access to `total_score` property with fallback to "-" for missing values
- Follows existing table cell styling conventions used throughout the component

https://claude.ai/code/session_01UtunndgrK2sfRNfr2vJggu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Score column to the interview session table displaying interview report scores. When score data is unavailable, a dash is shown instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->