### PR TITLE
feat: AIチャットにインタビュー機能の常時認知を追加

### DIFF
--- a/web/src/features/chat/server/services/handle-chat-request.ts
+++ b/web/src/features/chat/server/services/handle-chat-request.ts
@@ -108,9 +108,12 @@ export async function handleChatRequest({
   );
 
   // Build system prompt with interview suggestion instructions
+  const isBillPage =
+    context.pageContext?.type === "bill" || !!context.billContext;
   const systemPrompt = buildSystemPromptWithInterviewInstructions(
     promptResult.content,
-    shouldSuggestInterview
+    shouldSuggestInterview,
+    isBillPage
   );
 
   // Build tools configuration
@@ -269,6 +272,14 @@ function extractGatewayCost(event: {
   return Number.isFinite(numericCost) ? numericCost : undefined;
 }
 
+const INTERVIEW_AWARENESS_PROMPT = `
+
+## AIインタビュー機能について
+みらい議会には「AIインタビュー」機能があります。これは法案ごとに提供される機能で、ユーザーがAIインタビュアーと対話形式で法案に対する意見や知見を共有できる仕組みです。インタビュー結果は分析・レポート化され、政策議論に活用されます。
+
+この法案のインタビュー機能が現在利用可能かどうかは状況によって異なります。インタビューについて質問された場合は、この機能の存在を説明した上で、法案詳細ページでインタビューへの案内が表示されているか確認するよう案内してください。
+`;
+
 const INTERVIEW_SUGGESTION_PROMPT = `
 
 ## AIインタビュー提案について
@@ -365,12 +376,17 @@ async function hasExistingInterviewSession(
  */
 function buildSystemPromptWithInterviewInstructions(
   basePrompt: string,
-  shouldSuggestInterview: boolean
+  shouldSuggestInterview: boolean,
+  isBillPage: boolean
 ): string {
-  if (shouldSuggestInterview) {
-    return basePrompt + INTERVIEW_SUGGESTION_PROMPT;
+  if (!isBillPage) {
+    return basePrompt;
   }
-  return basePrompt;
+  let prompt = basePrompt + INTERVIEW_AWARENESS_PROMPT;
+  if (shouldSuggestInterview) {
+    prompt += INTERVIEW_SUGGESTION_PROMPT;
+  }
+  return prompt;
 }
 
 /**


### PR DESCRIPTION
## Summary
- 法案ページのAIチャットで、`shouldSuggestInterview` が false の場合でもインタビュー機能の存在を認知できるよう `INTERVIEW_AWARENESS_PROMPT` を追加
- `buildSystemPromptWithInterviewInstructions` に `isBillPage` 引数を追加し、法案ページでは常にインタビュー認知プロンプトを付与する構造に変更
- ホームページのチャットには影響なし（従来通り何も追加されない）

## 動作マトリクス

| ページ | shouldSuggest | 認知プロンプト | ツール指示 | ツール登録 |
|--------|--------------|--------------|----------|----------|
| ホーム  | false        | なし          | なし      | なし      |
| 法案   | false        | あり（NEW）   | なし      | なし      |
| 法案   | true         | あり（NEW）   | あり      | あり      |

## Test plan
- [x] `pnpm lint` — passed
- [x] `pnpm typecheck` — passed
- [x] `pnpm build` — passed
- [x] `pnpm --filter web test` — 68 files, 699 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 請求書ページでAIインタビュー機能の認識機能を追加しました。システムプロンプトを改善し、請求書ページでの対話体験がより最適化されるようになりました。インタビュー提案機能の動作も調整されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->