### PR TITLE
fix: 公開率の分母を完了セッション数に変更

### DIFF
--- a/admin/src/features/interview-reports/shared/utils/map-interview-statistics.test.ts
+++ b/admin/src/features/interview-reports/shared/utils/map-interview-statistics.test.ts
@@ -37,7 +37,7 @@ describe("mapInterviewStatistics", () => {
     expect(result.avgMessageCount).toBe(12.3);
     expect(result.avgDurationSeconds).toBe(345);
     expect(result.publicByUserCount).toBe(60);
-    expect(result.publicRate).toBe(60);
+    expect(result.publicRate).toBe(75);
   });
 
   it("handles zero total sessions", () => {

--- a/admin/src/features/interview-reports/shared/utils/map-interview-statistics.ts
+++ b/admin/src/features/interview-reports/shared/utils/map-interview-statistics.ts
@@ -37,6 +37,9 @@ export function mapInterviewStatistics(
     avgMessageCount: raw.avg_message_count,
     avgDurationSeconds: raw.avg_duration_seconds,
     publicByUserCount: raw.public_by_user_count,
-    publicRate: total > 0 ? (raw.public_by_user_count / total) * 100 : 0,
+    publicRate:
+      raw.completed_sessions > 0
+        ? (raw.public_by_user_count / raw.completed_sessions) * 100
+        : 0,
   };
 }


### PR DESCRIPTION
## Summary
- 公開許可の公開率計算で、分母を全セッション数（`total_sessions`）から完了セッション数（`completed_sessions`）に変更
- 未完了セッションはそもそも公開許可を選択する機会がないため、分母に含めると公開率が実態より低く表示されていた

## Changes
- `map-interview-statistics.ts`: `publicRate` の分母を `completed_sessions` に変更
- `map-interview-statistics.test.ts`: テストの期待値を更新（60/100=60% → 60/80=75%）

## Test plan
- [x] `pnpm lint` 通過
- [x] `pnpm typecheck` 通過
- [x] `pnpm build` 通過
- [x] `pnpm test` 全テスト通過（699件）
- [x] Codex review 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * インタビュー統計の公開率（パブリックレート）の計算ロジックを改善しました。より正確な統計情報がレポートに反映されるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->