### PR TITLE
fix: adminレポート一覧のカラム整理

### DIFF
--- a/admin/src/features/interview-reports/server/components/session-list.tsx
+++ b/admin/src/features/interview-reports/server/components/session-list.tsx
@@ -1,4 +1,4 @@
-import { Clock } from "lucide-react";
+import { CheckCircle2, Clock, XCircle } from "lucide-react";
 import type { Route } from "next";
 import Link from "next/link";
 
@@ -45,6 +45,13 @@ interface SessionListProps {
   totalCount: number;
   currentPage: number;
   sort?: SessionSortConfig;
+}
+
+function BooleanIcon({ value }: { value: boolean }) {
+  if (value) {
+    return <CheckCircle2 className="h-5 w-5 text-green-500" />;
+  }
+  return <XCircle className="h-5 w-5 text-red-400" />;
 }
 
 function buildPageUrl(


### PR DESCRIPTION
## Summary
- No.カラムを非表示
- レポートカラム（有無アイコン）を非表示
- セッションIDをクリックで詳細画面に遷移できるようリンク化（アクションカラムを削除）
- 要約カラムを一番右に移動

## Test plan
- [ ] adminレポート一覧ページでNo.カラムが表示されないことを確認
- [ ] レポートカラムが表示されないことを確認
- [ ] セッションIDクリックで詳細画面に遷移することを確認
- [ ] 要約が一番右のカラムに表示されることを確認
- [ ] ソート・ページネーションが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## セッションリストの UI 改善

* **Refactor**
  * セッションリストテーブルを整理しました。不要なカラムを削除し、セッションIDをリンク化、インタビューサマリーをテーブルに直接表示するようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->