### PR TITLE
fix: レポート詳細ページにrole_titleを表示

### DIFF
--- a/web/src/features/interview-report/server/components/public-report-page.tsx
+++ b/web/src/features/interview-report/server/components/public-report-page.tsx
@@ -64,6 +64,7 @@ export async function PublicReportPage({ reportId }: PublicReportPageProps) {
           summary={data.summary}
           stance={data.stance}
           role={data.role}
+          roleTitle={data.role_title}
           sessionStartedAt={data.session_started_at}
           duration={duration}
           characterCount={data.characterCount}

--- a/web/src/features/interview-report/server/components/report-chat-log-page.tsx
+++ b/web/src/features/interview-report/server/components/report-chat-log-page.tsx
@@ -56,6 +56,7 @@ export async function ReportChatLogPage({ reportId }: ReportChatLogPageProps) {
             <ReportMetaInfo
               stance={report.stance}
               role={report.role}
+              roleTitle={report.role_title}
               sessionStartedAt={report.session_started_at}
               characterCount={characterCount}
               variant="chat-log"

--- a/web/src/features/interview-report/server/components/report-complete-page.tsx
+++ b/web/src/features/interview-report/server/components/report-complete-page.tsx
@@ -124,6 +124,7 @@ export async function ReportCompletePage({
             summary={report.summary}
             stance={report.stance}
             role={report.role}
+            roleTitle={report.role_title}
             sessionStartedAt={report.session_started_at}
             duration={duration}
             characterCount={characterCount}

--- a/web/src/features/interview-report/shared/components/report-content.tsx
+++ b/web/src/features/interview-report/shared/components/report-content.tsx
@@ -16,6 +16,7 @@ interface ReportContentProps {
   summary: string | null;
   stance: string | null;
   role: string | null;
+  roleTitle?: string | null;
   sessionStartedAt: string | null;
   duration?: string;
   characterCount: number;
@@ -31,6 +32,7 @@ export function ReportContent({
   summary,
   stance,
   role,
+  roleTitle,
   sessionStartedAt,
   duration,
   characterCount,
@@ -52,6 +54,7 @@ export function ReportContent({
         <ReportMetaInfo
           stance={stance}
           role={role}
+          roleTitle={roleTitle}
           sessionStartedAt={sessionStartedAt}
           duration={duration}
           characterCount={characterCount}

--- a/web/src/features/interview-report/shared/components/report-meta-info.tsx
+++ b/web/src/features/interview-report/shared/components/report-meta-info.tsx
@@ -5,6 +5,7 @@ import { StanceDisplay } from "./stance-display";
 interface ReportMetaInfoProps {
   stance?: string | null;
   role?: string | null;
+  roleTitle?: string | null;
   sessionStartedAt: string | null;
   duration?: string;
   characterCount: number;
@@ -14,6 +15,7 @@ interface ReportMetaInfoProps {
 export function ReportMetaInfo({
   stance,
   role,
+  roleTitle,
   sessionStartedAt,
   duration,
   characterCount,
@@ -29,7 +31,9 @@ export function ReportMetaInfo({
         {/* スタンス */}
         {stance && <StanceDisplay stance={stance} />}
         {/* 役割 */}
-        {role && <RoleDisplay role={role} />}
+        {(role || roleTitle) && (
+          <RoleDisplay role={role} roleTitle={roleTitle} />
+        )}
       </div>
 
       {/* 日時・時間・文字数 */}

--- a/web/src/features/interview-report/shared/components/role-display.tsx
+++ b/web/src/features/interview-report/shared/components/role-display.tsx
@@ -1,16 +1,21 @@
-import { type InterviewReportRole, roleIcons, roleLabels } from "../constants";
+import {
+  formatRoleLabel,
+  type InterviewReportRole,
+  roleIcons,
+} from "../constants";
 
 interface RoleDisplayProps {
-  role: string;
+  role?: string | null;
+  roleTitle?: string | null;
 }
 
-export function RoleDisplay({ role }: RoleDisplayProps) {
-  const RoleIcon = roleIcons[role as InterviewReportRole];
+export function RoleDisplay({ role, roleTitle }: RoleDisplayProps) {
+  const RoleIcon = role ? roleIcons[role as InterviewReportRole] : undefined;
 
   return (
     <p className="text-sm text-gray-600 flex items-center gap-1">
       {RoleIcon && <RoleIcon size={16} strokeWidth={1.5} />}
-      {roleLabels[role as keyof typeof roleLabels] || role}
+      {formatRoleLabel(role, roleTitle)}
     </p>
   );
 }


### PR DESCRIPTION
## Summary
- レポート詳細ページ（公開レポート、完了ページ、会話ログ）で `role_title` が表示されていなかった問題を修正
- `RoleDisplay` コンポーネントで既存の `formatRoleLabel()` を使い、「専門的な有識者・経済学」のように role と role_title を中黒で結合表示するように変更
- `role` が null でも `role_title` がある場合に表示されるよう対応

## Test plan
- [x] `pnpm typecheck` 通過
- [x] `pnpm lint` 通過（既存の無関係な警告のみ）
- [x] `pnpm --filter web test` 全692テスト通過
- [x] Codex レビュー指摘を反映済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)