### PR TITLE
fix: レポートカードとリアクションボタンのUI改善

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -92,7 +92,7 @@
 
   /* Reaction */
   --color-mirai-reaction-active: #dd425f;
-  --color-mirai-reaction-inactive: #9f9f9f;
+  --color-mirai-reaction-inactive: var(--color-mirai-text-muted);
 
   /* Accent */
   --color-mirai-star: #ff9500;

--- a/web/src/features/interview-report/shared/components/report-card.tsx
+++ b/web/src/features/interview-report/shared/components/report-card.tsx
@@ -1,8 +1,8 @@
 import type { Route } from "next";
 import Image from "next/image";
 import Link from "next/link";
-import { cn } from "@/lib/utils";
 import { getPublicReportLink } from "@/features/interview-config/shared/utils/interview-links";
+import { cn } from "@/lib/utils";
 import {
   type InterviewReportRole,
   roleIcons,
@@ -81,39 +81,35 @@ export function ReportCard({
           />
         )}
         <div className="flex flex-col gap-2 min-w-0 flex-1">
-          <div className="flex flex-col gap-2.5">
-            <div className="flex items-center gap-2">
-              <div className="flex flex-1 min-w-0 items-center gap-2.5">
-                {stanceLabel && (
-                  <span
-                    className={cn(
-                      "inline-flex items-center justify-center px-3 py-0.5 rounded-2xl text-xs font-medium leading-3 flex-shrink-0",
-                      stanceBadgeBg,
-                      stanceTextColor
-                    )}
-                  >
-                    {stanceLabel}
-                  </span>
-                )}
-                {roleLabel && (
-                  <div className="flex items-center gap-1 text-mirai-text-subtle flex-shrink-0">
-                    {RoleIcon && (
-                      <RoleIcon size={16} className="flex-shrink-0" />
-                    )}
-                    <span className="text-xs leading-3">{roleLabel}</span>
-                  </div>
-                )}
-              </div>
-              <span className="text-[13px] text-mirai-text-muted whitespace-nowrap flex-shrink-0">
-                {relativeTime}
-              </span>
-            </div>
-
+          <div className="flex flex-col gap-1.5">
             {report.role_title && (
               <p className="text-base font-bold leading-snug text-mirai-text">
                 {report.role_title}
               </p>
             )}
+
+            <div className="flex flex-1 min-w-0 items-center gap-3">
+              {stanceLabel && (
+                <span
+                  className={cn(
+                    "inline-flex items-center justify-center px-3 py-0.5 rounded-2xl text-xs font-medium leading-3 flex-shrink-0",
+                    stanceBadgeBg,
+                    stanceTextColor
+                  )}
+                >
+                  {stanceLabel}
+                </span>
+              )}
+              {roleLabel && (
+                <div className="flex items-center gap-1 text-mirai-text-subtle flex-shrink-0">
+                  {RoleIcon && <RoleIcon size={16} className="flex-shrink-0" />}
+                  <span className="text-xs leading-3">{roleLabel}</span>
+                </div>
+              )}
+              <span className="text-[13px] text-mirai-text-muted whitespace-nowrap flex-shrink-0">
+                {relativeTime}
+              </span>
+            </div>
 
             {truncatedSummary && (
               <p className="text-sm leading-6 text-black">{truncatedSummary}</p>

--- a/web/src/features/report-reaction/client/components/reaction-buttons-inline.tsx
+++ b/web/src/features/report-reaction/client/components/reaction-buttons-inline.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { Button } from "@/components/ui/button";
 import { Lightbulb } from "lucide-react";
+import { Button } from "@/components/ui/button";
 import type { ReactionType, ReportReactionData } from "../../shared/types";
 import { useReactionToggle } from "../hooks/use-reaction-toggle";
 
@@ -61,11 +61,12 @@ function InlineReactionButton({
   return (
     <Button
       variant="ghost"
+      size="sm"
       onClick={onClick}
       disabled={disabled}
       aria-pressed={isActive}
       aria-label={`${label} ${count}`}
-      className="flex items-center gap-1 h-auto px-0 py-0 hover:bg-transparent"
+      className="flex items-center gap-1 h-auto !px-0 py-0 hover:bg-transparent"
     >
       <Icon size={24} className={`transition-colors ${colorClass}`} />
       <span className={`text-sm font-medium transition-colors ${colorClass}`}>


### PR DESCRIPTION
## Summary
- レポートカードのレイアウト調整: `role_title`を上部に配置し、スタンスバッジ・ロールラベル・日時を同一行に整理
- リアクションボタンのinactive色を`mirai-text-muted`トークンに統一（ハードコード値を除去）
- リアクションボタンに`size="sm"`を追加

## Test plan
- [x] `pnpm lint` パス
- [x] `pnpm typecheck` パス
- [x] `pnpm build` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **スタイル**
  * リアクションボタンのサイズを小さくし、パディングを調整しました。
  * インアクティブなリアクション色がテーマの統一されたテキストカラーと同期するように更新しました。
  * レポートカードのヘッダーレイアウトを整理し、視認性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->