### PR TITLE
fix: opinionSchema/contentRichnessSchemaにstrict()を追加

### DIFF
--- a/web/src/features/interview-session/shared/schemas.ts
+++ b/web/src/features/interview-session/shared/schemas.ts
@@ -1,14 +1,16 @@
 import { z } from "zod";
 
 // 意見スキーマ
-const opinionSchema = z.object({
-  title: z.string().describe("意見のタイトル（40文字以内）"),
-  content: z.string().describe("意見の説明（120文字以内）"),
-  source_message_id: z
-    .string()
-    .nullable()
-    .describe("この意見の根拠となるユーザー発言のメッセージID"),
-});
+const opinionSchema = z
+  .object({
+    title: z.string().describe("意見のタイトル（40文字以内）"),
+    content: z.string().describe("意見の説明（120文字以内）"),
+    source_message_id: z
+      .string()
+      .nullable()
+      .describe("この意見の根拠となるユーザー発言のメッセージID"),
+  })
+  .strict();
 
 // 0-100の情報充実度値（LLMが小数点を返す可能性があるため丸める）
 const contentRichnessValueSchema = z
@@ -17,24 +19,26 @@ const contentRichnessValueSchema = z
   .pipe(z.number().int().min(0).max(100));
 
 // 情報充実度スキーマ
-const contentRichnessSchema = z.object({
-  total: contentRichnessValueSchema.describe(
-    "総合的な情報充実度（0-100の整数）"
-  ),
-  clarity: contentRichnessValueSchema.describe(
-    "論点の明確さ（0-100）— 議論のポイントがはっきり浮かび上がっているか"
-  ),
-  specificity: contentRichnessValueSchema.describe(
-    "具体性（0-100）— 現場の実感や具体的な事例・数値が得られたか"
-  ),
-  impact: contentRichnessValueSchema.describe(
-    "影響への言及（0-100）— 社会的影響や関係者への影響について情報が得られたか"
-  ),
-  constructiveness: contentRichnessValueSchema.describe(
-    "提案の広がり（0-100）— 課題の指摘に加え、改善の方向性や代替案が含まれているか"
-  ),
-  reasoning: z.string().describe("上記の根拠を簡潔に説明（100文字以内）"),
-});
+const contentRichnessSchema = z
+  .object({
+    total: contentRichnessValueSchema.describe(
+      "総合的な情報充実度（0-100の整数）"
+    ),
+    clarity: contentRichnessValueSchema.describe(
+      "論点の明確さ（0-100）— 議論のポイントがはっきり浮かび上がっているか"
+    ),
+    specificity: contentRichnessValueSchema.describe(
+      "具体性（0-100）— 現場の実感や具体的な事例・数値が得られたか"
+    ),
+    impact: contentRichnessValueSchema.describe(
+      "影響への言及（0-100）— 社会的影響や関係者への影響について情報が得られたか"
+    ),
+    constructiveness: contentRichnessValueSchema.describe(
+      "提案の広がり（0-100）— 課題の指摘に加え、改善の方向性や代替案が含まれているか"
+    ),
+    reasoning: z.string().describe("上記の根拠を簡潔に説明（100文字以内）"),
+  })
+  .strict();
 
 export type InterviewContentRichness = z.infer<typeof contentRichnessSchema>;
 


### PR DESCRIPTION
## Summary
- OpenAI structured outputが全objectに `additionalProperties: false` を要求するため、`opinionSchema` と `contentRichnessSchema` に `.strict()` を追加
- 親スキーマ `interviewReportSchema` は既に `.strict()` を使用していたが、ネストされたスキーマには付与されていなかった
- これにより `Invalid schema for response_format` エラーが解消される

## Test plan
- [x] `pnpm lint` パス
- [x] `pnpm typecheck` パス
- [x] `pnpm build` パス
- [x] `pnpm test` パス（admin側の既存テスト失敗は本変更と無関係）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * インタビュー報告書のデータ検証を強化しました。意見と情報の豊かさに関するデータの整合性が向上しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->