### PR TITLE
admin: インタビュー管理タブを追加

### DIFF
--- a/admin/src/app/(protected)/interviews/page.tsx
+++ b/admin/src/app/(protected)/interviews/page.tsx
@@ -1,0 +1,34 @@
+import { redirect } from "next/navigation";
+import { getCurrentAdmin } from "@/features/auth/server/lib/auth-server";
+import { AllInterviewConfigList } from "@/features/interviews/server/components/all-interview-config-list";
+import {
+  getAllInterviewConfigs,
+  getAllSessionCounts,
+} from "@/features/interviews/server/loaders/get-all-interview-configs";
+import { routes } from "@/lib/routes";
+
+export default async function InterviewsPage() {
+  const currentAdmin = await getCurrentAdmin();
+
+  if (!currentAdmin) {
+    redirect(routes.login());
+  }
+
+  const [configs, sessionCounts] = await Promise.all([
+    getAllInterviewConfigs(),
+    getAllSessionCounts(),
+  ]);
+
+  return (
+    <div className="container mx-auto py-8">
+      <h1 className="text-2xl font-bold mb-8">インタビュー管理</h1>
+
+      <section className="rounded-lg border bg-white p-6">
+        <AllInterviewConfigList
+          configs={configs}
+          sessionCounts={sessionCounts}
+        />
+      </section>
+    </div>
+  );
+}

--- a/admin/src/app/(protected)/layout/navigation-links.tsx
+++ b/admin/src/app/(protected)/layout/navigation-links.tsx
@@ -10,6 +10,7 @@ const navigationLinks = [
   { href: routes.bills(), label: "議案管理" },
   { href: routes.dietSessions(), label: "国会会期管理" },
   { href: routes.tags(), label: "タグ管理" },
+  { href: routes.interviews(), label: "インタビュー" },
   { href: routes.experts(), label: "有識者" },
   { href: routes.admins(), label: "管理者" },
 ];

--- a/admin/src/features/interview-config/client/components/interview-config-list.tsx
+++ b/admin/src/features/interview-config/client/components/interview-config-list.tsx
@@ -40,22 +40,12 @@ import {
   duplicateInterviewConfig,
 } from "../../server/actions/upsert-interview-config";
 import type { InterviewConfig } from "../../shared/types";
+import { getModeLabel } from "../../shared/utils/get-mode-label";
 
 interface InterviewConfigListProps {
   billId: string;
   configs: InterviewConfig[];
   sessionCounts: Record<string, number> | null;
-}
-
-function getModeLabel(mode: InterviewConfig["mode"]): string {
-  switch (mode) {
-    case "loop":
-      return "ループ";
-    case "bulk":
-      return "一括";
-    default:
-      return mode;
-  }
 }
 
 export function InterviewConfigList({

--- a/admin/src/features/interview-config/server/repositories/interview-config-repository.ts
+++ b/admin/src/features/interview-config/server/repositories/interview-config-repository.ts
@@ -3,6 +3,26 @@ import "server-only";
 import { createAdminClient } from "@mirai-gikai/supabase";
 import type { InterviewConfig, InterviewQuestion } from "../../shared/types";
 
+export type InterviewConfigWithBill = InterviewConfig & {
+  bill: { id: string; name: string };
+};
+
+export async function findAllInterviewConfigs(): Promise<
+  InterviewConfigWithBill[]
+> {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("interview_configs")
+    .select("*, bill:bills!inner(id, name)")
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    throw new Error(`Failed to fetch interview configs: ${error.message}`);
+  }
+
+  return data as InterviewConfigWithBill[];
+}
+
 export async function findInterviewConfigsByBillId(
   billId: string
 ): Promise<InterviewConfig[]> {
@@ -163,6 +183,26 @@ export async function countSessionsByConfigIds(
   for (const configId of configIds) {
     result[configId] = 0;
   }
+  for (const row of data) {
+    result[row.interview_config_id] =
+      (result[row.interview_config_id] ?? 0) + 1;
+  }
+  return result;
+}
+
+export async function countAllSessionsByConfigId(): Promise<
+  Record<string, number>
+> {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("interview_sessions")
+    .select("interview_config_id");
+
+  if (error) {
+    throw new Error(`Failed to count sessions: ${error.message}`);
+  }
+
+  const result: Record<string, number> = {};
   for (const row of data) {
     result[row.interview_config_id] =
       (result[row.interview_config_id] ?? 0) + 1;

--- a/admin/src/features/interview-config/shared/utils/get-mode-label.test.ts
+++ b/admin/src/features/interview-config/shared/utils/get-mode-label.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { getModeLabel } from "./get-mode-label";
+
+describe("getModeLabel", () => {
+  it("loopをループと表示する", () => {
+    expect(getModeLabel("loop")).toBe("ループ");
+  });
+
+  it("bulkを一括と表示する", () => {
+    expect(getModeLabel("bulk")).toBe("一括");
+  });
+});

--- a/admin/src/features/interview-config/shared/utils/get-mode-label.ts
+++ b/admin/src/features/interview-config/shared/utils/get-mode-label.ts
@@ -1,0 +1,12 @@
+import type { InterviewConfig } from "../types";
+
+export function getModeLabel(mode: InterviewConfig["mode"]): string {
+  switch (mode) {
+    case "loop":
+      return "ループ";
+    case "bulk":
+      return "一括";
+    default:
+      return mode;
+  }
+}

--- a/admin/src/features/interviews/server/components/all-interview-config-list.tsx
+++ b/admin/src/features/interviews/server/components/all-interview-config-list.tsx
@@ -1,0 +1,129 @@
+import type { Route } from "next";
+import Link from "next/link";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { routes } from "@/lib/routes";
+import { BarChart3, Sparkles } from "lucide-react";
+import type { InterviewConfigWithBill } from "@/features/interview-config/server/repositories/interview-config-repository";
+import { getModeLabel } from "@/features/interview-config/shared/utils/get-mode-label";
+
+interface AllInterviewConfigListProps {
+  configs: InterviewConfigWithBill[];
+  sessionCounts: Record<string, number> | null;
+}
+
+export function AllInterviewConfigList({
+  configs,
+  sessionCounts,
+}: AllInterviewConfigListProps) {
+  return (
+    <div>
+      <div className="mb-4 text-sm text-gray-600">
+        {configs.length}件のインタビュー設定
+      </div>
+
+      {configs.length === 0 ? (
+        <div className="text-center py-8 text-gray-500">
+          インタビュー設定がありません。
+        </div>
+      ) : (
+        <div className="rounded-md border bg-white">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>設定名</TableHead>
+                <TableHead>議案</TableHead>
+                <TableHead>モード</TableHead>
+                <TableHead>ステータス</TableHead>
+                <TableHead>セッション数</TableHead>
+                <TableHead>作成日</TableHead>
+                <TableHead>リンク</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {configs.map((config) => (
+                <TableRow key={config.id}>
+                  <TableCell>
+                    <Link
+                      href={
+                        routes.billInterviewEdit(
+                          config.bill_id,
+                          config.id
+                        ) as Route
+                      }
+                      className="font-medium hover:underline"
+                    >
+                      {config.name}
+                    </Link>
+                  </TableCell>
+                  <TableCell>
+                    <Link
+                      href={routes.billInterview(config.bill_id) as Route}
+                      className="text-gray-700 hover:underline"
+                    >
+                      {config.bill.name}
+                    </Link>
+                  </TableCell>
+                  <TableCell>
+                    <Badge variant="outline">{getModeLabel(config.mode)}</Badge>
+                  </TableCell>
+                  <TableCell>
+                    <Badge
+                      variant={
+                        config.status === "public" ? "default" : "secondary"
+                      }
+                      className="w-16 justify-center"
+                    >
+                      {config.status === "public" ? "公開" : "非公開"}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="text-gray-600">
+                    {sessionCounts ? (sessionCounts[config.id] ?? 0) : "-"}
+                  </TableCell>
+                  <TableCell className="text-gray-600">
+                    {new Date(config.created_at).toLocaleDateString("ja-JP")}
+                  </TableCell>
+                  <TableCell>
+                    <div className="flex items-center gap-1">
+                      <Link
+                        href={
+                          routes.billReports(config.bill_id, config.id) as Route
+                        }
+                      >
+                        <Button variant="ghost" size="sm" className="gap-1">
+                          <BarChart3 className="h-4 w-4" />
+                          レポート
+                        </Button>
+                      </Link>
+                      <Link
+                        href={
+                          routes.billTopicAnalysis(
+                            config.bill_id,
+                            config.id
+                          ) as Route
+                        }
+                      >
+                        <Button variant="ghost" size="sm" className="gap-1">
+                          <Sparkles className="h-4 w-4" />
+                          トピック解析
+                        </Button>
+                      </Link>
+                    </div>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/admin/src/features/interviews/server/components/all-interview-config-list.tsx
+++ b/admin/src/features/interviews/server/components/all-interview-config-list.tsx
@@ -93,29 +93,42 @@ export function AllInterviewConfigList({
                   </TableCell>
                   <TableCell>
                     <div className="flex items-center gap-1">
-                      <Link
-                        href={
-                          routes.billReports(config.bill_id, config.id) as Route
-                        }
+                      <Button
+                        asChild
+                        variant="ghost"
+                        size="sm"
+                        className="gap-1"
                       >
-                        <Button variant="ghost" size="sm" className="gap-1">
+                        <Link
+                          href={
+                            routes.billReports(
+                              config.bill_id,
+                              config.id
+                            ) as Route
+                          }
+                        >
                           <BarChart3 className="h-4 w-4" />
                           レポート
-                        </Button>
-                      </Link>
-                      <Link
-                        href={
-                          routes.billTopicAnalysis(
-                            config.bill_id,
-                            config.id
-                          ) as Route
-                        }
+                        </Link>
+                      </Button>
+                      <Button
+                        asChild
+                        variant="ghost"
+                        size="sm"
+                        className="gap-1"
                       >
-                        <Button variant="ghost" size="sm" className="gap-1">
+                        <Link
+                          href={
+                            routes.billTopicAnalysis(
+                              config.bill_id,
+                              config.id
+                            ) as Route
+                          }
+                        >
                           <Sparkles className="h-4 w-4" />
                           トピック解析
-                        </Button>
-                      </Link>
+                        </Link>
+                      </Button>
                     </div>
                   </TableCell>
                 </TableRow>

--- a/admin/src/features/interviews/server/loaders/get-all-interview-configs.ts
+++ b/admin/src/features/interviews/server/loaders/get-all-interview-configs.ts
@@ -1,0 +1,30 @@
+import "server-only";
+
+import {
+  findAllInterviewConfigs,
+  type InterviewConfigWithBill,
+} from "@/features/interview-config/server/repositories/interview-config-repository";
+import { countAllSessionsByConfigId } from "@/features/interview-config/server/repositories/interview-config-repository";
+
+export async function getAllInterviewConfigs(): Promise<
+  InterviewConfigWithBill[]
+> {
+  try {
+    return await findAllInterviewConfigs();
+  } catch (error) {
+    console.error("Failed to fetch all interview configs:", error);
+    return [];
+  }
+}
+
+export async function getAllSessionCounts(): Promise<Record<
+  string,
+  number
+> | null> {
+  try {
+    return await countAllSessionsByConfigId();
+  } catch (error) {
+    console.error("Failed to fetch session counts:", error);
+    return null;
+  }
+}

--- a/admin/src/lib/routes.ts
+++ b/admin/src/lib/routes.ts
@@ -15,6 +15,7 @@ export const routes = {
   tags: () => "/tags" as const,
   dietSessions: () => "/diet-sessions" as const,
   experts: () => "/experts" as const,
+  interviews: () => "/interviews" as const,
 
   // ── 議案配下 ──────────────────────────────────────
   billEdit: (billId: string) => `/bills/${billId}/edit` as const,


### PR DESCRIPTION
## Summary
- adminナビゲーションに「インタビュー」タブを追加
- 全インタビュー設定を議案名付きでテーブル表示（設定名・議案・モード・ステータス・セッション数・作成日・レポート/トピック解析リンク）
- `getModeLabel` を共有ユーティリティに切り出し、既存の `interview-config-list.tsx` と新コンポーネントで共用
- セッション数カウントを全件一括取得に最適化（per-config → 全件一括）

## Test plan
- [x] `pnpm lint` pass
- [x] `pnpm typecheck` pass
- [x] `pnpm --filter admin test` pass (37 files, 273 tests)
- [ ] `/interviews` ページにアクセスしてインタビュー設定一覧が表示されることを確認
- [ ] 議案名クリックで該当議案のインタビュー設定ページに遷移することを確認
- [ ] レポート/トピック解析リンクが正しく動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * インタビュー管理ページを追加しました。設定一覧、請求名、実施モード、公開/非公開ステータス、セッション数、作成日を表示します。
  * 各設定からレポート表示とトピック解析に直接アクセスできます。
  * ナビゲーションメニューに「インタビュー」へのリンクを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->