### PR TITLE
ご意見一覧のソートラベル「おすすめ順」→「標準」に変更

### DIFF
--- a/web/src/features/interview-report/shared/utils/sort-order.ts
+++ b/web/src/features/interview-report/shared/utils/sort-order.ts
@@ -1,7 +1,7 @@
 export type SortOrder = "recommended" | "newest";
 
 export const sortOrderLabels: Record<SortOrder, string> = {
-  recommended: "おすすめ順",
+  recommended: "標準",
   newest: "新着順",
 };
 


### PR DESCRIPTION
## Summary
- ご意見一覧のソートラベルを「おすすめ順」から「標準」に変更

## Test plan
- [x] `pnpm lint` 通過
- [x] `pnpm typecheck` 通過
- [x] `pnpm build` 通過
- [x] `pnpm test` 全テスト通過（744 passed）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **スタイル**
  * インタビューレポートのソート順序表示ラベルを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->