### PR TITLE
fix: セッション数カウントをRPC関数に変更し1000件制限を解消

### DIFF
--- a/admin/src/features/interview-config/server/repositories/interview-config-repository.ts
+++ b/admin/src/features/interview-config/server/repositories/interview-config-repository.ts
@@ -150,10 +150,9 @@ export async function countSessionsByConfigIds(
   if (configIds.length === 0) return {};
 
   const supabase = createAdminClient();
-  const { data, error } = await supabase
-    .from("interview_sessions")
-    .select("interview_config_id")
-    .in("interview_config_id", configIds);
+  const { data, error } = await supabase.rpc("count_sessions_by_config_ids", {
+    p_config_ids: configIds,
+  });
 
   if (error) {
     throw new Error(`Failed to count sessions: ${error.message}`);
@@ -164,8 +163,7 @@ export async function countSessionsByConfigIds(
     result[configId] = 0;
   }
   for (const row of data) {
-    result[row.interview_config_id] =
-      (result[row.interview_config_id] ?? 0) + 1;
+    result[row.interview_config_id] = Number(row.session_count);
   }
   return result;
 }

--- a/packages/supabase/types/supabase.types.ts
+++ b/packages/supabase/types/supabase.types.ts
@@ -904,6 +904,13 @@ export type Database = {
           reaction_type: string
         }[]
       }
+      count_sessions_by_config_ids: {
+        Args: { p_config_ids: string[] }
+        Returns: {
+          interview_config_id: string
+          session_count: number
+        }[]
+      }
       find_public_reports_by_bill_id_ordered_by_reactions: {
         Args: {
           p_bill_id: string

--- a/supabase/migrations/20260331110000_add_count_sessions_by_config_ids.sql
+++ b/supabase/migrations/20260331110000_add_count_sessions_by_config_ids.sql
@@ -1,0 +1,16 @@
+-- 複数のinterview_config_idに対するセッション数を一括取得するRPC関数
+create or replace function count_sessions_by_config_ids(p_config_ids uuid[])
+returns table (
+  interview_config_id uuid,
+  session_count bigint
+)
+language sql
+stable
+as $$
+  select
+    s.interview_config_id,
+    count(s.id) as session_count
+  from interview_sessions s
+  where s.interview_config_id = any(p_config_ids)
+  group by s.interview_config_id;
+$$;

--- a/tests/supabase/db-function/count-sessions-by-config-ids.test.ts
+++ b/tests/supabase/db-function/count-sessions-by-config-ids.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import {
+  adminClient,
+  createTestBill,
+  createTestUser,
+  cleanupTestBill,
+  cleanupTestUser,
+} from "../utils";
+
+describe("count_sessions_by_config_ids", () => {
+  let bill1: { id: string };
+  let bill2: { id: string };
+  let user: { id: string };
+  let configId1: string;
+  let configId2: string;
+  let configIdEmpty: string;
+
+  beforeAll(async () => {
+    user = await createTestUser();
+    bill1 = await createTestBill();
+    bill2 = await createTestBill();
+
+    // config1: セッション3件
+    const { data: c1 } = await adminClient
+      .from("interview_configs")
+      .insert({ bill_id: bill1.id, status: "public", name: "設定1" })
+      .select()
+      .single();
+    configId1 = c1!.id;
+
+    for (let i = 0; i < 3; i++) {
+      await adminClient.from("interview_sessions").insert({
+        interview_config_id: configId1,
+        user_id: user.id,
+        started_at: new Date().toISOString(),
+      });
+    }
+
+    // config2: セッション1件
+    const { data: c2, error: c2Error } = await adminClient
+      .from("interview_configs")
+      .insert({ bill_id: bill1.id, status: "closed", name: "設定2" })
+      .select()
+      .single();
+    if (c2Error) throw new Error(`config2 作成失敗: ${c2Error.message}`);
+    configId2 = c2!.id;
+
+    await adminClient.from("interview_sessions").insert({
+      interview_config_id: configId2,
+      user_id: user.id,
+      started_at: new Date().toISOString(),
+    });
+
+    // configEmpty: セッション0件
+    const { data: c3 } = await adminClient
+      .from("interview_configs")
+      .insert({ bill_id: bill2.id, status: "closed", name: "設定3（空）" })
+      .select()
+      .single();
+    configIdEmpty = c3!.id;
+  });
+
+  afterAll(async () => {
+    await cleanupTestBill(bill1.id);
+    await cleanupTestBill(bill2.id);
+    await cleanupTestUser(user.id);
+  });
+
+  it("複数configのセッション数を正しくカウントする", async () => {
+    const { data, error } = await adminClient.rpc(
+      "count_sessions_by_config_ids",
+      { p_config_ids: [configId1, configId2] }
+    );
+
+    expect(error).toBeNull();
+    expect(data).toHaveLength(2);
+
+    const map = new Map(
+      data!.map((r) => [r.interview_config_id, r.session_count])
+    );
+    expect(map.get(configId1)).toBe(3);
+    expect(map.get(configId2)).toBe(1);
+  });
+
+  it("セッションが0件のconfigは結果に含まれない", async () => {
+    const { data, error } = await adminClient.rpc(
+      "count_sessions_by_config_ids",
+      { p_config_ids: [configIdEmpty] }
+    );
+
+    expect(error).toBeNull();
+    expect(data).toHaveLength(0);
+  });
+
+  it("空配列を渡すと空の結果を返す", async () => {
+    const { data, error } = await adminClient.rpc(
+      "count_sessions_by_config_ids",
+      { p_config_ids: [] }
+    );
+
+    expect(error).toBeNull();
+    expect(data).toHaveLength(0);
+  });
+
+  it("存在しないconfig IDを渡すと空の結果を返す", async () => {
+    const { data, error } = await adminClient.rpc(
+      "count_sessions_by_config_ids",
+      { p_config_ids: ["00000000-0000-0000-0000-000000000000"] }
+    );
+
+    expect(error).toBeNull();
+    expect(data).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- インタビュー設定一覧のセッション数が、Supabaseのデフォルト行数制限（1000行）により正確にカウントできなかった問題を修正
- 全行取得+JS側カウントから、DB側でGROUP BYカウントするRPC関数（`count_sessions_by_config_ids`）に変更
- 1クエリで全configのセッション数を正確に取得可能に

## 変更内容
- `supabase/migrations/`: `count_sessions_by_config_ids` RPC関数を追加
- `interview-config-repository.ts`: `.select().in()` → `.rpc()` に変更
- `packages/supabase/types/`: 型再生成

## Test plan
- [x] `pnpm lint` 通過
- [x] `pnpm typecheck` 通過
- [x] `pnpm build` 通過
- [x] `pnpm test` 全テスト通過（744 tests）
- [x] DB統合テスト追加・通過（`tests/supabase/db-function/count-sessions-by-config-ids.test.ts`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * セッション数カウント処理の最適化を実施しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->