### PR TITLE
fix: インタビュー提案バナーのアイコンをFigmaデザインに合わせる

### DIFF
--- a/web/src/features/chat/client/components/interview-suggestion-banner.tsx
+++ b/web/src/features/chat/client/components/interview-suggestion-banner.tsx
@@ -1,6 +1,5 @@
 import type { Route } from "next";
-import { ArrowRight, Check } from "lucide-react";
-import Image from "next/image";
+import { ArrowRight, BotMessageSquare, Check } from "lucide-react";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { getInterviewLPLink } from "@/features/interview-config/shared/utils/interview-links";
@@ -17,12 +16,7 @@ export function InterviewSuggestionBanner({
   return (
     <div className="flex gap-3 rounded-2xl bg-mirai-surface-light p-4">
       <div className="flex-shrink-0 size-10 rounded-lg bg-mirai-gradient flex items-center justify-center">
-        <Image
-          src="/icons/chat-button-icon.svg"
-          alt=""
-          width={32}
-          height={32}
-        />
+        <BotMessageSquare className="size-8 text-black" />
       </div>
       <div className="flex flex-col gap-3">
         <div className="flex flex-col gap-2">


### PR DESCRIPTION
## Summary
- チャット内のインタビュー提案バナーのアイコンをFigmaデザインに合わせて変更
- カスタムSVG（`chat-button-icon.svg` via `next/image`）→ `lucide-react` の `BotMessageSquare` に置き換え
- CLAUDE.mdのアイコンルール（インラインSVG禁止、lucide-react使用）にも準拠

## Test plan
- [x] `pnpm lint` パス
- [x] `pnpm typecheck` パス
- [x] `pnpm build` パス
- [x] `pnpm test` 全699テストパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **その他の改善**
  * チャット提案バナーのアイコン表示を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->