### PR TITLE
fix: レポート詳細の固定ReactionバーにPC用max-width制約を追加

### DIFF
--- a/web/src/features/report-reaction/client/components/reaction-buttons.tsx
+++ b/web/src/features/report-reaction/client/components/reaction-buttons.tsx
@@ -55,52 +55,54 @@ export function ReactionButtons({
 
   return (
     <>
-      <div className="fixed bottom-0 left-0 right-0 z-50 bg-white">
-        <div className="border-t border-gray-400" />
-        <div className="flex items-stretch">
-          {/* 参考になる */}
-          <Button
-            variant="ghost"
-            onClick={() => handleClick("helpful")}
-            disabled={isPending}
-            className="flex-1 flex items-center justify-center gap-2 h-auto py-5 rounded-none hover:bg-transparent active:bg-gray-50"
-          >
-            <Lightbulb
-              size={20}
-              className={`transition-colors ${
-                isActive
-                  ? "text-mirai-reaction-active fill-mirai-reaction-active"
-                  : "text-gray-800"
-              }`}
-            />
-            <span className="text-[15px] font-bold text-gray-800">
-              参考になる
-            </span>
-            {optimistic.counts.helpful > 0 && (
+      <div className="fixed bottom-0 left-0 right-0 z-50">
+        <div className="max-w-[700px] mx-auto bg-white">
+          <div className="border-t border-gray-400" />
+          <div className="flex items-stretch">
+            {/* 参考になる */}
+            <Button
+              variant="ghost"
+              onClick={() => handleClick("helpful")}
+              disabled={isPending}
+              className="flex-1 flex items-center justify-center gap-2 h-auto py-5 rounded-none hover:bg-transparent active:bg-gray-50"
+            >
+              <Lightbulb
+                size={20}
+                className={`transition-colors ${
+                  isActive
+                    ? "text-mirai-reaction-active fill-mirai-reaction-active"
+                    : "text-gray-800"
+                }`}
+              />
               <span className="text-[15px] font-bold text-gray-800">
-                {optimistic.counts.helpful}
+                参考になる
               </span>
-            )}
-          </Button>
-
-          {showShare && (
-            <>
-              {/* セパレーター */}
-              <div className="w-px self-center h-6 bg-gray-400 shrink-0" />
-
-              {/* 共有する */}
-              <Button
-                variant="ghost"
-                onClick={() => setIsShareModalOpen(true)}
-                className="flex-1 flex items-center justify-center gap-2 h-auto py-5 rounded-none hover:bg-transparent active:bg-gray-50"
-              >
-                <Upload size={20} className="text-gray-800" />
+              {optimistic.counts.helpful > 0 && (
                 <span className="text-[15px] font-bold text-gray-800">
-                  共有する
+                  {optimistic.counts.helpful}
                 </span>
-              </Button>
-            </>
-          )}
+              )}
+            </Button>
+
+            {showShare && (
+              <>
+                {/* セパレーター */}
+                <div className="w-px self-center h-6 bg-gray-400 shrink-0" />
+
+                {/* 共有する */}
+                <Button
+                  variant="ghost"
+                  onClick={() => setIsShareModalOpen(true)}
+                  className="flex-1 flex items-center justify-center gap-2 h-auto py-5 rounded-none hover:bg-transparent active:bg-gray-50"
+                >
+                  <Upload size={20} className="text-gray-800" />
+                  <span className="text-[15px] font-bold text-gray-800">
+                    共有する
+                  </span>
+                </Button>
+              </>
+            )}
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- レポート詳細ページの固定Reactionバー（参考になる/共有する）がPCで画面幅いっぱいに広がる問題を修正
- `MainLayout` と同じ `max-w-[700px] mx-auto` を固定バー内に追加し、コンテンツ幅に合わせた表示に変更

## Changes
- `web/src/features/report-reaction/client/components/reaction-buttons.tsx`
  - 固定バーの外側divから `bg-white` を内側のmax-width制約付きdivに移動
  - `max-w-[700px] mx-auto` ラッパーを追加

## Test plan
- [x] `pnpm lint` pass
- [x] `pnpm typecheck` pass
- [x] `pnpm build` pass
- [x] `pnpm test` pass (699 tests)
- [ ] PCブラウザでレポート詳細ページを開き、固定バーが700px幅に収まっていることを確認
- [ ] モバイルサイズでも固定バーが正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)