### PR TITLE
fix: OGP画像生成のフォント読み込みでwoff2エラーを修正

### DIFF
--- a/web/src/app/api/og/report/route.tsx
+++ b/web/src/app/api/og/report/route.tsx
@@ -40,14 +40,16 @@ async function loadFont(): Promise<ArrayBuffer | null> {
   try {
     const url =
       "https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&display=swap";
-    const css = await fetchWithTimeout(url).then((res) => res.text());
-    const fontUrl = css.match(
-      /src:\s*url\(([^)]+)\)\s*format\('(opentype|truetype)'\)/
-    )?.[1];
+    const cssRes = await fetchWithTimeout(url);
+    if (!cssRes.ok) return null;
+    const css = await cssRes.text();
+    const fontUrl = css
+      .match(/src:\s*url\(([^)]+)\)\s*format\('(opentype|truetype)'\)/)?.[1]
+      ?.replace(/^["']|["']$/g, "");
     if (!fontUrl) return null;
-    cachedFontData = await fetchWithTimeout(fontUrl).then((r) =>
-      r.arrayBuffer()
-    );
+    const fontRes = await fetchWithTimeout(fontUrl);
+    if (!fontRes.ok) return null;
+    cachedFontData = await fontRes.arrayBuffer();
     return cachedFontData;
   } catch {
     return null;


### PR DESCRIPTION
## Summary
- OGP画像生成（`/api/og/report`）でフォント読み込み時に `Unsupported OpenType signature wOF2` エラーが発生していた問題を修正
- 原因: Google Fontsへのリクエストにブラウザ User-Agent を送信していたため woff2 形式が返されていたが、Satori（`next/og` 内部のレンダラー）は woff2 に非対応
- 修正: User-Agent ヘッダーを削除し、TTF/OpenType 形式でフォントを取得するように変更

## Test plan
- [x] `pnpm lint` パス
- [x] `pnpm typecheck` パス
- [x] `pnpm build` パス
- [ ] `pnpm dev` でレポートページのOGP画像 `/api/og/report?id=<reportId>` が正常に生成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * Open Graphレポート画像のフォント読み込みを改善し、より多くの環境で正しく表示されるようになりました。
  * フォント取得時の検証とエラーハンドリングを強化し、失敗や不整合が起きにくくなりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->