### PR TITLE
fix: OGP画像生成のフォント読み込みエラーを修正

### DIFF
--- a/web/src/app/api/og/report/route.tsx
+++ b/web/src/app/api/og/report/route.tsx
@@ -17,12 +17,13 @@ const FONT_FETCH_TIMEOUT_MS = 3000;
 /** タイムアウト付きfetch */
 async function fetchWithTimeout(
   url: string,
+  init?: RequestInit,
   timeoutMs = FONT_FETCH_TIMEOUT_MS
 ) {
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    return await fetch(url, { signal: controller.signal });
+    return await fetch(url, { ...init, signal: controller.signal });
   } finally {
     clearTimeout(timeoutId);
   }
@@ -35,10 +36,15 @@ async function loadFont(): Promise<ArrayBuffer | null> {
   if (cachedFontData) return cachedFontData;
 
   try {
-    const css = await fetchWithTimeout(GOOGLE_FONTS_URL).then((res) =>
-      res.text()
-    );
-    const fontUrl = css.match(/src: url\(([^)]+)\) format\('woff2'\)/)?.[1];
+    // Google Fontsはwoff2を返すためにブラウザ相当のUser-Agentが必要
+    const css = await fetchWithTimeout(GOOGLE_FONTS_URL, {
+      headers: {
+        "User-Agent":
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36",
+      },
+    }).then((res) => res.text());
+    const fontUrl = (css.match(/src: url\(([^)]+)\) format\('woff2'\)/) ??
+      css.match(/src: url\(([^)]+)\) format\('[^']+'\)/))?.[1];
     if (!fontUrl) return null;
     cachedFontData = await fetchWithTimeout(fontUrl).then((r) =>
       r.arrayBuffer()
@@ -74,14 +80,19 @@ export async function GET(request: Request) {
   );
 
   const fontData = await loadFont();
-  const fonts: {
-    name: string;
-    data: ArrayBuffer;
-    style: "normal";
-    weight: 400;
-  }[] = fontData
-    ? [{ name: "Noto Sans JP", data: fontData, style: "normal", weight: 400 }]
-    : [];
+  // フォント取得失敗時はプロパティ自体を省略し、デフォルトフォントにフォールバック
+  const fontOptions = fontData
+    ? {
+        fonts: [
+          {
+            name: "Noto Sans JP",
+            data: fontData,
+            style: "normal" as const,
+            weight: 400 as const,
+          },
+        ],
+      }
+    : {};
 
   return new ImageResponse(
     <div
@@ -206,7 +217,7 @@ export async function GET(request: Request) {
     {
       width: 1200,
       height: 630,
-      fonts,
+      ...fontOptions,
       headers: {
         "Cache-Control": "public, max-age=3600, s-maxage=86400",
       },


### PR DESCRIPTION
## Summary
- Google Fonts APIからwoff2形式のフォントを確実に取得するため、fetch時にブラウザ相当のUser-Agentヘッダーを付与
- フォント取得失敗時に `fonts: []` を渡してsatori（next/og内部）がクラッシュする問題を修正。`fonts` オプション自体を省略してデフォルトフォントにフォールバックするよう変更
- フォントURL抽出の正規表現にwoff2以外のフォーマットへのフォールバックを追加

## エラー内容
```
[Error: failed to pipe response] {
  [cause]: [Error: No fonts are loaded. At least one font is required to calculate the layout.]
}
```

## Test plan
- [x] `pnpm lint` パス
- [x] `pnpm typecheck` パス
- [x] `pnpm build` パス
- [x] `pnpm test` パス（admin側の既存テスト1件失敗はdevelopでも同様）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * レポートのOG画像生成時のフォント読み込み処理を改善しました。フォント読み込みに失敗した場合でも適切にフォールバック処理が行われるようになりました。
  * ネットワークリクエストのタイムアウト処理を強化し、より堅牢になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->