### PR TITLE
feat: ミドルウェアにSupabaseセッションリフレッシュを追加

### DIFF
--- a/web/src/lib/supabase/middleware.ts
+++ b/web/src/lib/supabase/middleware.ts
@@ -1,0 +1,47 @@
+import type { Database } from "@mirai-gikai/supabase";
+import { createServerClient } from "@supabase/ssr";
+import { type NextRequest, NextResponse } from "next/server";
+
+/**
+ * ミドルウェアでSupabaseセッションをリフレッシュする
+ * リクエストごとにアクセストークンの有効期限を確認し、
+ * 期限切れの場合はリフレッシュトークンで自動更新してcookieに書き戻す
+ */
+export async function updateSupabaseSession(request: NextRequest) {
+  let supabaseResponse = NextResponse.next({
+    request,
+  });
+
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!supabaseUrl || !supabaseAnonKey) {
+    return supabaseResponse;
+  }
+
+  const supabase = createServerClient<Database>(supabaseUrl, supabaseAnonKey, {
+    cookies: {
+      getAll() {
+        return request.cookies.getAll();
+      },
+      setAll(cookiesToSet) {
+        for (const { name, value } of cookiesToSet) {
+          request.cookies.set(name, value);
+        }
+        supabaseResponse = NextResponse.next({
+          request,
+        });
+        for (const { name, value, options } of cookiesToSet) {
+          supabaseResponse.cookies.set(name, value, options);
+        }
+      },
+    },
+  });
+
+  // トークンリフレッシュをトリガーする
+  // getUser() はサーバーに問い合わせてトークンの有効性を確認し、
+  // 期限切れの場合は自動的にリフレッシュする
+  await supabase.auth.getUser();
+
+  return supabaseResponse;
+}

--- a/web/src/middleware.ts
+++ b/web/src/middleware.ts
@@ -11,8 +11,9 @@ import {
   isPageSpeedInsights,
   validateBasicAuth,
 } from "./lib/basic-auth";
+import { updateSupabaseSession } from "./lib/supabase/middleware";
 
-export function middleware(request: NextRequest) {
+export async function middleware(request: NextRequest) {
   // /dev routes: 本番では404、開発ではauthスキップ
   if (request.nextUrl.pathname.startsWith("/dev")) {
     if (process.env.NODE_ENV !== "development") {
@@ -21,7 +22,11 @@ export function middleware(request: NextRequest) {
     return NextResponse.next();
   }
 
-  const response = _handleDifficultyCookie(request);
+  // Supabaseセッションをリフレッシュ（トークン期限切れ時に自動更新）
+  const response = await updateSupabaseSession(request);
+
+  // URLパラメータからdifficulty Cookieをセット
+  _applyDifficultyCookie(request, response);
 
   const authConfig = getBasicAuthConfig();
 
@@ -57,15 +62,15 @@ export function isValidDifficultyLevel(
 }
 
 /**
- * URLパラメータからdifficultyを取得し、Cookieにセット
+ * URLパラメータからdifficultyを取得し、レスポンスのCookieにセット
  */
-function _handleDifficultyCookie(request: NextRequest): NextResponse {
+function _applyDifficultyCookie(
+  request: NextRequest,
+  response: NextResponse
+): void {
   const { searchParams } = new URL(request.url);
   const difficulty = searchParams.get("difficulty");
 
-  const response = NextResponse.next();
-
-  // 有効なdifficulty値の場合、Cookieにセット
   if (isValidDifficultyLevel(difficulty)) {
     response.cookies.set(
       DIFFICULTY_COOKIE_NAME,
@@ -73,8 +78,6 @@ function _handleDifficultyCookie(request: NextRequest): NextResponse {
       DIFFICULTY_COOKIE_OPTIONS
     );
   }
-
-  return response;
 }
 
 export function isHtmlAcceptHeader(accept: string): boolean {
@@ -85,3 +88,13 @@ function _isHtmlRequest(request: NextRequest) {
   const accept = request.headers.get("accept") || "";
   return isHtmlAcceptHeader(accept);
 }
+
+export const config = {
+  matcher: [
+    /*
+     * _next/static, _next/image, favicon.ico, 画像ファイル等の
+     * 静的アセットを除外し、ページリクエストのみでミドルウェアを実行する
+     */
+    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico)$).*)",
+  ],
+};


### PR DESCRIPTION
## Summary
- ミドルウェアでSupabaseセッションのトークンリフレッシュを実行するよう追加
- リクエストごとに `supabase.auth.getUser()` を呼び、期限切れのアクセストークンをリフレッシュトークンで自動更新してcookieに書き戻す
- 静的アセット（`_next/static`, 画像ファイル等）はmatcher設定で除外し、不要なauth通信を防止

## 背景
匿名ログインのセッションが自動で切れてしまう問題の修正。`@supabase/ssr` の推奨パターンに従い、ミドルウェアでサーバーサイドのトークンリフレッシュを行うことで、セッションの持続性を確保する。

## 変更内容
- `web/src/lib/supabase/middleware.ts`: Supabaseセッションリフレッシュユーティリティを新規作成
- `web/src/middleware.ts`: セッションリフレッシュの統合、matcher設定の追加

## Test plan
- [x] `pnpm lint` 通過
- [x] `pnpm typecheck` 通過
- [x] `pnpm test` 全62ファイル672テスト通過
- [ ] ローカルで匿名ログイン→1時間後もセッション維持を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced authentication session management with automatic token refresh capabilities
  * Selective middleware routing that optimizes performance by skipping processing on static pages

* **Refactor**
  * Improved cookie handling mechanisms for consistent session persistence and state management across requests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->