### PR TITLE
fix: biome lintのworktree競合エラーを解消

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "test:integration:coverage": "dotenv -e .env -- vitest run --config tests/supabase/vitest.config.mts && pnpm -r run test:integration:coverage",
     "build": "dotenv -e .env -- pnpm -r run build",
     "typecheck": "pnpm -r run typecheck",
-    "lint": "biome format . && biome lint .",
-    "lint:fix": "biome format --write . && biome lint --write .",
+    "lint": "biome format web/src admin/src tests && biome lint web/src admin/src tests",
+    "lint:fix": "biome format --write web/src admin/src tests && biome lint --write web/src admin/src tests",
     "postinstall": "npx simple-git-hooks"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- `pnpm lint` / `pnpm lint:fix` で `biome format .` / `biome lint .` がプロジェクトルート全体をスキャンし、`.claude/worktrees/` 内の `biome.json` を検出して「nested root configuration」エラーになる問題を修正
- スキャン対象を `.` から `web/src admin/src tests` に明示的に指定し、worktreeディレクトリを回避

## Test plan
- [x] `pnpm lint` がエラーなく完了することを確認
- [x] `pnpm lint:fix` がエラーなく完了することを確認
- [x] `pnpm typecheck` が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)