### PR TITLE
fix: next/imageでplacehold.coのSVG画像を許可する設定を追加

### DIFF
--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -1,5 +1,7 @@
 import type { NextConfig } from "next";
 
+const isDev = process.env.NODE_ENV === "development";
+
 const nextConfig: NextConfig = {
   experimental: {
     serverSourceMaps: true,
@@ -25,14 +27,21 @@ const nextConfig: NextConfig = {
         hostname: "*.supabase.co",
         pathname: "/storage/v1/object/public/bill-thumbnails/**",
       },
-      {
-        protocol: "https",
-        hostname: "placehold.co",
-      },
+      ...(isDev
+        ? [
+            {
+              protocol: "https" as const,
+              hostname: "placehold.co",
+            },
+          ]
+        : []),
     ],
-    dangerouslyAllowSVG: true,
-    contentDispositionType: "attachment",
-    contentSecurityPolicy: "default-src 'self'; script-src 'none'; sandbox;",
+    ...(isDev && {
+      dangerouslyAllowSVG: true,
+      contentDispositionType: "attachment" as const,
+      contentSecurityPolicy:
+        "default-src 'self'; script-src 'none'; sandbox;",
+    }),
   },
 };
 


### PR DESCRIPTION
## Summary
- seedデータの`thumbnail_url`に使用されている`placehold.co`がNext.jsの`images.remotePatterns`に含まれておらず、`next/image`でランタイムエラーが発生していた
- `placehold.co`を`remotePatterns`に追加し、SVG画像対応のため`dangerouslyAllowSVG`を有効化（CSP制限付き）

## Test plan
- [x] `pnpm lint` パス
- [x] `pnpm typecheck` パス
- [x] `pnpm build` パス
- [x] `pnpm test` パス（admin の既存テスト失敗1件は本変更と無関係）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 開発環境で外部プレースホルダー画像の読み込みを許可しました。
  * 開発環境でSVGの取り扱いやダウンロード時の動作を明示的に設定しました。
  * 開発環境用に画像配信時の制約を強化するコンテンツセキュリティポリシーを適用しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->