### PR TITLE
fix: リアクションボタンのinactive時の色とタップエリアを改善

### DIFF
--- a/web/src/features/report-reaction/client/components/reaction-buttons.tsx
+++ b/web/src/features/report-reaction/client/components/reaction-buttons.tsx
@@ -57,20 +57,20 @@ export function ReactionButtons({
     <>
       <div className="fixed bottom-0 left-0 right-0 z-50 bg-white">
         <div className="border-t border-gray-400" />
-        <div className="flex items-center py-5 px-4">
+        <div className="flex items-stretch">
           {/* 参考になる */}
           <Button
             variant="ghost"
             onClick={() => handleClick("helpful")}
             disabled={isPending}
-            className="flex-1 flex items-center justify-center gap-2 h-auto px-0 py-0 hover:bg-transparent"
+            className="flex-1 flex items-center justify-center gap-2 h-auto py-5 rounded-none hover:bg-transparent active:bg-gray-50"
           >
             <Lightbulb
               size={20}
               className={`transition-colors ${
                 isActive
                   ? "text-mirai-reaction-active fill-mirai-reaction-active"
-                  : "text-mirai-reaction-active"
+                  : "text-gray-800"
               }`}
             />
             <span className="text-[15px] font-bold text-gray-800">
@@ -86,13 +86,13 @@ export function ReactionButtons({
           {showShare && (
             <>
               {/* セパレーター */}
-              <div className="w-px h-6 bg-gray-400 shrink-0" />
+              <div className="w-px self-center h-6 bg-gray-400 shrink-0" />
 
               {/* 共有する */}
               <Button
                 variant="ghost"
                 onClick={() => setIsShareModalOpen(true)}
-                className="flex-1 flex items-center justify-center gap-2 h-auto px-0 py-0 hover:bg-transparent"
+                className="flex-1 flex items-center justify-center gap-2 h-auto py-5 rounded-none hover:bg-transparent active:bg-gray-50"
               >
                 <Upload size={20} className="text-gray-800" />
                 <span className="text-[15px] font-bold text-gray-800">


### PR DESCRIPTION
## Summary
- 「参考になる」ボタンのinactive時アイコン色をred → dark(text-gray-800)に変更し、Figmaデザインに合わせた
- ボタン自体にpaddingを付与してタップエリアを拡大（親divではなくボタン要素がタップ領域に）
- タップフィードバック(`active:bg-gray-50`)を追加

## Test plan
- [ ] レポート詳細ページでinactive時のアイコンがダーク色で表示されること
- [ ] 「参考になる」タップ後にアイコンが赤+塗りつぶしに変わること
- [ ] ボタンのタップ領域が広くなっていること（ボタンテキスト外のパディング部分もタップ可能）
- [ ] 共有ボタンも同様にタップエリアが広いこと
- [ ] `pnpm lint` / `pnpm typecheck` パス済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

**スタイル更新**
* リアクション・シェアボタンのレイアウトを改善し、より一貫した視覚的配置を実現しました
* ボタンのスタイルと配置をアップデートし、ユーザーインターフェースの統一性を向上させました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->