### PR TITLE
feat: うーんボタンを非表示にする

### DIFF
--- a/web/src/features/report-reaction/client/components/reaction-buttons-inline.tsx
+++ b/web/src/features/report-reaction/client/components/reaction-buttons-inline.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
-import { Frown, Lightbulb } from "lucide-react";
+import { Lightbulb } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useOptimistic, useTransition } from "react";
 import { toggleReaction } from "../../server/actions/toggle-reaction";
@@ -50,14 +50,6 @@ export function ReactionButtonsInline({
         disabled={isPending}
         onClick={(e) => handleClick(e, "helpful")}
       />
-      <InlineReactionButton
-        type="hmm"
-        label="うーん..."
-        count={optimistic.counts.hmm}
-        isActive={optimistic.userReaction === "hmm"}
-        disabled={isPending}
-        onClick={(e) => handleClick(e, "hmm")}
-      />
     </div>
   );
 }
@@ -79,7 +71,7 @@ function InlineReactionButton({
   disabled,
   onClick,
 }: InlineReactionButtonProps) {
-  const Icon = type === "helpful" ? Lightbulb : Frown;
+  const Icon = Lightbulb;
   const colorClass = isActive
     ? "text-mirai-reaction-active"
     : "text-mirai-reaction-inactive";

--- a/web/src/features/report-reaction/client/components/reaction-buttons.tsx
+++ b/web/src/features/report-reaction/client/components/reaction-buttons.tsx
@@ -2,7 +2,7 @@
 
 import { Button } from "@/components/ui/button";
 import { useAnonymousSupabaseUser } from "@/features/chat/client/hooks/use-anonymous-supabase-user";
-import { Frown, Lightbulb } from "lucide-react";
+import { Lightbulb } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useOptimistic, useTransition } from "react";
 import { toggleReaction } from "../../server/actions/toggle-reaction";
@@ -53,14 +53,6 @@ export function ReactionButtons({
             disabled={isPending}
             onClick={() => handleClick("helpful")}
           />
-          <ReactionButton
-            type="hmm"
-            label="うーん..."
-            count={optimistic.counts.hmm}
-            isActive={optimistic.userReaction === "hmm"}
-            disabled={isPending}
-            onClick={() => handleClick("hmm")}
-          />
         </div>
       </div>
     </div>
@@ -84,7 +76,7 @@ function ReactionButton({
   disabled,
   onClick,
 }: ReactionButtonProps) {
-  const Icon = type === "helpful" ? Lightbulb : Frown;
+  const Icon = Lightbulb;
 
   return (
     <Button


### PR DESCRIPTION
## Summary
- レポートのリアクションボタンから「うーん...」ボタンを非表示にする
- `ReactionButtons`（固定フッター版）と`ReactionButtonsInline`（インライン版）の両方から削除
- 未使用の`Frown`アイコンインポートも削除

Resolves GIKAI-266

## Test plan
- [x] `pnpm lint` — pass
- [x] `pnpm typecheck` — pass
- [x] `pnpm build` — pass
- [x] `pnpm test` — 699 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)