### PR TITLE
feat: レポートカードUIをFigmaデザインに合わせて更新

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -81,10 +81,14 @@
 
   /* Stance semantic colors */
   --color-stance-for-bg: #ecfcf1;
+  --color-stance-for-badge-start: #e2f6f3;
+  --color-stance-for-badge-end: #eef6e2;
   --color-stance-against: #c9272a;
   --color-stance-against-light: #d23c3f;
   --color-stance-against-bg: #fff1f1;
+  --color-stance-against-badge-bg: #ffeaea;
   --color-stance-neutral: #805f34;
+  --color-stance-neutral-badge-bg: #f7e8db;
 
   /* Reaction */
   --color-mirai-reaction-active: #dd425f;

--- a/web/src/features/interview-report/shared/components/report-card.tsx
+++ b/web/src/features/interview-report/shared/components/report-card.tsx
@@ -5,8 +5,9 @@ import { cn } from "@/lib/utils";
 import { getPublicReportLink } from "@/features/interview-config/shared/utils/interview-links";
 import {
   type InterviewReportRole,
-  formatRoleLabel,
   roleIcons,
+  roleLabels,
+  stanceBadgeBgStyles,
   stanceLabels,
   stanceTextColors,
 } from "../constants";
@@ -40,10 +41,15 @@ export function ReportCard({
   const stanceTextColor = report.stance
     ? stanceTextColors[report.stance] || ""
     : "";
+  const stanceBadgeBg = report.stance
+    ? stanceBadgeBgStyles[report.stance] || ""
+    : "";
   const RoleIcon = report.role
     ? roleIcons[report.role as InterviewReportRole]
     : null;
-  const roleLabel = formatRoleLabel(report.role, report.role_title);
+  const roleLabel = report.role
+    ? roleLabels[report.role as InterviewReportRole] || report.role
+    : null;
   const relativeTime = formatRelativeTime(report.created_at);
 
   const summary = report.summary || "";
@@ -58,46 +64,59 @@ export function ReportCard({
         href={(href ?? getPublicReportLink(report.id)) as Route}
         className="absolute inset-0 rounded-lg"
         aria-label={
-          [stanceLabel, roleLabel, truncatedSummary]
+          [stanceLabel, report.role_title || roleLabel, truncatedSummary]
             .filter(Boolean)
             .join(" / ") || "レポートを見る"
         }
       />
-      <div className="flex items-start gap-2.5">
+      <div className="flex items-start gap-3">
         {report.stance && (
           <Image
             src={`/icons/stance-${report.stance}.png`}
             alt={stanceLabel || ""}
-            width={38}
-            height={38}
+            width={42}
+            height={42}
             className="rounded-full flex-shrink-0"
           />
         )}
-        <div className="flex flex-col gap-2 min-w-0 flex-1">
-          {stanceLabel && (
-            <span
-              className={cn(
-                "text-base font-bold leading-4 tracking-[0.01em]",
-                stanceTextColor
-              )}
-            >
-              {stanceLabel}
+        <div className="flex flex-col gap-2.5 min-w-0 flex-1">
+          <div className="flex items-start gap-2">
+            {stanceLabel && (
+              <div className="flex-1 min-w-0">
+                <span
+                  className={cn(
+                    "inline-flex items-center justify-center px-3 py-0.5 rounded-2xl text-xs font-medium leading-3",
+                    stanceBadgeBg,
+                    stanceTextColor
+                  )}
+                >
+                  {stanceLabel}
+                </span>
+              </div>
+            )}
+            <span className="text-[13px] text-mirai-text-muted whitespace-nowrap flex-shrink-0">
+              {relativeTime}
             </span>
-          )}
-          {roleLabel && (
-            <div className="flex items-center gap-1 text-mirai-text-subtle">
-              {RoleIcon && <RoleIcon size={16} className="flex-shrink-0" />}
-              <span className="text-xs leading-3">{roleLabel}</span>
-            </div>
-          )}
+          </div>
+
+          <div className="flex flex-col gap-2">
+            {report.role_title && (
+              <p className="text-base font-bold leading-snug text-mirai-text">
+                {report.role_title}
+              </p>
+            )}
+            {roleLabel && (
+              <div className="flex items-center gap-1 text-mirai-text-subtle">
+                {RoleIcon && <RoleIcon size={16} className="flex-shrink-0" />}
+                <span className="text-xs leading-3">{roleLabel}</span>
+              </div>
+            )}
+          </div>
         </div>
-        <span className="text-[13px] text-mirai-text-muted whitespace-nowrap flex-shrink-0">
-          {relativeTime}
-        </span>
       </div>
 
       {truncatedSummary && (
-        <p className="mt-2 text-[13px] leading-[22px] text-black">
+        <p className="mt-2.5 text-[13px] leading-[22px] text-black">
           {truncatedSummary}
         </p>
       )}

--- a/web/src/features/interview-report/shared/constants.ts
+++ b/web/src/features/interview-report/shared/constants.ts
@@ -5,9 +5,9 @@ import { Briefcase, GraduationCap, Home, User } from "lucide-react";
  * スタンスのラベルマッピング
  */
 export const stanceLabels: Record<string, string> = {
-  for: "期待している",
-  against: "懸念している",
-  neutral: "期待と懸念両方がある",
+  for: "期待",
+  against: "懸念",
+  neutral: "期待＆懸念",
 };
 
 /**
@@ -17,6 +17,15 @@ export const stanceTextColors: Record<string, string> = {
   for: "text-primary-accent",
   against: "text-stance-against-light",
   neutral: "text-stance-neutral",
+};
+
+/**
+ * スタンスバッジの背景スタイルマッピング
+ */
+export const stanceBadgeBgStyles: Record<string, string> = {
+  for: "bg-linear-to-b from-stance-for-badge-start to-stance-for-badge-end",
+  against: "bg-stance-against-badge-bg",
+  neutral: "bg-stance-neutral-badge-bg",
 };
 
 /**


### PR DESCRIPTION
## Summary
- スタンス表示をテキストから色付きバッジ(ピル型)に変更（期待=グリーングラデーション、懸念=ピンク、期待＆懸念=ブラウン）
- スタンスラベルを短縮形に変更（「期待している」→「期待」等）
- アバターサイズを38→42pxに拡大
- role_titleとrole labelを分離表示し、role_titleを目立つ太字で表示
- カードレイアウトをFigmaデザインに合わせて再構成（バッジ+日時 → 役職名 → ロールアイコン+ラベルの3段構成）

## 変更ファイル
- `web/src/app/globals.css` - スタンスバッジ用カラートークン追加
- `web/src/features/interview-report/shared/constants.ts` - ラベル短縮・バッジスタイル追加
- `web/src/features/interview-report/shared/components/report-card.tsx` - カードレイアウト変更

## Test plan
- [x] `pnpm lint` — pass
- [x] `pnpm typecheck` — pass
- [x] `pnpm build` — pass
- [x] `pnpm --filter web test` — 74 files, 735 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * スタンスバッジの視覚的なスタイリング機能を追加しました。

* **スタイル**
  * インタビューレポートカードのレイアウトと表示を改善しました。
  * スタンス表示ラベルのテキストを簡潔に更新しました。
  * アイコンサイズと要素間隔の調整を行いました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->