### PR TITLE
fix: serverSourceMapsをexperimental配下に移動

### DIFF
--- a/admin/next.config.ts
+++ b/admin/next.config.ts
@@ -1,7 +1,9 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  serverSourceMaps: true,
+  experimental: {
+    serverSourceMaps: true,
+  },
   typedRoutes: true,
   turbopack: {
     root: "../",

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -1,7 +1,9 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  serverSourceMaps: true,
+  experimental: {
+    serverSourceMaps: true,
+  },
   typedRoutes: true,
   turbopack: {
     root: "../",


### PR DESCRIPTION
## Summary
- `serverSourceMaps: true` をトップレベルから `experimental.serverSourceMaps: true` に移動
- Next.js 15.5 では `serverSourceMaps` はまだ experimental オプションであり、トップレベルに設定すると無視される
- #617 で追加した設定が実際には機能していなかった問題を修正

## 変更内容
- `web/next.config.ts`: `serverSourceMaps` を `experimental` 配下に移動
- `admin/next.config.ts`: 同上

## 根拠
Next.js 15.5.9 のソースコードを確認した結果:
- `config-shared.js`: `experimental.serverSourceMaps: false` として定義（トップレベルには存在しない）
- `config-schema.js`: Zod の `strictObject` スキーマでトップレベルに `serverSourceMaps` は未定義
- `config.js`: graduated 設定リストに `serverSourceMaps` は含まれていない
- トップレベルに設定した値は Zod 警告が出るだけで完全に無視されていた

## テスト記録
- `pnpm lint` ✅
- `pnpm typecheck` ✅
- `pnpm build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 開発環境の設定構造を最適化しました。複数のプロジェクトで設定ファイルの構成を統一し、開発効率を向上させています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->