### PR TITLE
feat: 公開レポートページにリアクションボタンを追加

### DIFF
--- a/web/src/features/interview-report/server/components/public-report-page.tsx
+++ b/web/src/features/interview-report/server/components/public-report-page.tsx
@@ -5,6 +5,8 @@ import Image from "next/image";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { getBillDetailLink } from "@/features/interview-config/shared/utils/interview-links";
+import { ReactionButtons } from "@/features/report-reaction/client/components/reaction-buttons";
+import { getReportReactions } from "@/features/report-reaction/server/loaders/get-report-reactions";
 import { ReportContent } from "../../shared/components/report-content";
 import { parseOpinions } from "../../shared/utils/format-utils";
 import { calculateDuration } from "../../shared/utils/report-utils";
@@ -27,6 +29,7 @@ export async function PublicReportPage({ reportId }: PublicReportPageProps) {
     data.session_started_at,
     data.session_completed_at
   );
+  const reactionData = await getReportReactions(reportId);
 
   return (
     <div className="min-h-dvh bg-mirai-surface">
@@ -58,7 +61,7 @@ export async function PublicReportPage({ reportId }: PublicReportPageProps) {
       </div>
 
       {/* レポート本体（共通コンポーネント） */}
-      <div className="px-4 py-8">
+      <div className="px-4 pt-8 pb-28">
         <ReportContent
           reportId={reportId}
           billId={data.bill_id}
@@ -73,6 +76,9 @@ export async function PublicReportPage({ reportId }: PublicReportPageProps) {
           opinions={opinions}
         />
       </div>
+
+      {/* Reaction Buttons - Fixed at bottom */}
+      <ReactionButtons reportId={reportId} initialData={reactionData} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- chat-logページに配置されているリアクションボタン（参考になる / うーん...）を、公開レポート詳細ページ（`/report/[id]`）にも追加
- 固定バーで下部コンテンツが隠れないよう、コンテンツエリアにbottom paddingを追加

## 変更内容
- `web/src/features/interview-report/server/components/public-report-page.tsx`
  - `ReactionButtons` コンポーネントと `getReportReactions` ローダーをインポート
  - リアクションデータを取得してページ下部に固定表示
  - コンテンツ領域の `py-8` を `pt-8 pb-28` に変更してバーとの重なりを防止

## Test plan
- [x] `pnpm lint` 通過
- [x] `pnpm typecheck` 通過
- [x] `pnpm build` 通過
- [x] `pnpm test` 通過（68ファイル、699テスト全パス）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能

* パブリックレポートページに反応ボタン機能を追加しました
* ユーザーはレポートに対して反応を表示できるようになります
* ページ下部に固定される反応ボタンUIを追加し、レポート閲覧時の操作がより便利になりました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->