### PR TITLE
fix: モデレーションの該当カテゴリを削除

### DIFF
--- a/admin/src/features/interview-reports/server/components/session-detail.tsx
+++ b/admin/src/features/interview-reports/server/components/session-detail.tsx
@@ -274,27 +274,6 @@ export function SessionDetail({ session, billId }: SessionDetailProps) {
                     </div>
                   </div>
                 )}
-                {report.moderation_flagged_categories &&
-                  report.moderation_flagged_categories.length > 0 && (
-                    <div className="mt-3">
-                      <div className="text-sm text-gray-500 mb-1">
-                        該当カテゴリ
-                      </div>
-                      <div className="flex flex-wrap gap-1.5">
-                        {report.moderation_flagged_categories.map(
-                          (category) => (
-                            <Badge
-                              key={category}
-                              variant="outline"
-                              className="text-xs bg-red-50 text-red-700 border-red-200"
-                            >
-                              {category}
-                            </Badge>
-                          )
-                        )}
-                      </div>
-                    </div>
-                  )}
               </div>
             ) : (
               <div className="text-gray-500 text-sm">

--- a/admin/src/features/interview-reports/server/repositories/interview-report-repository.ts
+++ b/admin/src/features/interview-reports/server/repositories/interview-report-repository.ts
@@ -569,7 +569,6 @@ export async function updateModerationScore(
   params: {
     score: number;
     reasoning: string;
-    flaggedCategories: string[];
   }
 ): Promise<void> {
   const supabase = createAdminClient();
@@ -578,7 +577,6 @@ export async function updateModerationScore(
     .update({
       moderation_score: params.score,
       moderation_reasoning: params.reasoning,
-      moderation_flagged_categories: params.flaggedCategories,
     })
     .eq("id", reportId);
 

--- a/admin/src/features/interview-reports/server/services/batch-moderation-scoring.ts
+++ b/admin/src/features/interview-reports/server/services/batch-moderation-scoring.ts
@@ -53,12 +53,9 @@ export async function runSingleModerationScoring(
   await updateModerationScore(reportId, {
     score: object.score,
     reasoning: object.reasoning,
-    flaggedCategories: object.flagged_categories,
   });
 
-  console.log(
-    `[SingleModeration] report=${reportId} score=${object.score} categories=[${object.flagged_categories.join(",")}]`
-  );
+  console.log(`[SingleModeration] report=${reportId} score=${object.score}`);
 
   return { score: object.score };
 }

--- a/packages/shared/src/moderation/schemas.ts
+++ b/packages/shared/src/moderation/schemas.ts
@@ -12,9 +12,6 @@ export const moderationResultSchema = z.object({
     "モデレーションスコア（0-100の整数）: 0が最も適切、100が最も不適切"
   ),
   reasoning: z.string().describe("スコアの根拠を簡潔に説明（200文字以内）"),
-  flagged_categories: z
-    .array(z.string())
-    .describe("該当する評価カテゴリ名の配列（該当なしの場合は空配列）"),
 });
 
 export type ModerationResult = z.infer<typeof moderationResultSchema>;

--- a/packages/supabase/types/supabase.types.ts
+++ b/packages/supabase/types/supabase.types.ts
@@ -482,7 +482,6 @@ export type Database = {
           interview_session_id: string
           is_public_by_admin: boolean
           is_public_by_user: boolean
-          moderation_flagged_categories: string[] | null
           moderation_reasoning: string | null
           moderation_score: number | null
           moderation_status:
@@ -504,7 +503,6 @@ export type Database = {
           interview_session_id: string
           is_public_by_admin?: boolean
           is_public_by_user?: boolean
-          moderation_flagged_categories?: string[] | null
           moderation_reasoning?: string | null
           moderation_score?: number | null
           moderation_status?:
@@ -528,7 +526,6 @@ export type Database = {
           interview_session_id?: string
           is_public_by_admin?: boolean
           is_public_by_user?: boolean
-          moderation_flagged_categories?: string[] | null
           moderation_reasoning?: string | null
           moderation_score?: number | null
           moderation_status?:

--- a/supabase/migrations/20260326100000_drop_moderation_flagged_categories.sql
+++ b/supabase/migrations/20260326100000_drop_moderation_flagged_categories.sql
@@ -1,0 +1,3 @@
+-- interview_report テーブルからモデレーション該当カテゴリカラムを削除
+alter table interview_report
+  drop column moderation_flagged_categories;

--- a/web/src/features/interview-session/server/services/complete-interview-session.ts
+++ b/web/src/features/interview-session/server/services/complete-interview-session.ts
@@ -54,7 +54,6 @@ export async function completeInterviewSession({
   const MODERATION_TIMEOUT_MS = 30_000;
   let moderationScore: number | null = null;
   let moderationReasoning: string | null = null;
-  let moderationFlaggedCategories: string[] | null = null;
   try {
     const moderation = await Promise.race([
       evaluateModerationScore({
@@ -75,7 +74,6 @@ export async function completeInterviewSession({
     ]);
     moderationScore = moderation.score;
     moderationReasoning = moderation.reasoning;
-    moderationFlaggedCategories = moderation.flaggedCategories;
   } catch (error) {
     // モデレーション失敗はレポート保存をブロックしない
     const message = error instanceof Error ? error.message : "Unknown error";
@@ -98,7 +96,6 @@ export async function completeInterviewSession({
     content_richness: reportData.content_richness,
     moderation_score: moderationScore,
     moderation_reasoning: moderationReasoning,
-    moderation_flagged_categories: moderationFlaggedCategories,
   });
 
   // セッションを完了

--- a/web/src/features/interview-session/server/services/evaluate-moderation-score.ts
+++ b/web/src/features/interview-session/server/services/evaluate-moderation-score.ts
@@ -25,7 +25,6 @@ type ModerationOutput = {
   score: number;
   status: ModerationStatus;
   reasoning: string;
-  flaggedCategories: string[];
 };
 
 /**
@@ -46,14 +45,11 @@ export async function evaluateModerationScore(
 
   const status = determineModerationStatus(object.score);
 
-  console.log(
-    `Moderation result: score=${object.score}, status=${status}, categories=[${object.flagged_categories.join(",")}]`
-  );
+  console.log(`Moderation result: score=${object.score}, status=${status}`);
 
   return {
     score: object.score,
     status,
     reasoning: object.reasoning,
-    flaggedCategories: object.flagged_categories,
   };
 }


### PR DESCRIPTION
## Summary
- モデレーション結果から `flagged_categories`（該当カテゴリ）フィールドを完全に削除
- DB カラム `moderation_flagged_categories` を drop するマイグレーションを追加
- スキーマ・サービス・リポジトリ・UIコンポーネントから関連コードを一括削除
- スコア(`score`)と根拠(`reasoning`)のみを保持するシンプルな構成に変更

## Test plan
- [x] `pnpm lint` pass
- [x] `pnpm typecheck` pass
- [x] `pnpm build` pass
- [x] `pnpm test` pass（既存の無関係なテスト失敗1件のみ）
- [x] `pnpm db:types:gen` で型再生成済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * モデレーションレポートから「フラグ付きカテゴリ」機能を削除しました。該当カテゴリの表示セクションがレポート詳細から削除され、モデレーションスコアと理由のみが保持されるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->