### PR TITLE
fix: レポートカードUIをFigmaデザインに合わせて更新

### DIFF
--- a/web/src/features/interview-report/shared/components/report-card.tsx
+++ b/web/src/features/interview-report/shared/components/report-card.tsx
@@ -59,7 +59,7 @@ export function ReportCard({
       : summary;
 
   return (
-    <article className="relative bg-white rounded-lg px-4 py-[18px] hover:bg-gray-50 transition-colors">
+    <article className="relative bg-white rounded-lg p-4 hover:bg-gray-50 transition-colors">
       <Link
         href={(href ?? getPublicReportLink(report.id)) as Route}
         className="absolute inset-0 rounded-lg"
@@ -74,58 +74,58 @@ export function ReportCard({
           <Image
             src={`/icons/stance-${report.stance}.png`}
             alt={stanceLabel || ""}
-            width={42}
-            height={42}
+            width={34}
+            height={34}
             className="rounded-full flex-shrink-0"
           />
         )}
-        <div className="flex flex-col gap-2.5 min-w-0 flex-1">
-          <div className="flex items-start gap-2">
-            {stanceLabel && (
-              <div className="flex-1 min-w-0">
-                <span
-                  className={cn(
-                    "inline-flex items-center justify-center px-3 py-0.5 rounded-2xl text-xs font-medium leading-3",
-                    stanceBadgeBg,
-                    stanceTextColor
-                  )}
-                >
-                  {stanceLabel}
-                </span>
+        <div className="flex flex-col gap-2 min-w-0 flex-1">
+          <div className="flex flex-col gap-2.5">
+            <div className="flex items-center gap-2">
+              <div className="flex flex-1 min-w-0 items-center gap-2.5">
+                {stanceLabel && (
+                  <span
+                    className={cn(
+                      "inline-flex items-center justify-center px-3 py-0.5 rounded-2xl text-xs font-medium leading-3 flex-shrink-0",
+                      stanceBadgeBg,
+                      stanceTextColor
+                    )}
+                  >
+                    {stanceLabel}
+                  </span>
+                )}
+                {roleLabel && (
+                  <div className="flex items-center gap-1 text-mirai-text-subtle flex-shrink-0">
+                    {RoleIcon && (
+                      <RoleIcon size={16} className="flex-shrink-0" />
+                    )}
+                    <span className="text-xs leading-3">{roleLabel}</span>
+                  </div>
+                )}
               </div>
-            )}
-            <span className="text-[13px] text-mirai-text-muted whitespace-nowrap flex-shrink-0">
-              {relativeTime}
-            </span>
-          </div>
+              <span className="text-[13px] text-mirai-text-muted whitespace-nowrap flex-shrink-0">
+                {relativeTime}
+              </span>
+            </div>
 
-          <div className="flex flex-col gap-2">
             {report.role_title && (
               <p className="text-base font-bold leading-snug text-mirai-text">
                 {report.role_title}
               </p>
             )}
-            {roleLabel && (
-              <div className="flex items-center gap-1 text-mirai-text-subtle">
-                {RoleIcon && <RoleIcon size={16} className="flex-shrink-0" />}
-                <span className="text-xs leading-3">{roleLabel}</span>
-              </div>
+
+            {truncatedSummary && (
+              <p className="text-sm leading-6 text-black">{truncatedSummary}</p>
             )}
           </div>
+
+          {children && (
+            <div className="relative z-10 pointer-events-none [&_button]:pointer-events-auto [&_a]:pointer-events-auto">
+              {children}
+            </div>
+          )}
         </div>
       </div>
-
-      {truncatedSummary && (
-        <p className="mt-2.5 text-[13px] leading-[22px] text-black">
-          {truncatedSummary}
-        </p>
-      )}
-
-      {children && (
-        <div className="relative z-10 mt-2 pointer-events-none [&_button]:pointer-events-auto [&_a]:pointer-events-auto">
-          {children}
-        </div>
-      )}
     </article>
   );
 }

--- a/web/src/features/report-reaction/client/components/reaction-buttons-inline.tsx
+++ b/web/src/features/report-reaction/client/components/reaction-buttons-inline.tsx
@@ -85,12 +85,14 @@ function InlineReactionButton({
       aria-label={`${label} ${count}`}
       className="flex items-center gap-1 h-auto px-0 py-0 hover:bg-transparent"
     >
-      <Icon size={16} className={`transition-colors ${colorClass}`} />
-      <span className={`text-xs font-medium transition-colors ${colorClass}`}>
+      <Icon size={24} className={`transition-colors ${colorClass}`} />
+      <span className={`text-sm font-medium transition-colors ${colorClass}`}>
         {label}
       </span>
       {count > 0 && (
-        <span className={`text-xs font-medium transition-colors ${colorClass}`}>
+        <span
+          className={`text-[13px] font-medium transition-colors ${colorClass} ml-1`}
+        >
           {count}
         </span>
       )}


### PR DESCRIPTION
## Summary
- レポートカードのレイアウトをFigmaデザインに合わせて再構成
- アバターサイズを42px→34pxに縮小、パディングをp-4に統一
- スタンスバッジとロールラベルを同一行に配置（以前はロールラベルがタイトル下に表示）
- サマリーテキストとリアクションボタンを右カラム内に移動
- リアクションボタンのアイコンサイズを16px→24px、ラベルテキストを14pxに拡大

## Test plan
- [x] `pnpm lint` 通過
- [x] `pnpm typecheck` 通過
- [x] `pnpm --filter web test` 全74ファイル・730テスト通過
- [ ] 各スタンス（期待/懸念/期待＆懸念）のレポートカード表示確認
- [ ] リアクションボタンの動作確認（アクティブ/非アクティブ状態）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **スタイル**
  * レポートカードのレイアウトを最適化しました。パディングとアイコンサイズを調整し、コンテンツの配置をより効率的に再構成しました。
  * リアクションボタンのUI を改善しました。アイコンサイズを拡大し、テキストサイズとスペーシングを調整して視認性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->