### PR TITLE
fix: ご意見セクションの「もっと読む」UIをFigmaデザインに合わせる

### DIFF
--- a/web/src/features/interview-report/server/components/bill-interview-opinions-section.tsx
+++ b/web/src/features/interview-report/server/components/bill-interview-opinions-section.tsx
@@ -2,7 +2,6 @@ import "server-only";
 
 import type { Route } from "next";
 import Link from "next/link";
-import { ChevronRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { routes } from "@/lib/routes";
 import { ReactionButtonsInline } from "@/features/report-reaction/client/components/reaction-buttons-inline";
@@ -48,7 +47,7 @@ export async function BillInterviewOpinionsSection({
 
       {/* レポートカード一覧（リアクション付き） */}
       <AnonymousAuthProvider>
-        <div className="flex flex-col gap-4">
+        <div className="relative flex flex-col gap-4">
           {reports.map((report) => (
             <div key={report.id} className="flex flex-col">
               <ReportCard report={report} />
@@ -62,20 +61,26 @@ export async function BillInterviewOpinionsSection({
               </div>
             </div>
           ))}
+
+          {/* もっと読むリンク（グラデーションオーバーレイ付き） */}
+          {totalCount > reports.length && (
+            <div className="pointer-events-none absolute inset-x-0 bottom-0 h-[164px] bg-mirai-white-fade rounded-b-2xl">
+              <div className="absolute inset-x-0 bottom-6 flex justify-center pointer-events-auto">
+                <Button
+                  variant="outline"
+                  size="lg"
+                  asChild
+                  className="w-[214px] h-12 text-base font-bold border-mirai-text rounded-full hover:bg-gray-50 bg-white"
+                >
+                  <Link href={routes.billOpinions(billId) as Route}>
+                    もっと読む
+                  </Link>
+                </Button>
+              </div>
+            </div>
+          )}
         </div>
       </AnonymousAuthProvider>
-
-      {/* もっと読むリンク */}
-      {totalCount > reports.length && (
-        <div className="flex justify-center">
-          <Button variant="outline" asChild>
-            <Link href={routes.billOpinions(billId) as Route}>
-              もっと読む
-              <ChevronRight size={16} />
-            </Link>
-          </Button>
-        </div>
-      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- ご意見セクションの「もっと読む」ボタンをFigmaデザインに合わせて更新
- グラデーションオーバーレイ（`bg-mirai-white-fade`）を追加して背景透過効果を実現
- ボタンをpill型（`rounded-full`）に変更し、`previous-session-section`と同じUIパターンに統一
- `ChevronRight`アイコンを削除

## Changes
- `bill-interview-opinions-section.tsx`: カードリストに`relative`を追加、グラデーションオーバーレイ＋スタイル済みボタンを配置

## Test plan
- [x] `pnpm typecheck` パス
- [x] `pnpm test` 全699テストパス
- [x] `pnpm build` パス
- [x] Codexレビューパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **スタイル改善**
  * インタビューレポートの「もっと読む」ボタンのデザインを更新しました。ボタンをレポートリストの下部に配置し、グラデーション背景を追加して視認性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->