### PR TITLE
feat: adminレポート一覧にrole_titleとsummary列を追加

### DIFF
--- a/admin/src/features/interview-reports/server/components/session-list.tsx
+++ b/admin/src/features/interview-reports/server/components/session-list.tsx
@@ -108,7 +108,8 @@ export function SessionList({
               <TableHead className="w-20 text-center">レポート</TableHead>
               <TableHead className="w-20 text-center">公開</TableHead>
               <TableHead className="w-28">スタンス</TableHead>
-              <TableHead className="w-28">役割</TableHead>
+              <TableHead className="w-40">役割名</TableHead>
+              <TableHead className="w-64">要約</TableHead>
               <TableHead className="w-20 text-right">スコア</TableHead>
               <TableHead className="w-24 text-center">満足度</TableHead>
               <SortableTableHead
@@ -172,7 +173,12 @@ export function SessionList({
                     />
                   </TableCell>
                   <TableCell className="text-gray-600 text-sm">
-                    {session.interview_report?.role || "-"}
+                    {session.interview_report?.role_title || "-"}
+                  </TableCell>
+                  <TableCell className="text-gray-600 text-sm">
+                    <span className="line-clamp-2">
+                      {session.interview_report?.summary || "-"}
+                    </span>
                   </TableCell>
                   <TableCell className="text-right font-medium">
                     {session.interview_report?.total_score != null


### PR DESCRIPTION
## Summary
- レポート一覧テーブルの「役割」列を `role` → `role_title` に変更し、ヘッダーを「役割名」に更新
- 「要約」列を新規追加（`summary` を2行クランプで表示）

## Test plan
- [x] `pnpm lint` — pass
- [x] `pnpm typecheck` — pass
- [x] `pnpm test` — pass (692 tests)
- [x] Codex review — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * インタビューセッション一覧に「要約」列を追加しました

* **改善**
  * 役割列を「役割名」に変更し、情報表示の明確化を実現しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->