### PR TITLE
feat: レポート一覧の所要時間を平均から中央値に変更

### DIFF
--- a/admin/src/features/interview-reports/server/components/interview-statistics.tsx
+++ b/admin/src/features/interview-reports/server/components/interview-statistics.tsx
@@ -12,7 +12,7 @@ import {
 
 import { Card, CardContent } from "@/components/ui/card";
 import type { InterviewStatistics as InterviewStatisticsType } from "../../shared/types";
-import { formatAverageDuration } from "../../shared/utils/format-average-duration";
+import { formatDurationSeconds } from "../../shared/utils/format-average-duration";
 
 interface InterviewStatisticsProps {
   statistics: InterviewStatisticsType;
@@ -203,8 +203,8 @@ export function InterviewStatistics({
         />
         <StatCard
           icon={<Clock className="h-5 w-5" />}
-          label="平均所要時間"
-          value={formatAverageDuration(stats.avgDurationSeconds)}
+          label="所要時間（中央値）"
+          value={formatDurationSeconds(stats.medianDurationSeconds)}
         />
         <StatCard
           icon={<Eye className="h-5 w-5" />}

--- a/admin/src/features/interview-reports/shared/types/index.ts
+++ b/admin/src/features/interview-reports/shared/types/index.ts
@@ -40,7 +40,7 @@ export type InterviewStatistics = {
   roleDailyLifeAffected: number;
   roleGeneralCitizen: number;
   avgMessageCount: number | null;
-  avgDurationSeconds: number | null;
+  medianDurationSeconds: number | null;
   publicByUserCount: number;
   publicRate: number;
 };

--- a/admin/src/features/interview-reports/shared/utils/format-average-duration.test.ts
+++ b/admin/src/features/interview-reports/shared/utils/format-average-duration.test.ts
@@ -1,36 +1,36 @@
 import { describe, expect, it } from "vitest";
-import { formatAverageDuration } from "./format-average-duration";
+import { formatDurationSeconds } from "./format-average-duration";
 
-describe("formatAverageDuration", () => {
+describe("formatDurationSeconds", () => {
   it("returns dash for null", () => {
-    expect(formatAverageDuration(null)).toBe("-");
+    expect(formatDurationSeconds(null)).toBe("-");
   });
 
   it("returns dash for zero", () => {
-    expect(formatAverageDuration(0)).toBe("-");
+    expect(formatDurationSeconds(0)).toBe("-");
   });
 
   it("returns dash for negative", () => {
-    expect(formatAverageDuration(-10)).toBe("-");
+    expect(formatDurationSeconds(-10)).toBe("-");
   });
 
   it("formats seconds only", () => {
-    expect(formatAverageDuration(45)).toBe("45秒");
+    expect(formatDurationSeconds(45)).toBe("45秒");
   });
 
   it("formats minutes only", () => {
-    expect(formatAverageDuration(120)).toBe("2分");
+    expect(formatDurationSeconds(120)).toBe("2分");
   });
 
   it("formats minutes and seconds", () => {
-    expect(formatAverageDuration(150)).toBe("2分30秒");
+    expect(formatDurationSeconds(150)).toBe("2分30秒");
   });
 
   it("rounds to nearest second", () => {
-    expect(formatAverageDuration(150.7)).toBe("2分31秒");
+    expect(formatDurationSeconds(150.7)).toBe("2分31秒");
   });
 
   it("rounds tiny positive value to 1 second", () => {
-    expect(formatAverageDuration(0.3)).toBe("1秒");
+    expect(formatDurationSeconds(0.3)).toBe("1秒");
   });
 });

--- a/admin/src/features/interview-reports/shared/utils/format-average-duration.ts
+++ b/admin/src/features/interview-reports/shared/utils/format-average-duration.ts
@@ -1,11 +1,9 @@
-export function formatAverageDuration(
-  avgDurationSeconds: number | null
-): string {
-  if (avgDurationSeconds == null || avgDurationSeconds <= 0) {
+export function formatDurationSeconds(durationSeconds: number | null): string {
+  if (durationSeconds == null || durationSeconds <= 0) {
     return "-";
   }
 
-  const totalSeconds = Math.max(1, Math.round(avgDurationSeconds));
+  const totalSeconds = Math.max(1, Math.round(durationSeconds));
   const minutes = Math.floor(totalSeconds / 60);
   const seconds = totalSeconds % 60;
 

--- a/admin/src/features/interview-reports/shared/utils/map-interview-statistics.test.ts
+++ b/admin/src/features/interview-reports/shared/utils/map-interview-statistics.test.ts
@@ -15,7 +15,7 @@ describe("mapInterviewStatistics", () => {
     role_daily_life_affected_count: 15,
     role_general_citizen_count: 35,
     avg_message_count: 12.3,
-    avg_duration_seconds: 345,
+    median_duration_seconds: 345,
     public_by_user_count: 60,
   };
 
@@ -35,7 +35,7 @@ describe("mapInterviewStatistics", () => {
     expect(result.roleDailyLifeAffected).toBe(15);
     expect(result.roleGeneralCitizen).toBe(35);
     expect(result.avgMessageCount).toBe(12.3);
-    expect(result.avgDurationSeconds).toBe(345);
+    expect(result.medianDurationSeconds).toBe(345);
     expect(result.publicByUserCount).toBe(60);
     expect(result.publicRate).toBe(60);
   });
@@ -58,12 +58,12 @@ describe("mapInterviewStatistics", () => {
       avg_rating: null,
       avg_total_score: null,
       avg_message_count: null,
-      avg_duration_seconds: null,
+      median_duration_seconds: null,
     });
 
     expect(result.avgRating).toBeNull();
     expect(result.avgTotalScore).toBeNull();
     expect(result.avgMessageCount).toBeNull();
-    expect(result.avgDurationSeconds).toBeNull();
+    expect(result.medianDurationSeconds).toBeNull();
   });
 });

--- a/admin/src/features/interview-reports/shared/utils/map-interview-statistics.ts
+++ b/admin/src/features/interview-reports/shared/utils/map-interview-statistics.ts
@@ -13,7 +13,7 @@ type RawStatistics = {
   role_daily_life_affected_count: number;
   role_general_citizen_count: number;
   avg_message_count: number | null;
-  avg_duration_seconds: number | null;
+  median_duration_seconds: number | null;
   public_by_user_count: number;
 };
 
@@ -35,7 +35,7 @@ export function mapInterviewStatistics(
     roleDailyLifeAffected: raw.role_daily_life_affected_count,
     roleGeneralCitizen: raw.role_general_citizen_count,
     avgMessageCount: raw.avg_message_count,
-    avgDurationSeconds: raw.avg_duration_seconds,
+    medianDurationSeconds: raw.median_duration_seconds,
     publicByUserCount: raw.public_by_user_count,
     publicRate: total > 0 ? (raw.public_by_user_count / total) * 100 : 0,
   };

--- a/packages/supabase/types/supabase.types.ts
+++ b/packages/supabase/types/supabase.types.ts
@@ -878,11 +878,11 @@ export type Database = {
       get_interview_statistics: {
         Args: { p_config_id: string }
         Returns: {
-          avg_duration_seconds: number
           avg_message_count: number
           avg_rating: number
           avg_total_score: number
           completed_sessions: number
+          median_duration_seconds: number
           public_by_user_count: number
           role_daily_life_affected_count: number
           role_general_citizen_count: number

--- a/supabase/migrations/20260321110000_change_statistics_duration_to_median.sql
+++ b/supabase/migrations/20260321110000_change_statistics_duration_to_median.sql
@@ -1,0 +1,71 @@
+-- Change average duration to median duration in interview statistics
+-- DROP is required because RETURNS TABLE column rename is not allowed by CREATE OR REPLACE
+DROP FUNCTION IF EXISTS get_interview_statistics(UUID);
+CREATE FUNCTION get_interview_statistics(p_config_id UUID)
+RETURNS TABLE (
+  total_sessions BIGINT,
+  completed_sessions BIGINT,
+  avg_rating NUMERIC,
+  stance_for_count BIGINT,
+  stance_against_count BIGINT,
+  stance_neutral_count BIGINT,
+  avg_total_score NUMERIC,
+  role_subject_expert_count BIGINT,
+  role_work_related_count BIGINT,
+  role_daily_life_affected_count BIGINT,
+  role_general_citizen_count BIGINT,
+  avg_message_count NUMERIC,
+  median_duration_seconds NUMERIC,
+  public_by_user_count BIGINT
+) AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    -- Session counts
+    COUNT(s.id) AS total_sessions,
+    COUNT(s.completed_at) AS completed_sessions,
+
+    -- Average satisfaction rating (from completed sessions with rating)
+    ROUND(AVG(s.rating)::NUMERIC, 2) AS avg_rating,
+
+    -- Stance distribution (for/against/neutral only)
+    COUNT(CASE WHEN r.stance = 'for' THEN 1 END) AS stance_for_count,
+    COUNT(CASE WHEN r.stance = 'against' THEN 1 END) AS stance_against_count,
+    COUNT(CASE WHEN r.stance = 'neutral' THEN 1 END) AS stance_neutral_count,
+
+    -- Average total score
+    ROUND(AVG(r.total_score)::NUMERIC, 1) AS avg_total_score,
+
+    -- Role distribution
+    COUNT(CASE WHEN r.role = 'subject_expert' THEN 1 END) AS role_subject_expert_count,
+    COUNT(CASE WHEN r.role = 'work_related' THEN 1 END) AS role_work_related_count,
+    COUNT(CASE WHEN r.role = 'daily_life_affected' THEN 1 END) AS role_daily_life_affected_count,
+    COUNT(CASE WHEN r.role = 'general_citizen' THEN 1 END) AS role_general_citizen_count,
+
+    -- Average message count per session
+    ROUND(AVG(COALESCE(mc.message_count, 0))::NUMERIC, 1) AS avg_message_count,
+
+    -- Median duration in seconds (completed sessions only)
+    ROUND(
+      (SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (
+        ORDER BY EXTRACT(EPOCH FROM (sub.completed_at - sub.started_at))
+      )
+      FROM interview_sessions sub
+      WHERE sub.interview_config_id = p_config_id
+        AND sub.completed_at IS NOT NULL
+      )::NUMERIC, 0
+    ) AS median_duration_seconds,
+
+    -- Public by user count
+    COUNT(CASE WHEN r.is_public_by_user = TRUE THEN 1 END) AS public_by_user_count
+
+  FROM interview_sessions s
+  LEFT JOIN interview_report r ON r.interview_session_id = s.id
+  LEFT JOIN (
+    SELECT im.interview_session_id, COUNT(*) AS message_count
+    FROM interview_messages im
+    GROUP BY im.interview_session_id
+  ) mc ON mc.interview_session_id = s.id
+  WHERE s.interview_config_id = p_config_id;
+END;
+$$ LANGUAGE plpgsql STABLE;


### PR DESCRIPTION
## Summary
- レポート一覧の統計情報「平均所要時間」を「所要時間（中央値）」に変更
- SQLの`AVG`を`PERCENTILE_CONT(0.5)`に置き換え、外れ値の影響を受けにくい中央値を表示
- 関連する型定義・マッピング・フォーマット関数・テストを一括更新

## 変更内容
- **DB migration**: `get_interview_statistics`関数の`avg_duration_seconds`を`median_duration_seconds`に変更（DROP→CREATE）
- **型定義**: `avgDurationSeconds` → `medianDurationSeconds`
- **フォーマット関数**: `formatAverageDuration` → `formatDurationSeconds`（汎用名に変更）
- **UIラベル**: 「平均所要時間」→「所要時間（中央値）」

## Test plan
- [x] `pnpm lint` 通過
- [x] `pnpm typecheck` 通過
- [x] `pnpm test` 全テスト通過（admin 245件、web 699件）
- [x] `pnpm build` ビルド成功
- [x] Codexレビュー通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)