### PR TITLE
fix: ReportCardのLink prefetchを無効化

### DIFF
--- a/web/src/features/interview-report/shared/components/report-card.tsx
+++ b/web/src/features/interview-report/shared/components/report-card.tsx
@@ -62,6 +62,7 @@ export function ReportCard({
     <article className="relative bg-white rounded-lg px-4 py-[18px] hover:bg-gray-50 transition-colors">
       <Link
         href={(href ?? getPublicReportLink(report.id)) as Route}
+        prefetch={false}
         className="absolute inset-0 rounded-lg"
         aria-label={
           [stanceLabel, report.role_title || roleLabel, truncatedSummary]


### PR DESCRIPTION
## Summary
- レポート一覧ページで `ReportCard` の `<Link>` にビューポートベースの自動プリフェッチが有効になっており、表示されるカード分の詳細ページが先読みされていた
- `prefetch={false}` を設定し、ビューポート進入時の自動プリフェッチを無効化。ホバー時のプリフェッチは引き続き動作するため、ユーザー体感への影響は最小限

## Test plan
- [x] `pnpm lint` 通過
- [x] `pnpm typecheck` 通過
- [ ] レポート一覧ページでNetwork Tabを確認し、スクロール時にレポート詳細の先読みリクエストが発生しないことを確認
- [ ] レポートカードをクリックして詳細ページに正常に遷移できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **パフォーマンス改善**
  * レポートカードコンポーネントのリンク動作を調整し、事前読み込みを無効化することで、ページロード時のリソース消費を削減しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->