### PR TITLE
feat: seedデータにthumbnail_url・role_title・is_public_by_adminを追加

### DIFF
--- a/packages/seed/main/data.ts
+++ b/packages/seed/main/data.ts
@@ -66,6 +66,7 @@ export const bills: BillInsert[] = [
     published_at: "2025-08-01T09:00:00+09:00",
     publish_status: "published",
     is_featured: true,
+    thumbnail_url: "https://placehold.co/600x400",
   },
   {
     name: "こども家庭庁予算大幅増額法案",
@@ -75,6 +76,7 @@ export const bills: BillInsert[] = [
     published_at: "2025-01-20T10:00:00+09:00",
     publish_status: "published",
     is_featured: true,
+    thumbnail_url: "https://placehold.co/600x400",
   },
   {
     name: "18歳選挙権完全実施法案",
@@ -84,6 +86,7 @@ export const bills: BillInsert[] = [
     published_at: "2025-02-01T09:00:00+09:00",
     publish_status: "published",
     is_featured: false,
+    thumbnail_url: "https://placehold.co/600x400",
   },
   {
     name: "学校給食無償化促進法案",
@@ -93,6 +96,7 @@ export const bills: BillInsert[] = [
     published_at: "2025-01-10T09:00:00+09:00",
     publish_status: "published",
     is_featured: false,
+    thumbnail_url: "https://placehold.co/600x400",
   },
   // 第218回国会用の追加法案（デザイン確認用）- ループで生成
   ...Array.from({ length: 4 }, (_, i) => ({
@@ -105,6 +109,7 @@ export const bills: BillInsert[] = [
     published_at: `2025-08-0${i + 1}T09:00:00+09:00`,
     publish_status: "published" as const,
     is_featured: false,
+    thumbnail_url: "https://placehold.co/600x400",
   })),
   {
     name: "船荷証券の電子化に関する法律案",
@@ -114,6 +119,7 @@ export const bills: BillInsert[] = [
     published_at: "2025-09-15T09:00:00+09:00",
     publish_status: "published",
     is_featured: false,
+    thumbnail_url: "https://placehold.co/600x400",
   },
   {
     name: "中学生・高校生向けプログラミング教育必修化法案",
@@ -123,6 +129,7 @@ export const bills: BillInsert[] = [
     published_at: "2024-11-15T10:00:00+09:00",
     publish_status: "published",
     is_featured: false,
+    thumbnail_url: "https://placehold.co/600x400",
   },
 ];
 
@@ -407,6 +414,7 @@ export function createInterviewReports(
       stance: "for" as const,
       summary: "この法案に賛成。国民のためになると考えている。",
       role: "general_citizen" as const,
+      role_title: "一般市民",
       role_description: "法案の内容に賛同する市民",
       opinions: [{ title: "賛成理由", content: "国民のためになる" }],
     },
@@ -414,6 +422,7 @@ export function createInterviewReports(
       stance: "against" as const,
       summary: "財源の不明確さを理由に反対。",
       role: "work_related" as const,
+      role_title: "会社員",
       role_description: "財政面を懸念する市民",
       opinions: [{ title: "反対理由", content: "財源が不明確" }],
     },
@@ -421,6 +430,7 @@ export function createInterviewReports(
       stance: "neutral" as const,
       summary: "判断するにはより多くの情報が必要と考えている。",
       role: "subject_expert" as const,
+      role_title: "専門家",
       role_description: "慎重な判断を求める市民",
       opinions: [{ title: "態度保留理由", content: "情報不足" }],
     },
@@ -442,6 +452,7 @@ export function createInterviewReports(
         interview_session_id: sessionId,
         ...reportTemplates[patternIndex],
         is_public_by_user: loopIndex < 5, // 最初の5件は公開
+        is_public_by_admin: loopIndex < 3, // 最初の3ループ分は管理者承認済み
       });
     }
   });
@@ -520,6 +531,7 @@ export function createDemoReport(): InterviewReportInsert {
     stance: "neutral",
     summary: "期待と懸念両方がある",
     role: "subject_expert",
+    role_title: "フォワーダー",
     role_description:
       "中国航路担当のフォワーダー実務者\n業界経験20年\n船荷証券（B/L）手続きに日常的に関与",
     opinions: [
@@ -530,6 +542,7 @@ export function createDemoReport(): InterviewReportInsert {
       },
     ],
     is_public_by_user: true,
+    is_public_by_admin: true,
   };
 }
 
@@ -659,6 +672,7 @@ export function createAdditionalDemoReports(): InterviewReportInsert[] {
       stance: "for",
       summary: "物流コスト削減のため賛成",
       role: "work_related",
+      role_title: "運送会社経営者",
       role_description:
         "運送会社経営者\n従業員50名規模\n燃料費高騰の影響を直接受けている",
       opinions: [
@@ -669,6 +683,7 @@ export function createAdditionalDemoReports(): InterviewReportInsert[] {
         },
       ],
       is_public_by_user: true,
+      is_public_by_admin: true,
     },
     {
       id: DEMO_REPORT_ID_DAILY,
@@ -676,6 +691,7 @@ export function createAdditionalDemoReports(): InterviewReportInsert[] {
       stance: "for",
       summary: "地方在住者として生活必需品のガソリン代軽減を期待",
       role: "daily_life_affected",
+      role_title: "主婦",
       role_description:
         "地方在住の主婦\n車が唯一の移動手段\n子育て中で送り迎えに車を使用",
       opinions: [
@@ -686,6 +702,7 @@ export function createAdditionalDemoReports(): InterviewReportInsert[] {
         },
       ],
       is_public_by_user: true,
+      is_public_by_admin: true,
     },
     {
       id: DEMO_REPORT_ID_CITIZEN,
@@ -693,6 +710,7 @@ export function createAdditionalDemoReports(): InterviewReportInsert[] {
       stance: "neutral",
       summary: "環境と経済のバランスを考慮して判断",
       role: "general_citizen",
+      role_title: "会社員",
       role_description: "会社員\n環境問題に関心あり\n電気自動車への乗り換えを検討中",
       opinions: [
         {
@@ -702,6 +720,7 @@ export function createAdditionalDemoReports(): InterviewReportInsert[] {
         },
       ],
       is_public_by_user: true,
+      is_public_by_admin: true,
     },
   ];
 }

--- a/packages/seed/main/shipping-bill-data.ts
+++ b/packages/seed/main/shipping-bill-data.ts
@@ -81,6 +81,7 @@ const opinionPatterns: Array<{
     | "work_related"
     | "daily_life_affected"
     | "general_citizen";
+  role_title: string;
   role_description: string;
   opinions: Array<{ title: string; content: string }>;
 }> = [
@@ -90,6 +91,7 @@ const opinionPatterns: Array<{
     summary:
       "電子化により船荷証券の処理時間が大幅に短縮され、業務効率が向上する",
     role: "subject_expert",
+    role_title: "フォワーダー",
     role_description:
       "中国航路担当のフォワーダー実務者\n業界経験20年\nB/L手続きに日常的に関与",
     opinions: [
@@ -116,6 +118,7 @@ const opinionPatterns: Array<{
     summary:
       "電子化の方向性には賛同するが、中小企業の導入コスト支援が不可欠",
     role: "work_related",
+    role_title: "船会社経営者",
     role_description:
       "内航船会社の経営者\n従業員30名\nアジア近距離航路を主に運航",
     opinions: [
@@ -142,6 +145,7 @@ const opinionPatterns: Array<{
     summary:
       "電子化のメリットは理解するが、セキュリティと法的効力の担保が最優先",
     role: "subject_expert",
+    role_title: "リスクアナリスト",
     role_description:
       "貿易保険会社のリスクアナリスト\n海上保険・貿易リスク専門\n法務部門との連携業務",
     opinions: [
@@ -168,6 +172,7 @@ const opinionPatterns: Array<{
     summary:
       "電子化により港湾事務職の雇用が失われることを懸念",
     role: "work_related",
+    role_title: "港湾事務職員",
     role_description:
       "港湾事務職員\n通関・書類処理業務を担当\n勤続15年",
     opinions: [
@@ -194,6 +199,7 @@ const opinionPatterns: Array<{
     summary:
       "MLETR準拠の国内法整備は国際競争力維持のために不可欠",
     role: "subject_expert",
+    role_title: "大学教授",
     role_description:
       "海商法・国際取引法の大学教授\nUNCITRAL関連研究\n政府審議会委員",
     opinions: [
@@ -220,6 +226,7 @@ const opinionPatterns: Array<{
     summary:
       "技術的には十分実現可能。標準化とAPI連携が鍵",
     role: "work_related",
+    role_title: "物流テックCTO",
     role_description:
       "物流テック企業のCTO\n電子B/Lプラットフォーム開発経験\nブロックチェーン技術専門",
     opinions: [
@@ -245,6 +252,7 @@ const opinionPatterns: Array<{
     stance: "for",
     summary: "物流の効率化により商品の価格低下が期待できる",
     role: "general_citizen",
+    role_title: "会社員",
     role_description:
       "会社員\nECサイトでの海外通販を月数回利用\n物流効率化に関心あり",
     opinions: [
@@ -271,6 +279,7 @@ const opinionPatterns: Array<{
     summary:
       "L/C決済との連携が円滑にできれば電子化は歓迎",
     role: "subject_expert",
+    role_title: "貿易金融担当",
     role_description:
       "メガバンク貿易金融部門\nL/C（信用状）審査担当\n国際決済業務20年",
     opinions: [
@@ -297,6 +306,7 @@ const opinionPatterns: Array<{
     summary:
       "通関手続きの効率化は期待できるが、システム連携に課題がある",
     role: "work_related",
+    role_title: "税関職員",
     role_description:
       "財務省税関職員\n輸出入通関業務担当\nNACCS運用経験",
     opinions: [
@@ -322,6 +332,7 @@ const opinionPatterns: Array<{
     stance: "for",
     summary: "サプライチェーン全体の可視化・効率化に期待",
     role: "work_related",
+    role_title: "SCM部門長",
     role_description:
       "製造業大手のSCM部門長\n年間数千TEUの海上輸送を管理\nDX推進担当",
     opinions: [
@@ -445,9 +456,11 @@ export function createShippingBillReports(
       stance: pattern.stance,
       summary: pattern.summary,
       role: pattern.role,
+      role_title: pattern.role_title,
       role_description: pattern.role_description,
       opinions: pattern.opinions,
       is_public_by_user: true,
+      is_public_by_admin: index < 30, // 最初の30件は管理者承認済み
     };
   });
 }


### PR DESCRIPTION
## Summary
- 全法案(bills)に `thumbnail_url: "https://placehold.co/600x400"` を設定
- 全レポート(interview_report)に `role_title` を設定（「フォワーダー」「主婦」「大学教授」等）
- 一部レポートの `is_public_by_admin` を `true` に設定（デモレポート全件、テンプレートレポート最初の3ループ分、船荷証券レポート最初の30件）

## Test plan
- [ ] `pnpm typecheck` 通過確認済み
- [ ] `pnpm lint` エラーなし確認済み
- [ ] `pnpm seed` でデータ投入が正常に完了すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 請求書にサムネイル画像を表示
  * インタビューレポートに役職情報を追加
  * 管理者によるレポート表示制御機能を実装

<!-- end of auto-generated comment: release notes by coderabbit.ai -->