### PR TITLE
chore: .claude/worktrees をgitignoreに追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules
 # misc
 .DS_Store
 .vscode
+.claude/worktrees
 
 # env files
 .env


### PR DESCRIPTION
## Summary
- Claude Codeのworktree isolation機能が生成する `.claude/worktrees/` ディレクトリを `.gitignore` に追加
- ローカル作業用ディレクトリがリポジトリに混入するのを防止

## Test plan
- `.gitignore` のみの変更のため、ビルド・テストへの影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)