### PR TITLE
fix: 満足度評価ウィジェットをFigmaデザインに合わせて修正

### DIFF
--- a/web/src/app/dev/_components/preview-section.tsx
+++ b/web/src/app/dev/_components/preview-section.tsx
@@ -11,7 +11,7 @@ export function PreviewSection({ label, children }: PreviewSectionProps) {
       <h3 className="text-sm font-medium text-mirai-text-secondary mb-2">
         {label}
       </h3>
-      <div className="p-4">{children}</div>
+      <div className="md:p-4">{children}</div>
     </div>
   );
 }

--- a/web/src/features/interview-session/client/components/interview-rating-widget.tsx
+++ b/web/src/features/interview-session/client/components/interview-rating-widget.tsx
@@ -3,14 +3,14 @@
 import { ArrowRight, Star, X } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
-import {
-  FEEDBACK_RATING_THRESHOLD,
-  FEEDBACK_TAGS,
-  FEEDBACK_TAG_LABELS,
-  type FeedbackTag,
-} from "../../shared/constants/feedback-tags";
 import { submitInterviewFeedback } from "../../server/actions/submit-interview-feedback";
 import { submitInterviewRating } from "../../server/actions/submit-interview-rating";
+import {
+  FEEDBACK_RATING_THRESHOLD,
+  FEEDBACK_TAG_LABELS,
+  FEEDBACK_TAGS,
+  type FeedbackTag,
+} from "../../shared/constants/feedback-tags";
 
 type WidgetPhase = "rating" | "feedback" | "thankyou";
 
@@ -33,7 +33,7 @@ function RatingPhase({
       <p className="text-[13px] font-medium leading-none text-mirai-text text-center">
         AIはあなたの考えを十分に引き出せていますか
       </p>
-      <div className="flex justify-center gap-[15px]">
+      <div className="flex justify-center">
         {[1, 2, 3, 4, 5].map((star) => (
           <Button
             key={star}


### PR DESCRIPTION
## Summary
- ratingフェーズにタイトル「AIインタビュー改善のためのアンケート」をプライマリカラーで追加
- 星アイコンのサイズを`size-6`クラスで明示的に24pxに固定（Buttonコンポーネントによる16px縮小を防止）
- 内部要素の間隔を`gap-2.5`（10px）に調整してFigmaデザインに合わせ

## Test plan
- [x] `pnpm lint` 通過
- [x] `pnpm typecheck` 通過
- [x] `pnpm build` 通過
- [x] devプレビューページ（`/dev/features/interview/rating-widget`）で表示確認
- [x] Chrome DevToolsで星アイコンが24pxでレンダリングされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * インタビューレーティングフェーズに改善アンケートの紹介文を追加しました。

* **改善**
  * レーティングのアイコン表示を調整し、スタイルの一貫性を向上しました。
  * ウィジェット内の縦間隔を微調整してレイアウト密度を最適化しました。
  * プレビューセクションのパディングをレスポンシブに調整しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->