### PR TITLE
fix: 一括評価ボタンの文言を「モデレーション一括評価」に変更

### DIFF
--- a/admin/src/features/interview-reports/client/components/batch-moderation-button.tsx
+++ b/admin/src/features/interview-reports/client/components/batch-moderation-button.tsx
@@ -35,7 +35,7 @@ export function BatchModerationButton() {
       disabled={isPending}
     >
       <ShieldCheck className="h-4 w-4 mr-1" />
-      {isPending ? "評価中..." : "全レポート一括評価"}
+      {isPending ? "モデレーション評価中..." : "モデレーション一括評価"}
     </Button>
   );
 }


### PR DESCRIPTION
## Summary
- 「全レポート一括評価」ボタンの文言を「モデレーション一括評価」に変更
- 処理中の表示も「評価中...」→「モデレーション評価中...」に変更
- ボタンの目的がモデレーション評価であることが一目でわかるように改善

## Test plan
- [ ] admin画面のレポート一覧ページでボタンの文言が「モデレーション一括評価」になっていることを確認
- [ ] ボタン押下時に「モデレーション評価中...」と表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **スタイル**
  * モデレーション一括評価ボタンのラベルテキストを更新しました。処理中と待機中の状態表示がより具体的になり、ユーザーが実行中の機能をより明確に理解できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->