### PR TITLE
feat: adminレポート一覧にis_public_by_userカラムを追加

### DIFF
--- a/admin/src/features/interview-reports/server/components/session-list.tsx
+++ b/admin/src/features/interview-reports/server/components/session-list.tsx
@@ -106,8 +106,8 @@ export function SessionList({
               <TableHead className="w-32">セッションID</TableHead>
               <TableHead className="w-24">ステータス</TableHead>
               <TableHead className="w-20 text-center">レポート</TableHead>
-              <TableHead className="w-24 text-center">管理者公開</TableHead>
               <TableHead className="w-24 text-center">ユーザー公開</TableHead>
+              <TableHead className="w-24 text-center">管理者公開</TableHead>
               <TableHead className="w-28">スタンス</TableHead>
               <TableHead className="w-28">役割</TableHead>
               <TableHead className="w-20 text-right">スコア</TableHead>
@@ -160,7 +160,7 @@ export function SessionList({
                     {hasReport ? (
                       <VisibilityBadge
                         isPublic={
-                          session.interview_report?.is_public_by_admin ?? false
+                          session.interview_report?.is_public_by_user ?? false
                         }
                       />
                     ) : (
@@ -171,7 +171,7 @@ export function SessionList({
                     {hasReport ? (
                       <VisibilityBadge
                         isPublic={
-                          session.interview_report?.is_public_by_user ?? false
+                          session.interview_report?.is_public_by_admin ?? false
                         }
                       />
                     ) : (


### PR DESCRIPTION
## Summary
- adminのレポート一覧テーブルで、従来の「公開」カラム（`is_public_by_admin` のみ表示）を「管理者公開」と「ユーザー公開」の2カラムに分割
- `is_public_by_admin` と `is_public_by_user` の両方の状態を一覧で確認できるように

## 変更内容
- `session-list.tsx`: テーブルヘッダーを「公開」→「管理者公開」「ユーザー公開」に分割
- `session-list.tsx`: テーブルボディに `is_public_by_user` の `VisibilityBadge` セルを追加

## Test plan
- [x] `pnpm typecheck` 通過
- [x] Codex review 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * セッションレポート表の「公開」表示を分割し、「ユーザー公開」と「管理者公開」の2列を追加しました。各列でそれぞれの公開状態を確認でき、レポートが存在しない場合は控えめな「-」表示になります。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->