### PR TITLE
fix: Archiveセクションの件数表示が改行される問題を修正

### DIFF
--- a/web/src/features/bills/server/components/previous-session-section.tsx
+++ b/web/src/features/bills/server/components/previous-session-section.tsx
@@ -59,7 +59,7 @@ export function PreviousSessionSection({
             <span className="flex items-center gap-4">
               {new Date(session.start_date).getFullYear()}年 {session.name}
               の提出法案
-              <span>{totalBillCount}件</span>
+              <span className="shrink-0">{totalBillCount}件</span>
             </span>
             <ChevronRight className="h-6 w-6 text-gray-600 group-hover:translate-x-0.5 transition-transform" />
           </h3>


### PR DESCRIPTION
## Summary
- Archiveセクションで「10件」が改行されてしまう問題を、`shrink-0`を追加して修正

## Test plan
- [x] `pnpm lint` パス
- [x] `pnpm typecheck` パス
- [x] `pnpm build` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* 請求書セクションにおいて、請求書数の表示がレイアウト内で不正に縮小されるのを防ぎました。表示の安定性が改善されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->