### PR TITLE
fix: インタビューLPのレイアウト調整

### DIFF
--- a/web/src/features/interview-config/client/components/interview-lp-page.tsx
+++ b/web/src/features/interview-config/client/components/interview-lp-page.tsx
@@ -14,6 +14,7 @@ import {
   getInterviewDisclosureLink,
 } from "@/features/interview-config/shared/utils/interview-links";
 import { formatEstimatedDuration } from "@/features/interview-config/shared/utils/format-estimated-duration";
+import { NewInterviewButton } from "@/features/interview-session/client/components/new-interview-button";
 import { InterviewActionButtons } from "./interview-action-buttons";
 
 interface InterviewLPPageProps {
@@ -117,13 +118,15 @@ function _InterviewLPHero({
         ))}
       </div>
 
-      <div className="w-full max-w-[370px] mt-2 flex flex-col gap-3">
-        <InterviewActionButtons
-          billId={billId}
-          sessionInfo={sessionInfo}
-          previewToken={previewToken}
-        />
-      </div>
+      {sessionInfo?.status !== "completed" && (
+        <div className="w-full max-w-[370px] mt-2 flex flex-col gap-3">
+          <InterviewActionButtons
+            billId={billId}
+            sessionInfo={sessionInfo}
+            previewToken={previewToken}
+          />
+        </div>
+      )}
     </div>
   );
 }
@@ -319,10 +322,12 @@ export function InterviewLPPage({
           previewToken={previewToken}
         />
         {userReports && userReports.reports.length > 0 && (
-          <PastReportsSection
-            reports={userReports.reports}
-            reactionsRecord={userReports.reactionsRecord}
-          />
+          <PastReportsSection reports={userReports.reports} />
+        )}
+        {sessionInfo?.status === "completed" && sessionInfo?.reportId && (
+          <div className="w-full max-w-[370px]">
+            <NewInterviewButton billId={bill.id} previewToken={previewToken} />
+          </div>
         )}
         <_InterviewOverviewSection
           billId={bill.id}

--- a/web/src/features/interview-report/client/components/past-reports-section.tsx
+++ b/web/src/features/interview-report/client/components/past-reports-section.tsx
@@ -1,20 +1,12 @@
-"use client";
-
 import { getInterviewReportCompleteLink } from "@/features/interview-config/shared/utils/interview-links";
-import { ReactionButtonsInline } from "@/features/report-reaction/client/components/reaction-buttons-inline";
-import type { ReportReactionData } from "@/features/report-reaction/shared/types";
 import { ReportCard } from "../../shared/components/report-card";
 import type { ReportCardData } from "../../shared/components/report-card";
 
 interface PastReportsSectionProps {
   reports: ReportCardData[];
-  reactionsRecord: Record<string, ReportReactionData>;
 }
 
-export function PastReportsSection({
-  reports,
-  reactionsRecord,
-}: PastReportsSectionProps) {
+export function PastReportsSection({ reports }: PastReportsSectionProps) {
   if (reports.length === 0) {
     return null;
   }
@@ -25,27 +17,17 @@ export function PastReportsSection({
         過去のレポート
       </h2>
       <div className="flex flex-col gap-4">
-        {reports.map((report) => {
-          const reactionData = reactionsRecord[report.id];
-          return (
-            <div
-              key={report.id}
-              className="border border-black rounded-lg overflow-hidden"
-            >
-              <ReportCard
-                report={report}
-                href={getInterviewReportCompleteLink(report.id)}
-              >
-                {reactionData && (
-                  <ReactionButtonsInline
-                    reportId={report.id}
-                    initialData={reactionData}
-                  />
-                )}
-              </ReportCard>
-            </div>
-          );
-        })}
+        {reports.map((report) => (
+          <div
+            key={report.id}
+            className="border border-black rounded-lg overflow-hidden"
+          >
+            <ReportCard
+              report={report}
+              href={getInterviewReportCompleteLink(report.id)}
+            />
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/web/src/features/interview-report/server/loaders/get-user-reports-by-interview-config.ts
+++ b/web/src/features/interview-report/server/loaders/get-user-reports-by-interview-config.ts
@@ -1,18 +1,15 @@
 import "server-only";
 
 import { getChatSupabaseUser } from "@/features/chat/server/utils/supabase-server";
-import { getReportReactionsBatch } from "@/features/report-reaction/server/loaders/get-report-reactions";
-import type { ReportReactionData } from "@/features/report-reaction/shared/types";
 import type { ReportCardData } from "../../shared/components/report-card";
 import { findUserReportsByInterviewConfigId } from "../repositories/interview-report-repository";
 
 export interface UserReportsResult {
   reports: ReportCardData[];
-  reactionsRecord: Record<string, ReportReactionData>;
 }
 
 /**
- * ユーザーの過去のインタビューレポートとリアクション情報を取得
+ * ユーザーの過去のインタビューレポートを取得
  */
 export async function getUserReportsByInterviewConfig(
   interviewConfigId: string
@@ -44,12 +41,5 @@ export async function getUserReportsByInterviewConfig(
     created_at: r.created_at,
   }));
 
-  const reportIds = reports.map((r) => r.id);
-  const reactionsMap = await getReportReactionsBatch(reportIds);
-  const reactionsRecord = Object.fromEntries(reactionsMap) as Record<
-    string,
-    ReportReactionData
-  >;
-
-  return { reports, reactionsRecord };
+  return { reports };
 }


### PR DESCRIPTION
## Summary
- 「もう一度新たに回答する」ボタンを過去のレポートセクションの下に移動
- 「参考になる」リアクションボタンを一旦非表示（非公開レポートがあるため）
- 不要になったリアクションデータ取得（`getReportReactionsBatch`）を削除し、LP読み込み時の不要なDB呼び出しを解消

## Test plan
- [x] `pnpm lint` 通過
- [x] `pnpm typecheck` 通過
- [x] `pnpm build` 通過
- [x] `pnpm test` web側テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * インタビュー完了後、新しいインタビューを開始できるボタンが表示されるようになりました。

* **改善**
  * インタビュー完了時のUIが整理され、より簡潔な表示になりました。
  * 過去レポートセクションの表示が最適化されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->