### PR TITLE
fix: レポートOGP画像のfont-weightとバッジ位置をFigmaに合わせる

### DIFF
--- a/web/src/app/api/og/report/route.tsx
+++ b/web/src/app/api/og/report/route.tsx
@@ -56,7 +56,7 @@ async function loadFont(): Promise<ArrayBuffer | null> {
 
   try {
     const url =
-      "https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&display=swap";
+      "https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@800&display=swap";
     const cssRes = await fetchWithTimeout(url);
     if (!cssRes.ok) return null;
     const css = await cssRes.text();
@@ -106,7 +106,7 @@ export async function GET(request: Request) {
             name: "Noto Sans JP",
             data: fontData,
             style: "normal" as const,
-            weight: 400 as const,
+            weight: 800 as const,
           },
         ],
       }
@@ -142,7 +142,7 @@ export async function GET(request: Request) {
           style={{
             display: "flex",
             fontSize: 38,
-            fontWeight: 400,
+            fontWeight: 800,
             color: "#1f2937",
             lineHeight: 1.8,
             flex: 1,
@@ -158,7 +158,7 @@ export async function GET(request: Request) {
           style={{
             display: "flex",
             fontSize: 32,
-            fontWeight: 700,
+            fontWeight: 800,
             color: "#0f8472",
             lineHeight: 1.5,
           }}
@@ -170,7 +170,7 @@ export async function GET(request: Request) {
         <div
           style={{
             position: "absolute",
-            top: 32,
+            top: 0,
             right: 0,
             display: "flex",
             alignItems: "center",
@@ -188,7 +188,7 @@ export async function GET(request: Request) {
           <span
             style={{
               fontSize: 28,
-              fontWeight: 700,
+              fontWeight: 800,
               color: "#1f2937",
               letterSpacing: "0.03em",
             }}


### PR DESCRIPTION
## Summary
- レポートOGP画像のfont-weightを全テキスト要素で800に統一（Figmaデザインの FOT-TsukuGo Pro E 相当）
- 「みらい議会」バッジの位置をカード上端に密着させた（`top: 32` → `top: 0`）
- Google Fontsの読み込みweight指定を `wght@400;700` → `wght@800` に変更

## 変更詳細
| 要素 | 変更前 | 変更後 |
|---|---|---|
| サマリーテキスト fontWeight | 400 | 800 |
| 法案名 fontWeight | 700 | 800 |
| バッジ fontWeight | 700 | 800 |
| バッジ top | 32px | 0px |
| Google Fonts weight | 400;700 | 800 |

## Test plan
- [ ] `pnpm typecheck` 通過確認済み
- [ ] `pnpm lint` 通過確認済み
- [ ] `/api/og/report?id=<reportId>` でOGP画像が正しく生成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **スタイル**
  * ページ共有時に表示されるプレビュー画像のタイポグラフィを更新しました。フォントウェイトを強化し、バッジの配置を調整しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->