### PR TITLE
feat: 情報開示ページの使用モデルを独立セクションに分離

### DIFF
--- a/web/src/features/interview-config/server/components/interview-disclosure-page.tsx
+++ b/web/src/features/interview-config/server/components/interview-disclosure-page.tsx
@@ -90,14 +90,36 @@ function StaticDisclosureSection() {
   );
 }
 
-function DynamicDisclosureSection({
-  billName,
+function ModelSection({
   interviewConfig,
-  systemPrompt,
-  summaryPrompt,
-}: Omit<InterviewDisclosurePageProps, "billId">) {
+}: Pick<InterviewDisclosurePageProps, "interviewConfig">) {
   const chatModel = interviewConfig?.chat_model ?? DEFAULT_INTERVIEW_CHAT_MODEL;
 
+  return (
+    <div className="flex flex-col gap-3">
+      <h1 className="text-2xl font-bold text-black leading-[1.5]">
+        使用モデル
+      </h1>
+      <div className="bg-white rounded-2xl p-6 space-y-2">
+        <p className="text-sm leading-[1.83] text-black">
+          対話エンジンには以下のモデルを採用しています。
+        </p>
+        <p className="text-sm leading-[1.83] text-black">
+          モデル名称： {chatModel}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function PromptSection({
+  billName,
+  systemPrompt,
+  summaryPrompt,
+}: Pick<
+  InterviewDisclosurePageProps,
+  "billName" | "systemPrompt" | "summaryPrompt"
+>) {
   return (
     <div className="flex flex-col gap-3">
       <h1 className="text-2xl font-bold text-black leading-[1.5]">
@@ -108,16 +130,6 @@ function DynamicDisclosureSection({
         <p className="text-[15px] font-normal text-black leading-[1.87]">
           {billName}に関するAIインタビューにおけるプロンプト
         </p>
-
-        <div className="space-y-2">
-          <p className="text-sm font-bold text-black">使用モデル</p>
-          <p className="text-sm leading-[1.83] text-black">
-            対話エンジンには以下のモデルを採用しています。
-          </p>
-          <p className="text-sm leading-[1.83] text-black">
-            モデル名称： {chatModel}
-          </p>
-        </div>
 
         <div className="space-y-2">
           <p className="text-sm font-bold text-black">
@@ -156,7 +168,12 @@ export function InterviewDisclosurePage({
       <div className="flex flex-col gap-8 px-4 pt-24 md:pt-12 max-w-[600px] mx-auto w-full">
         <DisclosureBreadcrumb billId={billId} previewToken={previewToken} />
         <StaticDisclosureSection />
-        <DynamicDisclosureSection {...props} />
+        <ModelSection interviewConfig={props.interviewConfig} />
+        <PromptSection
+          billName={props.billName}
+          systemPrompt={props.systemPrompt}
+          summaryPrompt={props.summaryPrompt}
+        />
         <DisclosureBreadcrumb billId={billId} previewToken={previewToken} />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- 情報開示ページの「使用モデル」情報をプロンプト開示セクションから分離
- 独立したカードセクションとしてプロンプトセクションの上に配置
- `DynamicDisclosureSection` を `ModelSection` と `PromptSection` の2コンポーネントに分割

## Test plan
- [x] `pnpm lint` 通過
- [x] `pnpm typecheck` 通過
- [x] `pnpm build` 通過
- [x] `pnpm test` 通過（admin側の既存テスト失敗1件は本PR変更と無関係）

🤖 Generated with [Claude Code](https://claude.com/claude-code)