### PR TITLE
fix: トピック解析ページの「議案詳細に戻る」リンクが404になる問題を修正

### DIFF
--- a/admin/src/features/topic-analysis/server/components/topic-analysis-header.tsx
+++ b/admin/src/features/topic-analysis/server/components/topic-analysis-header.tsx
@@ -25,11 +25,11 @@ export function TopicAnalysisHeader({
           </Link>
         ) : (
           <Link
-            href={`/bills/${billId}`}
+            href="/bills"
             className="flex items-center gap-1 hover:underline"
           >
             <ArrowLeft className="h-4 w-4" />
-            議案詳細に戻る
+            議案一覧に戻る
           </Link>
         )}
       </div>


### PR DESCRIPTION
## Summary
- トピック解析ページの「議案詳細に戻る」リンクが `/bills/{id}` に遷移するが、adminに `/bills/[id]` ページが存在しないため404になっていた
- 他のページ（edit, interview, reports）と同様に `/bills`（議案一覧）に遷移するよう修正
- ラベルも「議案一覧に戻る」に統一

## 検証
- `pnpm lint` — pass
- `pnpm typecheck` — pass
- `pnpm test` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)