### PR TITLE
fix: モーダルのmax-width削除とフォントサイズ調整

### DIFF
--- a/web/src/features/interview-config/client/components/interview-consent-modal.tsx
+++ b/web/src/features/interview-config/client/components/interview-consent-modal.tsx
@@ -49,7 +49,7 @@ export function InterviewConsentModal({
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className="max-w-md px-8 py-12">
+      <DialogContent className="px-8 py-12">
         <DialogHeader>
           <DialogTitle className="text-lg font-bold text-primary text-center">
             AIインタビュー同意事項
@@ -58,7 +58,7 @@ export function InterviewConsentModal({
         </DialogHeader>
 
         <div className="flex flex-col gap-6 mt-6">
-          <ul className="flex flex-col gap-3 list-disc pl-5 text-xs font-bold text-gray-800 leading-[22px]">
+          <ul className="flex flex-col gap-3 list-disc pl-5 text-sm font-bold text-gray-800 leading-[22px]">
             <li>回答データは党内での政策検討に利用します。</li>
             <li>
               インタビューの回答内容の公開を許可した場合、のちにみらい議会上に掲載される場合があります。
@@ -76,7 +76,7 @@ export function InterviewConsentModal({
             />
             <label
               htmlFor="consent-agree"
-              className="text-xs font-bold text-black"
+              className="text-sm font-bold text-black"
             >
               <Link
                 href={routes.terms()}
@@ -100,7 +100,7 @@ export function InterviewConsentModal({
           </div>
         </div>
 
-        <div className="flex flex-col gap-4 mt-9">
+        <div className="flex flex-col gap-4 mt-6">
           <Button
             onClick={handleAgree}
             disabled={isLoading || !agreed}

--- a/web/src/features/interview-report/client/components/interview-public-consent-modal.tsx
+++ b/web/src/features/interview-report/client/components/interview-public-consent-modal.tsx
@@ -41,7 +41,7 @@ export function InterviewPublicConsentModal({
 }: InterviewPublicConsentModalProps) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-md py-9">
+      <DialogContent className="py-9">
         <DialogHeader>
           <p className="text-center text-primary-accent font-bold">
             あと少しです！

--- a/web/src/features/interview-report/client/components/make-private-modal.tsx
+++ b/web/src/features/interview-report/client/components/make-private-modal.tsx
@@ -41,7 +41,7 @@ export function MakePrivateModal({
 }: MakePrivateModalProps) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-sm py-9">
+      <DialogContent className="py-9">
         <DialogHeader>
           <DialogTitle className="text-lg font-bold text-primary-accent text-center leading-relaxed">
             インタビュー内容を

--- a/web/src/features/interview-report/client/components/make-public-modal.tsx
+++ b/web/src/features/interview-report/client/components/make-public-modal.tsx
@@ -41,7 +41,7 @@ export function MakePublicModal({
 }: MakePublicModalProps) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-md py-9">
+      <DialogContent className="py-9">
         <DialogHeader>
           <DialogTitle className="text-lg font-bold text-primary-accent text-center leading-relaxed">
             インタビュー内容を


### PR DESCRIPTION
## Summary
- 各モーダルの `max-w-md` / `max-w-sm` を削除し、DialogContentのデフォルト幅に統一
- インタビュー同意モーダルのフォントサイズを `text-xs` → `text-sm` に変更
- 同意モーダルのボタン上部マージンを `mt-9` → `mt-6` に調整

## Test plan
- [ ] インタビュー同意モーダルの表示確認
- [ ] 公開同意モーダルの表示確認
- [ ] 非公開モーダルの表示確認
- [ ] 公開モーダルの表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)