### PR TITLE
fix: レポート生成スキーマのreportフィールドをnullableに変更

### DIFF
--- a/web/src/features/interview-session/shared/schemas.test.ts
+++ b/web/src/features/interview-session/shared/schemas.test.ts
@@ -409,14 +409,23 @@ describe("interviewChatWithReportSchema", () => {
     expect(result.next_stage).toBe("summary");
   });
 
-  it("report は optional（省略可能）", () => {
+  it("report は nullable（null許容）", () => {
     const result = interviewChatWithReportSchema.parse({
       text: "インタビューを再開します",
+      report: null,
       next_stage: "chat" as const,
     });
     expect(result.text).toBe("インタビューを再開します");
-    expect(result.report).toBeUndefined();
+    expect(result.report).toBeNull();
     expect(result.next_stage).toBe("chat");
+  });
+
+  it("report を省略した場合を拒否する", () => {
+    const result = interviewChatWithReportSchema.safeParse({
+      text: "インタビューを再開します",
+      next_stage: "chat" as const,
+    });
+    expect(result.success).toBe(false);
   });
 
   it("text が欠けている場合を拒否する", () => {
@@ -465,9 +474,17 @@ describe("interviewChatResponseSchema", () => {
     expect(result.next_stage).toBe("summary");
   });
 
-  it("report が optional であること", () => {
-    const result = interviewChatResponseSchema.parse({ text: "テスト" });
-    expect(result.report).toBeUndefined();
+  it("report が optional かつ nullable であること", () => {
+    const withNull = interviewChatResponseSchema.parse({
+      text: "テスト",
+      report: null,
+    });
+    expect(withNull.report).toBeNull();
+
+    const withoutField = interviewChatResponseSchema.parse({
+      text: "テスト",
+    });
+    expect(withoutField.report).toBeUndefined();
   });
 
   it("quick_replies が optional かつ nullable であること", () => {

--- a/web/src/features/interview-session/shared/schemas.ts
+++ b/web/src/features/interview-session/shared/schemas.ts
@@ -117,13 +117,13 @@ export const interviewChatTextSchema = z.object({
 export type InterviewChatText = z.infer<typeof interviewChatTextSchema>;
 
 // summaryフェーズ用スキーマ（LLM出力用 - next_stageを含む）
-// chat遷移時はreportを省略できるようoptionalにしている
+// chat遷移時はreportをnullにする（OpenAI structured outputはoptionalを許容しないためnullableを使用）
 export const interviewChatWithReportSchema = z.object({
   text: z.string(),
   report: interviewReportSchema
-    .optional()
+    .nullable()
     .describe(
-      "インタビュー内容をまとめたレポート。next_stageがchatの場合は省略すること"
+      "インタビュー内容をまとめたレポート。next_stageがchatの場合はnullにすること"
     ),
   next_stage: interviewStageSchema.describe(
     "ステージ遷移判定。summary=レポート修正継続、summary_complete=レポート完了、chat=インタビュー再開"
@@ -137,7 +137,7 @@ export type InterviewChatWithReport = z.infer<
 // クライアント側で使う統一スキーマ（両方のレスポンスを受け取れる）
 export const interviewChatResponseSchema = z.object({
   text: z.string(),
-  report: interviewReportSchema.optional(),
+  report: interviewReportSchema.optional().nullable(),
   quick_replies: z.array(z.string()).optional().nullable(),
   question_id: z.string().optional().nullable(),
   topic_title: z.string().optional().nullable(),


### PR DESCRIPTION
## Summary
- OpenAI structured outputが`required`配列に全プロパティを要求するため、`interviewChatWithReportSchema`の`report`フィールドを`.optional()`から`.nullable()`に変更
- クライアント側の`interviewChatResponseSchema`にも`.nullable()`を追加し、LLMが返す`report: null`を正しく受け付けるように修正
- `report`を省略した場合にバリデーションが失敗することを確認するテストを追加

## 背景
レポート生成時に以下のエラーが発生していた:
```
Invalid schema for response_format 'response': In context=(), 'required' is required to be supplied and to be an array including every key in properties. Missing 'report'.
```

OpenAIのstructured outputでは、`properties`に定義された全フィールドが`required`配列に含まれている必要がある。Zodの`.optional()`はフィールドを`required`から除外するため、代わりに`.nullable()`を使用して`required`に含めつつ`null`を許容するように変更した。

## Test plan
- [x] `pnpm --filter web test` — 730テスト全パス
- [x] `pnpm typecheck` — 変更ファイルにエラーなし（既存エラーはpackages/shared起因）
- [x] `pnpm lint` — エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * インタビューセッションのレポートフィールドのnull値の取り扱いを改善し、より明確な検証ルールが適用されるようになりました。

* **テスト**
  * レポートフィールドのnull値処理に関するテストケースを追加・更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->