### PR TITLE
feat: モデレーション根拠・該当カテゴリを保存・表示

### DIFF
--- a/admin/src/features/interview-reports/server/components/session-detail.tsx
+++ b/admin/src/features/interview-reports/server/components/session-detail.tsx
@@ -259,6 +259,33 @@ export function SessionDetail({ session, billId }: SessionDetailProps) {
               <div className="text-xs text-gray-400">
                 0-29: OK / 30-69: Warning / 70-100: NG
               </div>
+              {report.moderation_reasoning && (
+                <div className="mt-3">
+                  <div className="text-sm text-gray-500 mb-1">根拠</div>
+                  <div className="text-sm bg-gray-50 p-3 rounded-lg">
+                    {report.moderation_reasoning}
+                  </div>
+                </div>
+              )}
+              {report.moderation_flagged_categories &&
+                report.moderation_flagged_categories.length > 0 && (
+                  <div className="mt-3">
+                    <div className="text-sm text-gray-500 mb-1">
+                      該当カテゴリ
+                    </div>
+                    <div className="flex flex-wrap gap-1.5">
+                      {report.moderation_flagged_categories.map((category) => (
+                        <Badge
+                          key={category}
+                          variant="outline"
+                          className="text-xs bg-red-50 text-red-700 border-red-200"
+                        >
+                          {category}
+                        </Badge>
+                      ))}
+                    </div>
+                  </div>
+                )}
             </div>
           </CardContent>
         </Card>

--- a/admin/src/features/interview-reports/server/repositories/interview-report-repository.ts
+++ b/admin/src/features/interview-reports/server/repositories/interview-report-repository.ts
@@ -546,12 +546,20 @@ export async function findReportsForModerationScoring() {
 
 export async function updateModerationScore(
   reportId: string,
-  score: number
+  params: {
+    score: number;
+    reasoning: string;
+    flaggedCategories: string[];
+  }
 ): Promise<void> {
   const supabase = createAdminClient();
   const { error } = await supabase
     .from("interview_report")
-    .update({ moderation_score: score })
+    .update({
+      moderation_score: params.score,
+      moderation_reasoning: params.reasoning,
+      moderation_flagged_categories: params.flaggedCategories,
+    })
     .eq("id", reportId);
 
   if (error) {

--- a/admin/src/features/interview-reports/server/services/batch-moderation-scoring.ts
+++ b/admin/src/features/interview-reports/server/services/batch-moderation-scoring.ts
@@ -47,7 +47,11 @@ export async function runBatchModerationScoring(): Promise<BatchModerationResult
         prompt,
       });
 
-      await updateModerationScore(report.id, object.score);
+      await updateModerationScore(report.id, {
+        score: object.score,
+        reasoning: object.reasoning,
+        flaggedCategories: object.flagged_categories,
+      });
 
       console.log(
         `[BatchModeration] report=${report.id} score=${object.score} categories=[${object.flagged_categories.join(",")}]`

--- a/packages/supabase/types/supabase.types.ts
+++ b/packages/supabase/types/supabase.types.ts
@@ -482,6 +482,8 @@ export type Database = {
           interview_session_id: string
           is_public_by_admin: boolean
           is_public_by_user: boolean
+          moderation_flagged_categories: string[] | null
+          moderation_reasoning: string | null
           moderation_score: number | null
           moderation_status:
             | Database["public"]["Enums"]["moderation_status_enum"]
@@ -502,6 +504,8 @@ export type Database = {
           interview_session_id: string
           is_public_by_admin?: boolean
           is_public_by_user?: boolean
+          moderation_flagged_categories?: string[] | null
+          moderation_reasoning?: string | null
           moderation_score?: number | null
           moderation_status?:
             | Database["public"]["Enums"]["moderation_status_enum"]
@@ -524,6 +528,8 @@ export type Database = {
           interview_session_id?: string
           is_public_by_admin?: boolean
           is_public_by_user?: boolean
+          moderation_flagged_categories?: string[] | null
+          moderation_reasoning?: string | null
           moderation_score?: number | null
           moderation_status?:
             | Database["public"]["Enums"]["moderation_status_enum"]

--- a/supabase/migrations/20260325210000_add_moderation_reasoning_to_interview_report.sql
+++ b/supabase/migrations/20260325210000_add_moderation_reasoning_to_interview_report.sql
@@ -1,0 +1,8 @@
+-- interview_report テーブルにモデレーション根拠・該当カテゴリカラムを追加
+alter table interview_report
+  add column moderation_reasoning text,
+  add column moderation_flagged_categories text[] default '{}';
+
+-- カラムコメント
+comment on column interview_report.moderation_reasoning is 'モデレーションスコアの根拠（200文字以内）';
+comment on column interview_report.moderation_flagged_categories is 'モデレーションで該当した評価カテゴリ名の配列';

--- a/web/src/features/interview-session/server/services/complete-interview-session.ts
+++ b/web/src/features/interview-session/server/services/complete-interview-session.ts
@@ -53,6 +53,8 @@ export async function completeInterviewSession({
   // モデレーションスコアを評価（タイムアウト30秒）
   const MODERATION_TIMEOUT_MS = 30_000;
   let moderationScore: number | null = null;
+  let moderationReasoning: string | null = null;
+  let moderationFlaggedCategories: string[] | null = null;
   try {
     const moderation = await Promise.race([
       evaluateModerationScore({
@@ -72,6 +74,8 @@ export async function completeInterviewSession({
       ),
     ]);
     moderationScore = moderation.score;
+    moderationReasoning = moderation.reasoning;
+    moderationFlaggedCategories = moderation.flaggedCategories;
   } catch (error) {
     // モデレーション失敗はレポート保存をブロックしない
     const message = error instanceof Error ? error.message : "Unknown error";
@@ -93,6 +97,8 @@ export async function completeInterviewSession({
     opinions: enrichedOpinions,
     content_richness: reportData.content_richness,
     moderation_score: moderationScore,
+    moderation_reasoning: moderationReasoning,
+    moderation_flagged_categories: moderationFlaggedCategories,
   });
 
   // セッションを完了

--- a/web/src/features/interview-session/server/services/evaluate-moderation-score.ts
+++ b/web/src/features/interview-session/server/services/evaluate-moderation-score.ts
@@ -24,6 +24,8 @@ type ModerationInput = {
 type ModerationOutput = {
   score: number;
   status: ModerationStatus;
+  reasoning: string;
+  flaggedCategories: string[];
 };
 
 /**
@@ -51,5 +53,7 @@ export async function evaluateModerationScore(
   return {
     score: object.score,
     status,
+    reasoning: object.reasoning,
+    flaggedCategories: object.flagged_categories,
   };
 }


### PR DESCRIPTION
## Summary
- モデレーション評価時にAIが返す `reasoning`（根拠）と `flagged_categories`（該当カテゴリ）を `interview_report` テーブルに保存するよう変更
- adminのセッション詳細画面のモデレーションカードに根拠・該当カテゴリを表示
- インタビュー完了時（web）とバッチ一括評価時（admin）の両方で保存に対応

## Changes
- **DBマイグレーション**: `moderation_reasoning` (text) と `moderation_flagged_categories` (text[]) カラムを追加
- **web**: `evaluateModerationScore` がreasoning/flaggedCategoriesも返すよう変更、`completeInterviewSession` で保存
- **admin**: `updateModerationScore` をオブジェクトパラメータに変更、batch処理でも保存
- **admin UI**: セッション詳細のモデレーションカードに根拠テキストと該当カテゴリバッジを表示

## Test plan
- [x] `pnpm typecheck` — pass
- [x] `pnpm lint` — pass (既存warningのみ)
- [x] `pnpm build` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * モデレーション詳細情報を拡張しました。モデレーションスコアカードに根拠と該当カテゴリが表示されるようになり、モデレーション判断の詳細が確認できます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->