### PR TITLE
feat: インタビューページのOGPを法案詳細のものに変更

### DIFF
--- a/web/src/app/(main)/bills/[id]/interview/page.tsx
+++ b/web/src/app/(main)/bills/[id]/interview/page.tsx
@@ -24,32 +24,33 @@ export async function generateMetadata({
     };
   }
 
-  const billName = bill.bill_content?.title ?? bill.name;
-  const description = `法案についてのAIインタビュー - ${billName}`;
+  const description = bill.bill_content?.summary || "議案の詳細情報";
   const defaultOgpUrl = new URL("/ogp.jpg", env.webUrl).toString();
   const shareImageUrl =
     bill.share_thumbnail_url || bill.thumbnail_url || defaultOgpUrl;
 
   return {
-    title: `AIインタビュー - ${billName}`,
+    title: bill.name,
     description: description,
     alternates: {
       canonical: `/bills/${bill.id}/interview`,
     },
     openGraph: {
-      title: `AIインタビュー - ${billName}`,
+      title: bill.name,
       description: description,
-      type: "website",
+      type: "article",
+      publishedTime: bill.published_at ?? undefined,
+      modifiedTime: bill.updated_at,
       images: [
         {
           url: shareImageUrl,
-          alt: `${billName} のAIインタビューページ`,
+          alt: `${bill.name} のOGPイメージ`,
         },
       ],
     },
     twitter: {
       card: "summary_large_image",
-      title: `AIインタビュー - ${billName}`,
+      title: bill.name,
       description: description,
       images: [shareImageUrl],
     },


### PR DESCRIPTION
## Summary
- インタビューページ（`/bills/[id]/interview`）のOGPメタデータを法案詳細ページ（`/bills/[id]`）と同じものに変更
- SNSでインタビューページをシェアした際に、法案の名前・概要・サムネイルが表示されるようになる

## Changes
- `openGraph.title` / `twitter.title`: `AIインタビュー - {法案名}` → `{bill.name}`（法案詳細と同一）
- `openGraph.description` / `twitter.description`: `法案についてのAIインタビュー - {法案名}` → `{bill.bill_content.summary}`（法案詳細と同一）
- `openGraph.type`: `website` → `article`
- `openGraph.publishedTime` / `modifiedTime` を追加
- `title`（ブラウザタブ）: `AIインタビュー - {法案名}` → `{bill.name}`
- OGP画像のalt属性を法案詳細と統一

## Test plan
- [x] `pnpm lint` passed
- [x] `pnpm typecheck` passed
- [x] `pnpm test` passed (664 tests)
- [x] Codex review passed

Resolves GIKAI-229

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced social media previews with bill content summaries and publication/modification timestamps
  * Improved metadata structure for better search engine visibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->