### PR TITLE
refactor: admin自己呼び出しURLをenv.adminUrlに一元化

### DIFF
--- a/admin/src/features/interview-reports/server/actions/run-batch-moderation-action.ts
+++ b/admin/src/features/interview-reports/server/actions/run-batch-moderation-action.ts
@@ -2,6 +2,7 @@
 
 import { cookies } from "next/headers";
 import { requireAdmin } from "@/features/auth/server/lib/auth-server";
+import { env } from "@/lib/env";
 
 interface BatchModerationResult {
   success: boolean;
@@ -20,7 +21,7 @@ export async function runBatchModerationAction(): Promise<BatchModerationResult>
   await requireAdmin();
 
   try {
-    const baseUrl = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3001";
+    const baseUrl = env.adminUrl;
     const cookieStore = await cookies();
     const cookieHeader = cookieStore.toString();
     const response = await fetch(`${baseUrl}/api/batch/moderation-scoring`, {

--- a/admin/src/features/topic-analysis/server/actions/run-topic-analysis-action.ts
+++ b/admin/src/features/topic-analysis/server/actions/run-topic-analysis-action.ts
@@ -2,6 +2,7 @@
 
 import { revalidatePath } from "next/cache";
 import { requireAdmin } from "@/features/auth/server/lib/auth-server";
+import { env } from "@/lib/env";
 
 interface RunTopicAnalysisResult {
   success: boolean;
@@ -22,7 +23,7 @@ export async function runTopicAnalysisAction(
 
   try {
     // API Route 経由で実行（maxDuration を活用するため）
-    const baseUrl = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3001";
+    const baseUrl = env.adminUrl;
     const response = await fetch(`${baseUrl}/api/topic-analysis/run`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },

--- a/admin/src/features/topic-analysis/server/utils/trigger-next-phase.ts
+++ b/admin/src/features/topic-analysis/server/utils/trigger-next-phase.ts
@@ -1,17 +1,19 @@
 import "server-only";
 
+import { env } from "@/lib/env";
+
 /**
  * 次フェーズのAPI routeを内部fetchで起動する
  *
  * REVALIDATE_SECRET を Bearer token として使用し、
- * NEXT_PUBLIC_APP_URL を自己呼び出しURLとして使用する
+ * env.adminUrl を自己呼び出しURLとして使用する
  */
 export async function triggerNextPhase(
   phase: 1 | 2 | 3,
   versionId: string,
   billId: string
 ): Promise<void> {
-  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3001";
+  const baseUrl = env.adminUrl;
   const secret = process.env.REVALIDATE_SECRET;
 
   if (!secret) {

--- a/admin/src/lib/env.ts
+++ b/admin/src/lib/env.ts
@@ -13,6 +13,9 @@ if (!process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY) {
 }
 
 export const env = {
+  adminUrl: process.env.VERCEL_URL
+    ? `https://${process.env.VERCEL_URL}`
+    : process.env.ADMIN_URL || "http://localhost:3001",
   webUrl: process.env.NEXT_PUBLIC_WEB_URL || "http://localhost:3000",
   supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL,
   supabaseAnonKey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,


### PR DESCRIPTION
## Summary
- `NEXT_PUBLIC_APP_URL`の散在（3箇所）を`env.adminUrl`に集約
- `VERCEL_URL` → `ADMIN_URL` → `localhost:3001` のフォールバックチェーンにより、Vercel環境では環境変数設定不要に
- 対象: `run-batch-moderation-action`, `run-topic-analysis-action`, `trigger-next-phase`

## Test plan
- [x] `pnpm typecheck` パス
- [x] `pnpm --filter admin build` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)