### PR TITLE
インタビューconfig一覧テーブルからテーマ列を削除

### DIFF
--- a/admin/src/features/interview-config/client/components/interview-config-list.tsx
+++ b/admin/src/features/interview-config/client/components/interview-config-list.tsx
@@ -126,7 +126,6 @@ export function InterviewConfigList({
                 <TableRow>
                   <TableHead>設定名</TableHead>
                   <TableHead>モード</TableHead>
-                  <TableHead>テーマ</TableHead>
                   <TableHead>ステータス</TableHead>
                   <TableHead>作成日</TableHead>
                   <TableHead className="w-[50px]" />
@@ -149,24 +148,6 @@ export function InterviewConfigList({
                       <Badge variant="outline">
                         {getModeLabel(config.mode)}
                       </Badge>
-                    </TableCell>
-                    <TableCell className="max-w-[400px]">
-                      {config.themes && config.themes.length > 0 ? (
-                        <div className="flex flex-col gap-1">
-                          {config.themes.map((theme) => (
-                            <Badge
-                              key={theme}
-                              variant="secondary"
-                              className="text-xs max-w-full truncate"
-                              title={theme}
-                            >
-                              {theme}
-                            </Badge>
-                          ))}
-                        </div>
-                      ) : (
-                        <span className="text-gray-400">-</span>
-                      )}
                     </TableCell>
                     <TableCell>
                       <Badge


### PR DESCRIPTION
## Summary
- インタビューconfig一覧テーブルからテーマ（themes）列を削除
- テーブルヘッダーとセルの両方を削除

## Test plan
- [x] `pnpm lint` パス
- [x] `pnpm typecheck` パス
- [x] `pnpm build` パス
- [x] `pnpm test` 全テストパス (76ファイル, 744テスト)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **UI 変更**
  * インタビュー設定一覧の表からテーマ列を削除しました。ステータスと作成日の列、および編集・複製・削除操作は変わりません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->