### PR TITLE
fix: レポートシェアモーダルの最大幅を500pxに拡大

### DIFF
--- a/web/src/features/report-reaction/client/components/report-share-modal.tsx
+++ b/web/src/features/report-reaction/client/components/report-share-modal.tsx
@@ -77,7 +77,7 @@ export function ReportShareModal({
       onKeyDown={handleBackgroundKeyDown}
       tabIndex={-1}
     >
-      <div className="bg-white rounded-2xl px-3 py-9 w-[370px] max-w-full flex flex-col items-center gap-6">
+      <div className="bg-white rounded-2xl px-3 py-9 w-[500px] max-w-full flex flex-col items-center gap-6">
         {/* タイトルと法案名 */}
         <div className="flex flex-col items-center gap-3 text-center w-full">
           <h2 className="text-2xl font-bold text-gray-800">意見をシェアする</h2>


### PR DESCRIPTION
## Summary
- レポートシェアモーダル（`ReportShareModal`）の幅を `w-[370px]` → `w-[500px]` に変更
- `max-w-full` が併用されているためレスポンシブ対応は維持

## Test plan
- [ ] レポートシェアモーダルを開いてPC画面で幅が500px程度になることを確認
- [ ] スマホ画面幅でもモーダルが画面内に収まることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)