### PR TITLE
feat: admin レポート一覧にアーカイブ済みステータス表示・フィルタを追加

### DIFF
--- a/admin/src/features/interview-reports/client/components/session-filter-bar.tsx
+++ b/admin/src/features/interview-reports/client/components/session-filter-bar.tsx
@@ -20,6 +20,7 @@ const STATUS_OPTIONS = [
   { value: "all", label: "すべて" },
   { value: "completed", label: "完了" },
   { value: "in_progress", label: "進行中" },
+  { value: "archived", label: "アーカイブ" },
 ] as const;
 
 const VISIBILITY_OPTIONS = [

--- a/admin/src/features/interview-reports/server/components/session-status-badge.tsx
+++ b/admin/src/features/interview-reports/server/components/session-status-badge.tsx
@@ -16,6 +16,16 @@ export function SessionStatusBadge({ status }: SessionStatusBadgeProps) {
       </Badge>
     );
   }
+  if (status === "archived") {
+    return (
+      <Badge
+        variant="outline"
+        className="bg-gray-50 text-gray-700 border-gray-200"
+      >
+        アーカイブ
+      </Badge>
+    );
+  }
   return (
     <Badge
       variant="outline"

--- a/admin/src/features/interview-reports/server/repositories/interview-report-repository.ts
+++ b/admin/src/features/interview-reports/server/repositories/interview-report-repository.ts
@@ -67,7 +67,9 @@ export async function findInterviewSessionsWithReport(
   if (filters.status === "completed") {
     query = query.not("completed_at", "is", null);
   } else if (filters.status === "in_progress") {
-    query = query.is("completed_at", null);
+    query = query.is("completed_at", null).is("archived_at", null);
+  } else if (filters.status === "archived") {
+    query = query.is("completed_at", null).not("archived_at", "is", null);
   }
 
   // レポートレベルフィルタ（inner join使用時のみ有効）
@@ -168,7 +170,13 @@ export async function findFilteredSessionIds(
         null
       );
     } else if (filters.status === "in_progress") {
-      reportQuery = reportQuery.is("interview_sessions.completed_at", null);
+      reportQuery = reportQuery
+        .is("interview_sessions.completed_at", null)
+        .is("interview_sessions.archived_at", null);
+    } else if (filters.status === "archived") {
+      reportQuery = reportQuery
+        .is("interview_sessions.completed_at", null)
+        .not("interview_sessions.archived_at", "is", null);
     }
 
     if (filters.visibility === "public") {
@@ -203,7 +211,9 @@ export async function findFilteredSessionIds(
   if (filters.status === "completed") {
     query = query.not("completed_at", "is", null);
   } else if (filters.status === "in_progress") {
-    query = query.is("completed_at", null);
+    query = query.is("completed_at", null).is("archived_at", null);
+  } else if (filters.status === "archived") {
+    query = query.is("completed_at", null).not("archived_at", "is", null);
   }
 
   const { data, error } = await query;
@@ -325,7 +335,9 @@ export async function countInterviewSessionsByConfigId(
   if (filters.status === "completed") {
     query = query.not("completed_at", "is", null);
   } else if (filters.status === "in_progress") {
-    query = query.is("completed_at", null);
+    query = query.is("completed_at", null).is("archived_at", null);
+  } else if (filters.status === "archived") {
+    query = query.is("completed_at", null).not("archived_at", "is", null);
   }
 
   // レポートレベルフィルタ

--- a/admin/src/features/interview-reports/shared/types/index.ts
+++ b/admin/src/features/interview-reports/shared/types/index.ts
@@ -28,7 +28,11 @@ export type InterviewSessionDetail = InterviewSession & {
 };
 
 // フィルタ関連の型定義
-export type SessionStatusFilter = "all" | "completed" | "in_progress";
+export type SessionStatusFilter =
+  | "all"
+  | "completed"
+  | "in_progress"
+  | "archived";
 export type VisibilityFilter = "all" | "public" | "private";
 export type StanceFilter = "all" | "for" | "against" | "neutral";
 export type RoleFilter =
@@ -49,6 +53,7 @@ export const SESSION_STATUS_FILTER_VALUES: readonly SessionStatusFilter[] = [
   "all",
   "completed",
   "in_progress",
+  "archived",
 ] as const;
 
 export const VISIBILITY_FILTER_VALUES: readonly VisibilityFilter[] = [

--- a/admin/src/features/interview-reports/shared/utils/get-session-status.test.ts
+++ b/admin/src/features/interview-reports/shared/utils/get-session-status.test.ts
@@ -3,12 +3,35 @@ import { getSessionStatus } from "./get-session-status";
 
 describe("getSessionStatus", () => {
   it("completed_atがある場合は'completed'を返す", () => {
-    expect(getSessionStatus({ completed_at: "2024-01-01T12:00:00Z" })).toBe(
-      "completed"
+    expect(
+      getSessionStatus({
+        completed_at: "2024-01-01T12:00:00Z",
+        archived_at: null,
+      })
+    ).toBe("completed");
+  });
+
+  it("completed_atがnullでarchived_atもnullの場合は'in_progress'を返す", () => {
+    expect(getSessionStatus({ completed_at: null, archived_at: null })).toBe(
+      "in_progress"
     );
   });
 
-  it("completed_atがnullの場合は'in_progress'を返す", () => {
-    expect(getSessionStatus({ completed_at: null })).toBe("in_progress");
+  it("completed_atがnullでarchived_atがある場合は'archived'を返す", () => {
+    expect(
+      getSessionStatus({
+        completed_at: null,
+        archived_at: "2024-01-01T12:00:00Z",
+      })
+    ).toBe("archived");
+  });
+
+  it("completed_atとarchived_atの両方がある場合は'completed'を返す", () => {
+    expect(
+      getSessionStatus({
+        completed_at: "2024-01-01T12:00:00Z",
+        archived_at: "2024-01-02T12:00:00Z",
+      })
+    ).toBe("completed");
   });
 });

--- a/admin/src/features/interview-reports/shared/utils/get-session-status.ts
+++ b/admin/src/features/interview-reports/shared/utils/get-session-status.ts
@@ -1,10 +1,14 @@
-export type SessionStatus = "completed" | "in_progress";
+export type SessionStatus = "completed" | "in_progress" | "archived";
 
 /**
- * completed_atの有無でセッションステータスを判定する
+ * completed_at, archived_atの有無でセッションステータスを判定する
  */
 export function getSessionStatus(session: {
   completed_at: string | null;
+  archived_at: string | null;
 }): SessionStatus {
+  if (!session.completed_at && session.archived_at) {
+    return "archived";
+  }
   return session.completed_at ? "completed" : "in_progress";
 }

--- a/admin/src/features/interview-reports/shared/utils/parse-session-filter-params.test.ts
+++ b/admin/src/features/interview-reports/shared/utils/parse-session-filter-params.test.ts
@@ -52,6 +52,16 @@ describe("parseSessionFilterParams", () => {
     });
   });
 
+  it("archivedステータスを受け付ける", () => {
+    const result = parseSessionFilterParams("archived");
+    expect(result).toEqual({
+      status: "archived",
+      visibility: "all",
+      stance: "all",
+      role: "all",
+    });
+  });
+
   it("一部のみ指定した場合、残りはデフォルト", () => {
     const result = parseSessionFilterParams("all", undefined, "against");
     expect(result).toEqual({

--- a/supabase/migrations/20260324120000_add_archived_status_filter_to_sort_rpcs.sql
+++ b/supabase/migrations/20260324120000_add_archived_status_filter_to_sort_rpcs.sql
@@ -1,0 +1,134 @@
+-- Add archived status filter support to sort RPC functions
+-- archived = completed_at IS NULL AND archived_at IS NOT NULL
+
+-- 1. find_sessions_ordered_by_message_count
+DROP FUNCTION IF EXISTS find_sessions_ordered_by_message_count(UUID, BOOLEAN, INT, INT, TEXT, TEXT, TEXT, TEXT);
+
+CREATE FUNCTION find_sessions_ordered_by_message_count(
+  p_config_id UUID,
+  p_ascending BOOLEAN DEFAULT FALSE,
+  p_offset INT DEFAULT 0,
+  p_limit INT DEFAULT 30,
+  p_status TEXT DEFAULT NULL,
+  p_visibility TEXT DEFAULT NULL,
+  p_stance TEXT DEFAULT NULL,
+  p_role TEXT DEFAULT NULL
+)
+RETURNS TABLE (session_id UUID) AS $$
+BEGIN
+  RETURN QUERY
+  SELECT s.id AS session_id
+  FROM interview_sessions s
+  LEFT JOIN (
+    SELECT im.interview_session_id, COUNT(*)::BIGINT AS cnt
+    FROM interview_messages im
+    INNER JOIN interview_sessions iss
+      ON iss.id = im.interview_session_id
+    WHERE iss.interview_config_id = p_config_id
+    GROUP BY im.interview_session_id
+  ) mc ON mc.interview_session_id = s.id
+  LEFT JOIN interview_report r ON r.interview_session_id = s.id
+  WHERE s.interview_config_id = p_config_id
+    AND (p_status IS NULL OR
+         (p_status = 'completed' AND s.completed_at IS NOT NULL) OR
+         (p_status = 'in_progress' AND s.completed_at IS NULL AND s.archived_at IS NULL) OR
+         (p_status = 'archived' AND s.completed_at IS NULL AND s.archived_at IS NOT NULL))
+    AND (p_visibility IS NULL OR
+         (p_visibility = 'public' AND r.is_public_by_admin = TRUE) OR
+         (p_visibility = 'private' AND r.is_public_by_admin = FALSE))
+    AND (p_stance IS NULL OR r.stance = p_stance::stance_type_enum)
+    AND (p_role IS NULL OR r.role = p_role::interview_report_role_enum)
+  ORDER BY
+    CASE WHEN p_ascending THEN COALESCE(mc.cnt, 0) END ASC,
+    CASE WHEN NOT p_ascending THEN COALESCE(mc.cnt, 0) END DESC,
+    s.started_at DESC,
+    s.id DESC
+  OFFSET p_offset
+  LIMIT p_limit;
+END;
+$$ LANGUAGE plpgsql STABLE;
+
+-- 2. find_sessions_ordered_by_total_content_richness
+DROP FUNCTION IF EXISTS find_sessions_ordered_by_total_content_richness(UUID, BOOLEAN, INT, INT, TEXT, TEXT, TEXT, TEXT);
+
+CREATE FUNCTION find_sessions_ordered_by_total_content_richness(
+  p_config_id UUID,
+  p_ascending BOOLEAN DEFAULT FALSE,
+  p_offset INT DEFAULT 0,
+  p_limit INT DEFAULT 30,
+  p_status TEXT DEFAULT NULL,
+  p_visibility TEXT DEFAULT NULL,
+  p_stance TEXT DEFAULT NULL,
+  p_role TEXT DEFAULT NULL
+)
+RETURNS TABLE (session_id UUID) AS $$
+BEGIN
+  RETURN QUERY
+  SELECT s.id AS session_id
+  FROM interview_sessions s
+  LEFT JOIN interview_report r
+    ON r.interview_session_id = s.id
+  WHERE s.interview_config_id = p_config_id
+    AND (p_status IS NULL OR
+         (p_status = 'completed' AND s.completed_at IS NOT NULL) OR
+         (p_status = 'in_progress' AND s.completed_at IS NULL AND s.archived_at IS NULL) OR
+         (p_status = 'archived' AND s.completed_at IS NULL AND s.archived_at IS NOT NULL))
+    AND (p_visibility IS NULL OR
+         (p_visibility = 'public' AND r.is_public_by_admin = TRUE) OR
+         (p_visibility = 'private' AND r.is_public_by_admin = FALSE))
+    AND (p_stance IS NULL OR r.stance = p_stance::stance_type_enum)
+    AND (p_role IS NULL OR r.role = p_role::interview_report_role_enum)
+  ORDER BY
+    CASE WHEN p_ascending THEN r.total_content_richness END ASC NULLS LAST,
+    CASE WHEN NOT p_ascending THEN r.total_content_richness END DESC NULLS LAST,
+    s.started_at DESC,
+    s.id DESC
+  OFFSET p_offset
+  LIMIT p_limit;
+END;
+$$ LANGUAGE plpgsql STABLE;
+
+-- 3. find_sessions_ordered_by_helpful_count
+DROP FUNCTION IF EXISTS find_sessions_ordered_by_helpful_count(UUID, BOOLEAN, INT, INT, TEXT, TEXT, TEXT, TEXT);
+
+CREATE FUNCTION find_sessions_ordered_by_helpful_count(
+  p_config_id UUID,
+  p_ascending BOOLEAN DEFAULT FALSE,
+  p_offset INT DEFAULT 0,
+  p_limit INT DEFAULT 30,
+  p_status TEXT DEFAULT NULL,
+  p_visibility TEXT DEFAULT NULL,
+  p_stance TEXT DEFAULT NULL,
+  p_role TEXT DEFAULT NULL
+)
+RETURNS TABLE (session_id UUID) AS $$
+BEGIN
+  RETURN QUERY
+  SELECT s.id AS session_id
+  FROM interview_sessions s
+  LEFT JOIN interview_report r ON r.interview_session_id = s.id
+  LEFT JOIN (
+    SELECT rr.interview_report_id, COUNT(*)::BIGINT AS cnt
+    FROM report_reactions rr
+    WHERE rr.reaction_type = 'helpful'
+    GROUP BY rr.interview_report_id
+  ) hc ON hc.interview_report_id = r.id
+  WHERE s.interview_config_id = p_config_id
+    AND (p_status IS NULL OR
+         (p_status = 'completed' AND s.completed_at IS NOT NULL) OR
+         (p_status = 'in_progress' AND s.completed_at IS NULL AND s.archived_at IS NULL) OR
+         (p_status = 'archived' AND s.completed_at IS NULL AND s.archived_at IS NOT NULL))
+    AND (p_visibility IS NULL OR
+         (p_visibility = 'public' AND r.is_public_by_admin = TRUE) OR
+         (p_visibility = 'private' AND r.is_public_by_admin = FALSE))
+    AND (p_stance IS NULL OR r.stance = p_stance::stance_type_enum)
+    AND (p_role IS NULL OR r.role = p_role::interview_report_role_enum)
+  ORDER BY
+    CASE WHEN p_ascending THEN COALESCE(hc.cnt, 0) END ASC,
+    CASE WHEN NOT p_ascending THEN COALESCE(hc.cnt, 0) END DESC,
+    s.started_at DESC,
+    s.id DESC
+  OFFSET p_offset
+  LIMIT p_limit;
+END;
+$$ LANGUAGE plpgsql STABLE;


### PR DESCRIPTION
## Summary
- `getSessionStatus` に `archived_at` 判定を追加し、`completed_at` が null かつ `archived_at` がある場合に `"archived"` ステータスを返すようにした
- `SessionStatusBadge` にアーカイブ用バッジ（グレー）を追加
- ステータスフィルタに「アーカイブ」オプションを追加し、進行中フィルタからアーカイブ済みセッションを除外
- リポジトリ層の全ステータスフィルタ箇所（4箇所）に `archived` 条件を追加
- RPC関数（3関数）のステータスフィルタにも `archived` 条件を追加するマイグレーションを作成

## Test plan
- [x] `pnpm --filter admin test` 全253テスト通過
- [x] `pnpm build` 成功
- [x] `pnpm lint` 新規エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)