### PR TITLE
feat: 意見カードに「元の回答を見る」リンクを追加

### DIFF
--- a/web/src/features/interview-report/server/components/report-chat-log-page.tsx
+++ b/web/src/features/interview-report/server/components/report-chat-log-page.tsx
@@ -179,7 +179,10 @@ function ChatMessage({ message }: ChatMessageProps) {
     const displayText = getMessageDisplayText(message.content);
     // AI message: icon on top left with gray background, then plain text below
     return (
-      <div className="flex flex-col items-start gap-2">
+      <div
+        id={`message-${message.id}`}
+        className="flex flex-col items-start gap-2 scroll-mt-4"
+      >
         <div className="w-9 h-9 rounded-full bg-gray-100 flex items-center justify-center">
           <Bot size={24} className="text-gray-600" />
         </div>
@@ -192,7 +195,10 @@ function ChatMessage({ message }: ChatMessageProps) {
 
   // User message: icon on top right, then bubble below
   return (
-    <div className="flex flex-col items-end gap-2">
+    <div
+      id={`message-${message.id}`}
+      className="flex flex-col items-end gap-2 scroll-mt-4"
+    >
       <div className="w-9 h-9 rounded-full bg-mirai-light-gradient flex items-center justify-center">
         <UserRound size={20} className="text-gray-600" />
       </div>

--- a/web/src/features/interview-report/shared/components/opinions-list.tsx
+++ b/web/src/features/interview-report/shared/components/opinions-list.tsx
@@ -1,20 +1,26 @@
 import type { ReactNode } from "react";
+import type { Route } from "next";
+import { ArrowRight } from "lucide-react";
+import Link from "next/link";
+import { getInterviewChatLogLink } from "@/features/interview-config/shared/utils/interview-links";
+import type { ParsedOpinion as Opinion } from "../utils/format-utils";
 
-export interface Opinion {
-  title: string;
-  content: string;
-}
+export type { Opinion };
 
 interface OpinionsListProps {
   opinions: Opinion[];
   title?: string;
   footer?: ReactNode;
+  reportId?: string;
+  chatLogFrom?: "complete";
 }
 
 export function OpinionsList({
   opinions,
   title = "💬意見の要約",
   footer,
+  reportId,
+  chatLogFrom,
 }: OpinionsListProps) {
   if (opinions.length === 0) {
     return null;
@@ -40,6 +46,17 @@ export function OpinionsList({
               </p>
             </div>
             <p className="text-sm text-gray-600">{opinion.content}</p>
+            {reportId && opinion.source_message_id && (
+              <Link
+                href={
+                  `${getInterviewChatLogLink(reportId, chatLogFrom)}#message-${opinion.source_message_id}` as Route
+                }
+                className="inline-flex items-center gap-1 text-sm text-primary font-medium"
+              >
+                元の回答を見る
+                <ArrowRight size={14} />
+              </Link>
+            )}
           </div>
         ))}
         {footer}

--- a/web/src/features/interview-report/shared/components/report-content.tsx
+++ b/web/src/features/interview-report/shared/components/report-content.tsx
@@ -72,6 +72,8 @@ export function ReportContent({
       <OpinionsList
         opinions={opinions}
         title="💬主な意見"
+        reportId={reportId}
+        chatLogFrom={from}
         footer={
           <Link
             href={getInterviewChatLogLink(reportId, from) as Route}

--- a/web/src/features/interview-report/shared/utils/format-utils.test.ts
+++ b/web/src/features/interview-report/shared/utils/format-utils.test.ts
@@ -75,4 +75,12 @@ describe("parseOpinions", () => {
   it("returns empty array for an empty array", () => {
     expect(parseOpinions([])).toEqual([]);
   });
+
+  it("preserves source_message_id when present", () => {
+    const opinions = [
+      { title: "Title", content: "Content", source_message_id: "msg-123" },
+      { title: "Title 2", content: "Content 2", source_message_id: null },
+    ];
+    expect(parseOpinions(opinions)).toEqual(opinions);
+  });
 });

--- a/web/src/features/interview-report/shared/utils/format-utils.ts
+++ b/web/src/features/interview-report/shared/utils/format-utils.ts
@@ -11,16 +11,20 @@ export function formatRoleDescriptionLines(text: string): string[] {
     .map((line) => (line.startsWith("・") ? line : `・${line}`));
 }
 
+export interface ParsedOpinion {
+  title: string;
+  content: string;
+  source_message_id?: string | null;
+}
+
 /**
  * Parse opinions from an unknown value (typically JSON from DB).
- * Returns a typed array of {title, content} objects, or an empty array
- * if the input is not an array.
+ * Returns a typed array of {title, content, source_message_id} objects,
+ * or an empty array if the input is not an array.
  */
-export function parseOpinions(
-  opinions: unknown
-): Array<{ title: string; content: string }> {
+export function parseOpinions(opinions: unknown): ParsedOpinion[] {
   if (!Array.isArray(opinions)) {
     return [];
   }
-  return opinions as Array<{ title: string; content: string }>;
+  return opinions as ParsedOpinion[];
 }


### PR DESCRIPTION
## Summary
- レポートページの各意見カードに「元の回答を見る」リンクを追加
- リンクは会話ログページの該当メッセージ（`source_message_id`）へのアンカーリンク
- `source_message_id` は既にDB保存済みのため、表示側の変更のみ

## 変更内容
- `parseOpinions` の返却型に `source_message_id` を追加（`ParsedOpinion` 型として統合）
- `OpinionsList` に `reportId`/`chatLogFrom` props を追加し、`source_message_id` がある意見に「元の回答を見る」リンクを表示
- `ReportContent` から `reportId`/`chatLogFrom` を `OpinionsList` に伝播
- 会話ログページのメッセージに `id` 属性を追加してアンカー対応（`scroll-mt-4` 付き）

## Test plan
- [x] `pnpm lint` パス
- [x] `pnpm typecheck` パス
- [x] `pnpm build` パス
- [x] `pnpm --filter web test` 731テスト全パス
- [ ] レポートページで `source_message_id` がある意見に「元の回答を見る」リンクが表示される
- [ ] リンクをクリックすると会話ログページの該当メッセージにスクロールする
- [ ] `source_message_id` がない意見にはリンクが表示されない

🤖 Generated with [Claude Code](https://claude.com/claude-code)