### PR TITLE
feat: サーバー側ソースマップを有効化

### DIFF
--- a/admin/next.config.ts
+++ b/admin/next.config.ts
@@ -1,6 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  serverSourceMaps: true,
   typedRoutes: true,
   turbopack: {
     root: "../",

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -1,6 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  serverSourceMaps: true,
   typedRoutes: true,
   turbopack: {
     root: "../",


### PR DESCRIPTION
## Summary
- web/admin の `next.config.ts` に `serverSourceMaps: true` を追加
- サーバーサイドエラーのスタックトレースが元のソースコードの行番号で表示されるようになる
- Vercel 環境変数 `NODE_OPTIONS=--enable-source-maps` と組み合わせて使用

## 変更内容
- `web/next.config.ts`: `serverSourceMaps: true` を追加
- `admin/next.config.ts`: `serverSourceMaps: true` を追加

## 備考
- ランタイムパフォーマンスへの影響はなし（エラー発生時のスタックトレース変換のみ）
- サーバー側の source map はクライアントに配信されないため、セキュリティリスクなし
- Vercel の Preview 環境に `NODE_OPTIONS=--enable-source-maps` を環境変数として設定済み

## テスト記録
- `pnpm lint` ✅
- `pnpm typecheck` ✅
- `pnpm build` ✅
- `pnpm test` ✅（既存の1件失敗は本変更と無関係）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * デバッグおよび本番環境でのエラー追跡の効率向上のため、サーバーサイドソースマップの生成機能を有効化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->