### PR TITLE
fix: dev-sidebarのLink hrefの型エラーを修正

### DIFF
--- a/web/src/app/dev/_components/dev-sidebar.tsx
+++ b/web/src/app/dev/_components/dev-sidebar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { Route } from "next";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
@@ -22,7 +23,7 @@ function SidebarContent({ onNavigate }: { onNavigate?: () => void }) {
             {group.items.map((item) => (
               <li key={item.path}>
                 <Link
-                  href={item.path}
+                  href={item.path as Route}
                   onClick={onNavigate}
                   className={cn(
                     "block px-3 py-1.5 rounded text-sm transition-colors",


### PR DESCRIPTION
## Summary
- `web/src/app/dev/_components/dev-sidebar.tsx` で `item.path`（`string` 型）を Next.js `Link` の `href` に渡す際の型エラーを修正
- `Route` 型へのキャストで `next build` の型チェックを通過させる

## Test plan
- [x] `pnpm lint` 通過
- [x] `pnpm --filter web typecheck` 通過
- [x] `pnpm --filter web build` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **その他の改善**
  * 型安全性の内部改善を実施しました。

---

**注記:** このプルリクエストは内部的な改善のみが含まれており、ユーザーが認識できる変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->