### PR TITLE
refactor: 公開レポートのキャッシュ・revalidate削除

### DIFF
--- a/web/src/features/interview-report/server/actions/update-public-setting.ts
+++ b/web/src/features/interview-report/server/actions/update-public-setting.ts
@@ -1,7 +1,5 @@
 "use server";
 
-import { revalidateTag } from "next/cache";
-import { CACHE_TAGS } from "@/lib/cache-tags";
 import { verifySessionOwnership } from "@/features/interview-session/server/utils/verify-session-ownership";
 import {
   findReportBySessionId,
@@ -29,7 +27,6 @@ export async function updatePublicSetting(
   try {
     const report = await findReportBySessionId(sessionId);
     await updateReportPublicSetting(report.id, isPublic);
-    revalidateTag(CACHE_TAGS.PUBLIC_INTERVIEW_REPORTS);
     return { success: true };
   } catch {
     return { success: false, error: "公開設定の更新に失敗しました" };

--- a/web/src/features/interview-report/server/loaders/get-all-public-reports-by-bill-id.ts
+++ b/web/src/features/interview-report/server/loaders/get-all-public-reports-by-bill-id.ts
@@ -1,11 +1,8 @@
 import "server-only";
 
-import { unstable_cache } from "next/cache";
-import { CACHE_TAGS } from "@/lib/cache-tags";
 import type { PublicInterviewReport } from "./get-public-reports-by-bill-id";
 import { findPublicReportsByBillId } from "../repositories/interview-report-repository";
 
-const REVALIDATE_SECONDS = 600;
 const MAX_REPORTS = 1000;
 
 /**
@@ -14,23 +11,14 @@ const MAX_REPORTS = 1000;
 export async function getAllPublicReportsByBillId(
   billId: string
 ): Promise<PublicInterviewReport[]> {
-  return unstable_cache(
-    async () => {
-      const rawReports = await findPublicReportsByBillId(billId, MAX_REPORTS);
-      return rawReports.map((r) => ({
-        id: r.id,
-        stance: r.stance,
-        role: r.role,
-        role_title: r.role_title,
-        summary: r.summary,
-        total_content_richness: r.total_content_richness,
-        created_at: r.created_at,
-      }));
-    },
-    [`all-public-reports-${billId}`],
-    {
-      tags: [CACHE_TAGS.PUBLIC_INTERVIEW_REPORTS],
-      revalidate: REVALIDATE_SECONDS,
-    }
-  )();
+  const rawReports = await findPublicReportsByBillId(billId, MAX_REPORTS);
+  return rawReports.map((r) => ({
+    id: r.id,
+    stance: r.stance,
+    role: r.role,
+    role_title: r.role_title,
+    summary: r.summary,
+    total_content_richness: r.total_content_richness,
+    created_at: r.created_at,
+  }));
 }

--- a/web/src/features/interview-report/server/loaders/get-public-reports-by-bill-id.ts
+++ b/web/src/features/interview-report/server/loaders/get-public-reports-by-bill-id.ts
@@ -1,13 +1,9 @@
 import "server-only";
 
-import { unstable_cache } from "next/cache";
-import { CACHE_TAGS } from "@/lib/cache-tags";
 import {
   countPublicReportsByBillId,
   findPublicReportsByBillId,
 } from "../repositories/interview-report-repository";
-
-const REVALIDATE_SECONDS = 600;
 
 export type PublicInterviewReport = {
   id: string;
@@ -30,29 +26,20 @@ export type PublicReportsResult = {
 export async function getPublicReportsByBillId(
   billId: string
 ): Promise<PublicReportsResult> {
-  return unstable_cache(
-    async () => {
-      const [rawReports, totalCount] = await Promise.all([
-        findPublicReportsByBillId(billId, 3),
-        countPublicReportsByBillId(billId),
-      ]);
+  const [rawReports, totalCount] = await Promise.all([
+    findPublicReportsByBillId(billId, 3),
+    countPublicReportsByBillId(billId),
+  ]);
 
-      const reports: PublicInterviewReport[] = rawReports.map((r) => ({
-        id: r.id,
-        stance: r.stance,
-        role: r.role,
-        role_title: r.role_title,
-        summary: r.summary,
-        total_content_richness: r.total_content_richness,
-        created_at: r.created_at,
-      }));
+  const reports: PublicInterviewReport[] = rawReports.map((r) => ({
+    id: r.id,
+    stance: r.stance,
+    role: r.role,
+    role_title: r.role_title,
+    summary: r.summary,
+    total_content_richness: r.total_content_richness,
+    created_at: r.created_at,
+  }));
 
-      return { reports, totalCount };
-    },
-    [`public-reports-${billId}`],
-    {
-      tags: [CACHE_TAGS.PUBLIC_INTERVIEW_REPORTS],
-      revalidate: REVALIDATE_SECONDS,
-    }
-  )();
+  return { reports, totalCount };
 }

--- a/web/src/features/report-reaction/server/actions/toggle-reaction.ts
+++ b/web/src/features/report-reaction/server/actions/toggle-reaction.ts
@@ -1,8 +1,6 @@
 "use server";
 
-import { revalidatePath } from "next/cache";
 import { getAuthenticatedUser } from "@/features/interview-session/server/utils/verify-session-ownership";
-import { routes } from "@/lib/routes";
 import type { ReactionType } from "../../shared/types";
 import {
   deleteReaction,
@@ -40,8 +38,7 @@ export async function toggleReaction(
   const userId = authResult.userId;
 
   try {
-    // レポートが公開されているか確認し、紐づくbillIdもサーバー側で取得
-    const { isPublic, billId } = await getReportPublicStatus(reportId);
+    const isPublic = await getReportPublicStatus(reportId);
     if (!isPublic) {
       return {
         success: false,
@@ -53,23 +50,11 @@ export async function toggleReaction(
     const currentReaction = await findUserReaction(reportId, userId);
 
     if (currentReaction === reactionType) {
-      // 同じリアクション → 解除
       await deleteReaction(reportId, userId);
-      revalidatePath(routes.reportChatLog(reportId));
-      if (billId) {
-        revalidatePath(routes.billDetail(billId));
-        revalidatePath(routes.billOpinions(billId));
-      }
       return { success: true, newReaction: null };
     }
 
-    // 新規 or 切り替え → upsert
     await upsertReaction(reportId, userId, reactionType);
-    revalidatePath(routes.reportChatLog(reportId));
-    if (billId) {
-      revalidatePath(routes.billDetail(billId));
-      revalidatePath(routes.billOpinions(billId));
-    }
     return { success: true, newReaction: reactionType };
   } catch {
     return {

--- a/web/src/features/report-reaction/server/repositories/report-reaction-repository.ts
+++ b/web/src/features/report-reaction/server/repositories/report-reaction-repository.ts
@@ -3,40 +3,25 @@ import "server-only";
 import { createAdminClient } from "@mirai-gikai/supabase";
 import type { ReactionCounts, ReactionType } from "../../shared/types";
 
-interface ReportPublicStatus {
-  isPublic: boolean;
-  billId: string | null;
-}
-
 /**
- * レポートが公開されているか確認し、紐づくbillIdもサーバー側で解決して返す
+ * レポートが公開されているか確認する
  * ユーザー公開設定(is_public_by_user)と管理者公開設定(is_public_by_admin)の両方がtrueの場合のみ公開
  */
 export async function getReportPublicStatus(
   reportId: string
-): Promise<ReportPublicStatus> {
+): Promise<boolean> {
   const supabase = createAdminClient();
   const { data, error } = await supabase
     .from("interview_report")
-    .select(
-      "is_public_by_admin, is_public_by_user, interview_sessions(interview_configs(bill_id))"
-    )
+    .select("is_public_by_admin, is_public_by_user")
     .eq("id", reportId)
     .single();
 
   if (error || !data) {
-    return { isPublic: false, billId: null };
+    return false;
   }
 
-  const session = data.interview_sessions as {
-    interview_configs: { bill_id: string } | null;
-  } | null;
-  const billId = session?.interview_configs?.bill_id ?? null;
-
-  return {
-    isPublic: data.is_public_by_admin && data.is_public_by_user,
-    billId,
-  };
+  return data.is_public_by_admin && data.is_public_by_user;
 }
 
 /**

--- a/web/src/lib/cache-tags.ts
+++ b/web/src/lib/cache-tags.ts
@@ -5,7 +5,6 @@ export const CACHE_TAGS = {
   BILLS: "bills",
   DIET_SESSIONS: "diet-sessions",
   INTERVIEW_CONFIGS: "interview-configs",
-  PUBLIC_INTERVIEW_REPORTS: "public-interview-reports",
 } as const;
 
 export type CacheTag = (typeof CACHE_TAGS)[keyof typeof CACHE_TAGS];


### PR DESCRIPTION
## Summary
- 公開レポートの `unstable_cache`（600秒TTL）を削除し、常にDBから最新データを取得するよう変更
- リアクション時の `revalidatePath` / `revalidateTag` を削除（キャッシュがないため不要）
- `getReportPublicStatus` から不要な `billId` 返却とDB joinを除去

## Why
- リアクション毎に `revalidatePath` でキャッシュが破棄されるため、600秒TTLが実質機能していなかった
- キャッシュ→revalidate のサイクルがリアクション押下時にレポートの並び順が変わるUX問題を引き起こしていた
- キャッシュ管理の複雑さ（タグ管理、revalidate整合性）に対してメリットが薄い

## Changes
- `get-all-public-reports-by-bill-id.ts`: `unstable_cache` 除去
- `get-public-reports-by-bill-id.ts`: `unstable_cache` 除去
- `toggle-reaction.ts`: `revalidatePath` 除去、`billId` 参照除去
- `update-public-setting.ts`: `revalidateTag` 除去
- `report-reaction-repository.ts`: `getReportPublicStatus` を簡素化（`billId` とDB join除去）
- `cache-tags.ts`: `PUBLIC_INTERVIEW_REPORTS` 定義削除

## Test plan
- [x] `pnpm typecheck` pass
- [x] `pnpm build` pass
- [x] `pnpm test` pass（全708テスト）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * 公開インタビューレポートのデータ取得処理を最適化しました。
  * レポート反応機能の内部処理を簡素化しました。
  * キャッシング関連の内部機構を整理しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->