### PR TITLE
トピック解析を高速化する

### DIFF
--- a/admin/src/features/topic-analysis/server/services/step1-extract-topics.ts
+++ b/admin/src/features/topic-analysis/server/services/step1-extract-topics.ts
@@ -8,6 +8,7 @@ import {
 } from "../../shared/constants";
 import { topicExtractionSchema } from "../../shared/schemas";
 import type { FlatOpinion } from "../../shared/types";
+import { retryTopicAnalysisRequest } from "../utils/retry-topic-analysis-request";
 
 function chunk<T>(array: T[], size: number): T[][] {
   const chunks: T[][] = [];
@@ -55,10 +56,12 @@ async function extractTopicsFromBatch(
     .map((o, i) => `[${i + 1}] ${o.title}\n${o.content}`)
     .join("\n\n");
 
-  const { object } = await generateObject({
-    model: TOPIC_ANALYSIS_MODEL,
-    schema: topicExtractionSchema,
-    prompt: `あなたは議案に対する市民の意見を分析する専門家です。
+  const { object } = await retryTopicAnalysisRequest(
+    () =>
+      generateObject({
+        model: TOPIC_ANALYSIS_MODEL,
+        schema: topicExtractionSchema,
+        prompt: `あなたは議案に対する市民の意見を分析する専門家です。
 
 ## 議案情報
 タイトル: ${billTitle}
@@ -79,14 +82,18 @@ ${opinionsText}
   - 良い例: 「貿易事務コストを削減すべき」「システムの安全性が不十分」「現場職員への教育支援を充実させるべき」
 - 似たような意見はまとめて1つのトピックにしてください
 - 意見が少ない場合でも最低1つのトピックを抽出してください`,
-    experimental_telemetry: {
-      isEnabled: true,
-      functionId: "topic-analysis-step1-extract",
-      metadata: {
-        batchIndex: String(batchIndex),
-      },
-    },
-  });
+        experimental_telemetry: {
+          isEnabled: true,
+          functionId: "topic-analysis-step1-extract",
+          metadata: {
+            batchIndex: String(batchIndex),
+          },
+        },
+      }),
+    {
+      label: `step1-extract batch=${batchIndex}`,
+    }
+  );
 
   return object.topics.map((t) => t.name);
 }

--- a/admin/src/features/topic-analysis/server/services/step3-classify-opinions.ts
+++ b/admin/src/features/topic-analysis/server/services/step3-classify-opinions.ts
@@ -8,6 +8,7 @@ import {
   TOPIC_ANALYSIS_MODEL,
 } from "../../shared/constants";
 import type { FlatOpinion } from "../../shared/types";
+import { retryTopicAnalysisRequest } from "../utils/retry-topic-analysis-request";
 
 function chunk<T>(array: T[], size: number): T[][] {
   const chunks: T[][] = [];
@@ -72,10 +73,12 @@ async function classifyBatch(
 
   const topicsText = topicNames.map((t, i) => `${i + 1}. ${t}`).join("\n");
 
-  const { object } = await generateObject({
-    model: TOPIC_ANALYSIS_MODEL,
-    schema: classifyBatchSchema,
-    prompt: `あなたは議案分析の専門家です。各意見を適切なトピックに分類してください。
+  const { object } = await retryTopicAnalysisRequest(
+    () =>
+      generateObject({
+        model: TOPIC_ANALYSIS_MODEL,
+        schema: classifyBatchSchema,
+        prompt: `あなたは議案分析の専門家です。各意見を適切なトピックに分類してください。
 
 ## 法案
 ${billTitle}
@@ -92,14 +95,18 @@ ${opinionsText}
 - topic_namesには分類先のトピック名を配列で指定してください
 - 1つの意見が複数のトピックに該当する場合は複数指定してください
 - どのトピックにも該当しない意見は空配列にしてください`,
-    experimental_telemetry: {
-      isEnabled: true,
-      functionId: "topic-analysis-step3-classify",
-      metadata: {
-        batchIndex: String(batchIndex),
-      },
-    },
-  });
+        experimental_telemetry: {
+          isEnabled: true,
+          functionId: "topic-analysis-step3-classify",
+          metadata: {
+            batchIndex: String(batchIndex),
+          },
+        },
+      }),
+    {
+      label: `step3-classify batch=${batchIndex}`,
+    }
+  );
 
   // LLMが返した連番IDを元のinterview_report_id + opinion_indexにマッピング
   return object.classifications

--- a/admin/src/features/topic-analysis/server/services/step4-generate-topic-reports.ts
+++ b/admin/src/features/topic-analysis/server/services/step4-generate-topic-reports.ts
@@ -3,7 +3,7 @@ import "server-only";
 import { generateObject } from "ai";
 import {
   TOPIC_ANALYSIS_MAX_CONCURRENCY,
-  TOPIC_ANALYSIS_MODEL,
+  TOPIC_ANALYSIS_WRITING_MODEL,
 } from "../../shared/constants";
 import { topicReportSchema } from "../../shared/schemas";
 import type { FlatOpinion, RepresentativeOpinion } from "../../shared/types";
@@ -66,7 +66,7 @@ async function generateSingleTopicReport(
   const sessionList = sessionIds.map((id, i) => `  ${i + 1}. ${id}`).join("\n");
 
   const result = await generateObject({
-    model: TOPIC_ANALYSIS_MODEL,
+    model: TOPIC_ANALYSIS_WRITING_MODEL,
     schema: topicReportSchema,
     prompt: `あなたは市民意見の分析レポートを作成します。
 

--- a/admin/src/features/topic-analysis/server/services/step5-generate-summary.ts
+++ b/admin/src/features/topic-analysis/server/services/step5-generate-summary.ts
@@ -1,7 +1,7 @@
 import "server-only";
 
 import { generateObject } from "ai";
-import { TOPIC_ANALYSIS_MODEL } from "../../shared/constants";
+import { TOPIC_ANALYSIS_WRITING_MODEL } from "../../shared/constants";
 import { overallSummarySchema } from "../../shared/schemas";
 
 type TopicSummaryInput = {
@@ -29,7 +29,7 @@ export async function generateOverallSummary(
     .join("\n\n");
 
   const result = await generateObject({
-    model: TOPIC_ANALYSIS_MODEL,
+    model: TOPIC_ANALYSIS_WRITING_MODEL,
     schema: overallSummarySchema,
     prompt: `あなたは市民意見の分析レポートの全体サマリを作成します。
 

--- a/admin/src/features/topic-analysis/server/utils/retry-topic-analysis-request.test.ts
+++ b/admin/src/features/topic-analysis/server/utils/retry-topic-analysis-request.test.ts
@@ -18,6 +18,7 @@ describe("retryTopicAnalysisRequest", () => {
       .mockRejectedValueOnce({ statusCode: 429 })
       .mockResolvedValueOnce("ok");
     const sleepFn = vi.fn().mockResolvedValue(undefined);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
     await expect(
       retryTopicAnalysisRequest(fn, { label: "step1" }, { sleepFn })
@@ -25,6 +26,8 @@ describe("retryTopicAnalysisRequest", () => {
 
     expect(fn).toHaveBeenCalledTimes(2);
     expect(sleepFn).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("status=429"));
+    warnSpy.mockRestore();
   });
 
   it("リトライ不可エラーは即座に失敗する", async () => {
@@ -44,6 +47,7 @@ describe("retryTopicAnalysisRequest", () => {
     const error = { response: { status: 503 } };
     const fn = vi.fn().mockRejectedValue(error);
     const sleepFn = vi.fn().mockResolvedValue(undefined);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
     await expect(
       retryTopicAnalysisRequest(
@@ -55,5 +59,33 @@ describe("retryTopicAnalysisRequest", () => {
 
     expect(fn).toHaveBeenCalledTimes(3);
     expect(sleepFn).toHaveBeenCalledTimes(2);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("status=503"));
+    warnSpy.mockRestore();
+  });
+
+  it("不正な maxAttempts を明示エラーにする", async () => {
+    await expect(
+      retryTopicAnalysisRequest(
+        vi.fn().mockResolvedValue("ok"),
+        {
+          label: "step1",
+          maxAttempts: 0,
+        },
+        { sleepFn: vi.fn().mockResolvedValue(undefined) }
+      )
+    ).rejects.toThrow("maxAttempts must be greater than or equal to 1");
+  });
+
+  it("不正な baseDelayMs を明示エラーにする", async () => {
+    await expect(
+      retryTopicAnalysisRequest(
+        vi.fn().mockResolvedValue("ok"),
+        {
+          label: "step1",
+          baseDelayMs: -1,
+        },
+        { sleepFn: vi.fn().mockResolvedValue(undefined) }
+      )
+    ).rejects.toThrow("baseDelayMs must be greater than or equal to 0");
   });
 });

--- a/admin/src/features/topic-analysis/server/utils/retry-topic-analysis-request.test.ts
+++ b/admin/src/features/topic-analysis/server/utils/retry-topic-analysis-request.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  getRetryDelayMs,
+  retryTopicAnalysisRequest,
+} from "./retry-topic-analysis-request";
+
+describe("getRetryDelayMs", () => {
+  it("指数バックオフと jitter を加算する", () => {
+    expect(getRetryDelayMs(1, 500, () => 0.5)).toBe(750);
+    expect(getRetryDelayMs(2, 500, () => 0.2)).toBe(1100);
+  });
+});
+
+describe("retryTopicAnalysisRequest", () => {
+  it("リトライ可能なエラーでは成功するまで再試行する", async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce({ statusCode: 429 })
+      .mockResolvedValueOnce("ok");
+    const sleepFn = vi.fn().mockResolvedValue(undefined);
+
+    await expect(
+      retryTopicAnalysisRequest(fn, { label: "step1" }, { sleepFn })
+    ).resolves.toBe("ok");
+
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(sleepFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("リトライ不可エラーは即座に失敗する", async () => {
+    const error = new Error("schema mismatch");
+    const fn = vi.fn().mockRejectedValue(error);
+    const sleepFn = vi.fn().mockResolvedValue(undefined);
+
+    await expect(
+      retryTopicAnalysisRequest(fn, { label: "step3" }, { sleepFn })
+    ).rejects.toThrow("schema mismatch");
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(sleepFn).not.toHaveBeenCalled();
+  });
+
+  it("最大試行回数で失敗を返す", async () => {
+    const error = { response: { status: 503 } };
+    const fn = vi.fn().mockRejectedValue(error);
+    const sleepFn = vi.fn().mockResolvedValue(undefined);
+
+    await expect(
+      retryTopicAnalysisRequest(
+        fn,
+        { label: "step3", maxAttempts: 3 },
+        { sleepFn }
+      )
+    ).rejects.toEqual(error);
+
+    expect(fn).toHaveBeenCalledTimes(3);
+    expect(sleepFn).toHaveBeenCalledTimes(2);
+  });
+});

--- a/admin/src/features/topic-analysis/server/utils/retry-topic-analysis-request.ts
+++ b/admin/src/features/topic-analysis/server/utils/retry-topic-analysis-request.ts
@@ -1,0 +1,106 @@
+import "server-only";
+
+const DEFAULT_MAX_ATTEMPTS = 3;
+const DEFAULT_BASE_DELAY_MS = 500;
+
+type RetryOptions = {
+  label: string;
+  maxAttempts?: number;
+  baseDelayMs?: number;
+};
+
+type RetryDeps = {
+  randomFn?: () => number;
+  sleepFn?: (ms: number) => Promise<void>;
+};
+
+export function getRetryDelayMs(
+  attempt: number,
+  baseDelayMs: number,
+  randomFn: () => number = Math.random
+): number {
+  const jitter = Math.floor(randomFn() * baseDelayMs);
+  return baseDelayMs * 2 ** (attempt - 1) + jitter;
+}
+
+function getErrorStatus(error: unknown): number | undefined {
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "statusCode" in error &&
+    typeof error.statusCode === "number"
+  ) {
+    return error.statusCode;
+  }
+
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "response" in error &&
+    typeof error.response === "object" &&
+    error.response !== null &&
+    "status" in error.response &&
+    typeof error.response.status === "number"
+  ) {
+    return error.response.status;
+  }
+
+  return undefined;
+}
+
+function isRetryableError(error: unknown): boolean {
+  const status = getErrorStatus(error);
+  if (status !== undefined) {
+    return status === 429 || status >= 500;
+  }
+
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  const message = error.message.toLowerCase();
+  return (
+    message.includes("rate limit") ||
+    message.includes("timeout") ||
+    message.includes("temporarily unavailable") ||
+    message.includes("overloaded")
+  );
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+export async function retryTopicAnalysisRequest<T>(
+  fn: () => Promise<T>,
+  options: RetryOptions,
+  deps: RetryDeps = {}
+): Promise<T> {
+  const {
+    label,
+    maxAttempts = DEFAULT_MAX_ATTEMPTS,
+    baseDelayMs = DEFAULT_BASE_DELAY_MS,
+  } = options;
+  const { randomFn = Math.random, sleepFn = sleep } = deps;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      if (!isRetryableError(error) || attempt === maxAttempts) {
+        throw error;
+      }
+
+      const delayMs = getRetryDelayMs(attempt, baseDelayMs, randomFn);
+      console.warn(
+        `[TopicAnalysis] ${label} failed on attempt ${attempt}/${maxAttempts}. Retrying in ${delayMs}ms...`,
+        error
+      );
+      await sleepFn(delayMs);
+    }
+  }
+
+  throw new Error(`[TopicAnalysis] ${label} exhausted all retries`);
+}

--- a/admin/src/features/topic-analysis/server/utils/retry-topic-analysis-request.ts
+++ b/admin/src/features/topic-analysis/server/utils/retry-topic-analysis-request.ts
@@ -73,6 +73,20 @@ function sleep(ms: number): Promise<void> {
   });
 }
 
+function getSanitizedErrorDetails(error: unknown): string {
+  const status = getErrorStatus(error);
+  if (error instanceof Error) {
+    const statusSuffix = status !== undefined ? ` status=${status}` : "";
+    return `message="${error.message}"${statusSuffix}`;
+  }
+
+  if (status !== undefined) {
+    return `status=${status}`;
+  }
+
+  return "unknown error";
+}
+
 export async function retryTopicAnalysisRequest<T>(
   fn: () => Promise<T>,
   options: RetryOptions,
@@ -85,6 +99,14 @@ export async function retryTopicAnalysisRequest<T>(
   } = options;
   const { randomFn = Math.random, sleepFn = sleep } = deps;
 
+  if (maxAttempts < 1) {
+    throw new Error("maxAttempts must be greater than or equal to 1");
+  }
+
+  if (baseDelayMs < 0) {
+    throw new Error("baseDelayMs must be greater than or equal to 0");
+  }
+
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     try {
       return await fn();
@@ -95,8 +117,7 @@ export async function retryTopicAnalysisRequest<T>(
 
       const delayMs = getRetryDelayMs(attempt, baseDelayMs, randomFn);
       console.warn(
-        `[TopicAnalysis] ${label} failed on attempt ${attempt}/${maxAttempts}. Retrying in ${delayMs}ms...`,
-        error
+        `[TopicAnalysis] ${label} failed on attempt ${attempt}/${maxAttempts}. Retrying in ${delayMs}ms. ${getSanitizedErrorDetails(error)}`
       );
       await sleepFn(delayMs);
     }

--- a/admin/src/features/topic-analysis/shared/constants.ts
+++ b/admin/src/features/topic-analysis/shared/constants.ts
@@ -4,7 +4,7 @@ import { AI_MODELS } from "@/lib/ai/models";
 export const TOPIC_ANALYSIS_BATCH_SIZE = 100;
 
 /** 並列LLM呼び出し上限 */
-export const TOPIC_ANALYSIS_MAX_CONCURRENCY = 10;
+export const TOPIC_ANALYSIS_MAX_CONCURRENCY = 100;
 
 /** トピックあたりの代表意見数上限 */
 export const TOPIC_ANALYSIS_MAX_REPRESENTATIVES = 5;

--- a/admin/src/features/topic-analysis/shared/constants.ts
+++ b/admin/src/features/topic-analysis/shared/constants.ts
@@ -1,7 +1,7 @@
 import { AI_MODELS } from "@/lib/ai/models";
 
 /** バッチあたりの意見数 */
-export const TOPIC_ANALYSIS_BATCH_SIZE = 100;
+export const TOPIC_ANALYSIS_BATCH_SIZE = 25;
 
 /** 並列LLM呼び出し上限 */
 export const TOPIC_ANALYSIS_MAX_CONCURRENCY = 100;
@@ -10,7 +10,10 @@ export const TOPIC_ANALYSIS_MAX_CONCURRENCY = 100;
 export const TOPIC_ANALYSIS_MAX_REPRESENTATIVES = 5;
 
 /** トピック解析で使用するモデル */
-export const TOPIC_ANALYSIS_MODEL = AI_MODELS.gemini3_flash_preview;
+export const TOPIC_ANALYSIS_MODEL = AI_MODELS.gemini3_1_flash_lite_preview;
+
+/** トピックレポート生成と全体サマリで使用するモデル */
+export const TOPIC_ANALYSIS_WRITING_MODEL = AI_MODELS.gemini3_flash_preview;
 
 /** 解析パイプラインの全ステップ数 */
 export const ANALYSIS_TOTAL_STEPS = 7;

--- a/packages/shared/src/ai/models.ts
+++ b/packages/shared/src/ai/models.ts
@@ -20,6 +20,7 @@ export const AI_MODELS = {
   // --- Google ---
   gemini3_flash: "google/gemini-3-flash",
   gemini3_flash_preview: "google/gemini-3-flash-preview",
+  gemini3_1_flash_lite_preview: "google/gemini-3.1-flash-lite-preview",
   gemini3_1_pro_preview: "google/gemini-3.1-pro-preview",
   // --- Anthropic ---
   claude_haiku_4_5: "anthropic/claude-haiku-4.5",


### PR DESCRIPTION
## 概要
- トピック解析のバッチサイズを 25 件に変更
- トピック解析の並列数を 100 に変更
- step1-3 は gemini-3.1-flash-lite-preview を使い、step4-5 は gemini-3-flash-preview を使うよう分離
- AI モデル定義に gemini-3.1-flash-lite-preview を追加

## 検証
- pnpm typecheck
- pnpm build
- ローカルで admin を起動し、トピック解析が最後まで完了することを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Chores**
  * トピック解析のバッチサイズを縮小し、並行処理上限を大幅に引き上げて処理効率を改善しました。
  * レポート生成と要約でより適した生成モデルを利用するよう切替えました。

* **New Features**
  * 新しいAIモデルを追加しました（トピック解析で利用可能）。

* **Bug Fixes**
  * 一時的なエラーやレート制限時に自動で再試行する仕組みを導入し、安定性を向上しました。

* **Tests**
  * 再試行ロジックの単体テストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->