### PR TITLE
Add satisfaction rating display to interview session list

### DIFF
--- a/admin/src/features/interview-reports/server/components/session-list.tsx
+++ b/admin/src/features/interview-reports/server/components/session-list.tsx
@@ -1,4 +1,4 @@
-import { CheckCircle2, Clock, ExternalLink, XCircle } from "lucide-react";
+import { CheckCircle2, Clock, ExternalLink, Star, XCircle } from "lucide-react";
 import Link from "next/link";
 
 import { Button } from "@/components/ui/button";
@@ -81,6 +81,7 @@ export function SessionList({
               <TableHead className="w-28">スタンス</TableHead>
               <TableHead className="w-28">役割</TableHead>
               <TableHead className="w-20 text-right">スコア</TableHead>
+              <TableHead className="w-24 text-center">満足度</TableHead>
               <TableHead className="w-44">開始時刻</TableHead>
               <TableHead className="w-24">時間</TableHead>
               <TableHead className="w-24 text-right">メッセージ数</TableHead>
@@ -134,6 +135,24 @@ export function SessionList({
                     {session.interview_report?.total_score != null
                       ? session.interview_report.total_score
                       : "-"}
+                  </TableCell>
+                  <TableCell className="text-center">
+                    {session.rating != null ? (
+                      <div className="flex items-center justify-center gap-0.5">
+                        {[1, 2, 3, 4, 5].map((star) => (
+                          <Star
+                            key={star}
+                            className={`h-4 w-4 ${
+                              star <= session.rating!
+                                ? "fill-yellow-400 text-yellow-400"
+                                : "text-gray-300"
+                            }`}
+                          />
+                        ))}
+                      </div>
+                    ) : (
+                      <span className="text-gray-400">-</span>
+                    )}
                   </TableCell>
                   <TableCell className="text-gray-600">
                     <div className="flex items-center gap-1">


### PR DESCRIPTION
## Summary
Added a new "満足度" (satisfaction rating) column to the interview session list table that displays star ratings based on session feedback.

## Key Changes
- Imported `Star` icon from lucide-react for rating visualization
- Added new table header column "満足度" (satisfaction) with centered alignment
- Implemented star rating display component that:
  - Shows 5-star rating when `session.rating` is available
  - Fills stars with yellow color up to the rating value
  - Displays gray unfilled stars for remaining positions
  - Shows a dash ("-") when no rating is available
  - Uses flexbox layout for proper star alignment and spacing

## Implementation Details
- The star rating component conditionally renders based on whether `session.rating` is null
- Filled stars use `fill-yellow-400 text-yellow-400` classes for solid appearance
- Empty stars use `text-gray-300` for visual distinction
- Stars are sized at 4x4 pixels with minimal gap spacing (0.5) for compact display
- The column is 24 units wide with centered text alignment to match the table's design

https://claude.ai/code/session_015G9H2M77Rjs3UDWcvbKQKY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added a satisfaction rating column to the interview sessions list, displaying star ratings (1–5) when available or a dash (—) when not yet rated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->