### PR TITLE
fix: 公開設定モーダルの文言をFigmaデザインに合わせて修正

### DIFF
--- a/web/src/features/interview-report/client/components/interview-public-consent-modal.tsx
+++ b/web/src/features/interview-report/client/components/interview-public-consent-modal.tsx
@@ -61,10 +61,10 @@ export function InterviewPublicConsentModal({
 
           <div className="space-y-4">
             <CheckListItem>
-              公開を許可した場合、今後みらい議会にあなたのご意見が匿名で掲載されることがあります。
+              公開を許可した場合、今後みらい議会にあなたのご意見の要約とインタビュー原文が匿名で掲載されることがあります。
             </CheckListItem>
             <CheckListItem>
-              さまざまな当事者の意見が公開されることで、より深い法案議論が実現できます。
+              さまざまな意見が公開されることで、より深い法案議論が実現できます
             </CheckListItem>
           </div>
 

--- a/web/src/features/interview-report/client/components/make-public-modal.tsx
+++ b/web/src/features/interview-report/client/components/make-public-modal.tsx
@@ -52,10 +52,10 @@ export function MakePublicModal({
 
         <div className="space-y-4 mt-6">
           <CheckListItem>
-            公開を許可した場合、今後みらい議会にあなたのご意見が匿名で掲載されることがあります。
+            公開を許可した場合、今後みらい議会にあなたのご意見の要約とインタビュー原文が匿名で掲載されることがあります。
           </CheckListItem>
           <CheckListItem>
-            さまざまな当事者の意見が公開されることで、より深い法案議論が実現できます。
+            さまざまな意見が公開されることで、より深い法案議論が実現できます
           </CheckListItem>
           <p className="text-sm text-black">
             非公開で提出した場合でも、ご意見は党内での政策検討に活用させていただきます。


### PR DESCRIPTION
## Summary
- 公開設定モーダルのチェックリスト文言をFigmaデザインに合わせて修正
  - 「ご意見が匿名で」→「ご意見の要約とインタビュー原文が匿名で」（公開内容をより正確に説明）
  - 「さまざまな当事者の意見が」→「さまざまな意見が」
- 同じ文言を使用している `make-public-modal.tsx` も同様に修正

## 対象ファイル
- `web/src/features/interview-report/client/components/interview-public-consent-modal.tsx`
- `web/src/features/interview-report/client/components/make-public-modal.tsx`

## Test plan
- [x] `pnpm lint` パス
- [x] `pnpm typecheck` パス
- [ ] 公開設定モーダルの文言がFigmaと一致することを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)