### PR TITLE
feat: インタビュー回答済みでも導線を表示 & トップページAIにインタビュー認知を追加

### DIFF
--- a/web/src/features/chat/server/services/handle-chat-request.ts
+++ b/web/src/features/chat/server/services/handle-chat-request.ts
@@ -281,7 +281,7 @@ const INTERVIEW_AWARENESS_PROMPT_BILL = `${INTERVIEW_AWARENESS_BASE}
 `;
 
 const INTERVIEW_AWARENESS_PROMPT_HOME = `${INTERVIEW_AWARENESS_BASE}
-インタビューについて質問された場合は、この機能の存在を説明した上で、興味のある法案の詳細ページからAIインタビューに参加できることを案内してください。
+インタビューについて質問された場合は、この機能の存在を説明した上で、利用可否は法案ごとに異なるため、興味のある法案の詳細ページでインタビューへの案内が表示されているか確認するよう案内してください。
 `;
 
 const INTERVIEW_SUGGESTION_PROMPT = `


### PR DESCRIPTION
## Summary
- インタビュー回答済みユーザーにもAIチャット内でインタビューへの導線（suggest_interviewツール）を表示するよう変更
- トップページのAIチャットにもインタビュー機能の認知プロンプトを追加し、ユーザーがインタビューについて質問した際に案内できるようにした
- インタビュー認知プロンプトの共通部分を`INTERVIEW_AWARENESS_BASE`に切り出してDRY化

## Changes
- `determineShouldSuggestInterview`: セッション存在チェック（`hasExistingInterviewSession`）を削除。`findLatestNonArchivedSession`のインポートも削除
- `buildSystemPromptWithInterviewInstructions`: `isBillPage: boolean`から`pageType: "home" | "bill" | undefined`に変更し、homeページでもインタビュー認知プロンプトを付与
- `INTERVIEW_AWARENESS_PROMPT`を`INTERVIEW_AWARENESS_PROMPT_BILL`と`INTERVIEW_AWARENESS_PROMPT_HOME`に分離し、共通部分を`INTERVIEW_AWARENESS_BASE`に切り出し

## Test plan
- [x] `pnpm lint` — パス
- [x] `pnpm typecheck` — パス
- [x] `pnpm build` — パス
- [x] `pnpm --filter web test` — 68ファイル 699テスト全パス

Resolves GIKAI-168

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 改善

* **機能変更**
  * インタビュー提案の表示判定が簡素化され、サーバー側の既存セッション検索は廃止されました（公開設定の有無に基づく判定）。
  * ユーザーIDや既存セッションの照会に依存しなくなりました。
  * ページ種別（bill/home/未定義）に基づくシステムプロンプトを導入し、それぞれ専用の案内文を追加しました。
  * 一部の案内ロジックと補助処理が整理されました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->