### PR TITLE
fix: biome includesに.claude/worktrees除外を追加

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -45,6 +45,11 @@
     }
   },
   "files": {
-    "includes": ["web/src/**/*", "admin/src/**/*", "tests/**/*"]
+    "includes": [
+      "web/src/**/*",
+      "admin/src/**/*",
+      "tests/**/*",
+      "!.claude/worktrees"
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- `.claude/worktrees` 配下のworktreeにbiome.jsonが存在するとnested config errorが発生する問題を修正
- `files.includes` に `!.claude/worktrees` を追加してフォルダ自体をスキャン対象から除外（`useBiomeIgnoreFolder` 推奨パターン）

## Test plan
- [x] `pnpm lint` パス確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)