### PR TITLE
レポート一括公開のconfigId解決バグを修正

### DIFF
--- a/admin/src/app/(protected)/bills/[id]/interview/[configId]/reports/page.tsx
+++ b/admin/src/app/(protected)/bills/[id]/interview/[configId]/reports/page.tsx
@@ -82,7 +82,7 @@ export default async function ReportsPage({
           <p className="text-gray-600 mt-1">議案「{bill.name}」のレポート</p>
         </div>
         <div className="flex items-center gap-2">
-          <BatchPublishButton billId={id} />
+          <BatchPublishButton billId={id} configId={configId} />
           <BatchModerationButton />
         </div>
       </div>

--- a/admin/src/features/interview-reports/client/components/batch-publish-button.tsx
+++ b/admin/src/features/interview-reports/client/components/batch-publish-button.tsx
@@ -19,9 +19,13 @@ import {
 
 interface BatchPublishButtonProps {
   billId: string;
+  configId: string;
 }
 
-export function BatchPublishButton({ billId }: BatchPublishButtonProps) {
+export function BatchPublishButton({
+  billId,
+  configId,
+}: BatchPublishButtonProps) {
   const router = useRouter();
   const [isRunning, setIsRunning] = useState(false);
   const [open, setOpen] = useState(false);
@@ -34,6 +38,7 @@ export function BatchPublishButton({ billId }: BatchPublishButtonProps) {
     setIsCounting(true);
     try {
       const result = await countBulkPublishTargetsAction({
+        configId,
         billId,
         maxModerationScore,
         minContentRichness,
@@ -57,6 +62,7 @@ export function BatchPublishButton({ billId }: BatchPublishButtonProps) {
 
     try {
       const result = await bulkPublishReportsAction({
+        configId,
         billId,
         maxModerationScore,
         minContentRichness,

--- a/admin/src/features/interview-reports/server/actions/bulk-publish-reports-action.ts
+++ b/admin/src/features/interview-reports/server/actions/bulk-publish-reports-action.ts
@@ -3,9 +3,9 @@
 import { createAdminClient } from "@mirai-gikai/supabase";
 import { revalidateTag } from "next/cache";
 import { requireAdmin } from "@/features/auth/server/lib/auth-server";
-import { findInterviewConfigIdByBillId } from "../repositories/interview-report-repository";
 
 interface BulkPublishParams {
+  configId: string;
   billId: string;
   maxModerationScore: number;
   minContentRichness: number;
@@ -17,12 +17,21 @@ interface BulkPublishResult {
   error?: string;
 }
 
-async function resolveConfigId(billId: string): Promise<string> {
-  const config = await findInterviewConfigIdByBillId(billId);
-  if (!config) {
-    throw new Error("対象の議案にインタビュー設定が見つかりません");
+async function verifyConfigBelongsToBill(
+  configId: string,
+  billId: string
+): Promise<void> {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("interview_configs")
+    .select("id")
+    .eq("id", configId)
+    .eq("bill_id", billId)
+    .single();
+
+  if (error || !data) {
+    throw new Error("指定されたインタビュー設定はこの議案に属していません");
   }
-  return config.id;
 }
 
 export async function bulkPublishReportsAction(
@@ -31,11 +40,11 @@ export async function bulkPublishReportsAction(
   await requireAdmin();
 
   try {
-    const configId = await resolveConfigId(params.billId);
+    await verifyConfigBelongsToBill(params.configId, params.billId);
     const supabase = createAdminClient();
 
     const { data, error } = await supabase.rpc("bulk_publish_reports", {
-      p_config_id: configId,
+      p_config_id: params.configId,
       p_max_moderation_score: params.maxModerationScore,
       p_min_content_richness: params.minContentRichness,
     });
@@ -64,11 +73,11 @@ export async function countBulkPublishTargetsAction(
   await requireAdmin();
 
   try {
-    const configId = await resolveConfigId(params.billId);
+    await verifyConfigBelongsToBill(params.configId, params.billId);
     const supabase = createAdminClient();
 
     const { data, error } = await supabase.rpc("count_bulk_publish_targets", {
-      p_config_id: configId,
+      p_config_id: params.configId,
       p_max_moderation_score: params.maxModerationScore,
       p_min_content_richness: params.minContentRichness,
     });

--- a/admin/src/features/interview-reports/server/repositories/interview-report-repository.ts
+++ b/admin/src/features/interview-reports/server/repositories/interview-report-repository.ts
@@ -23,26 +23,6 @@ function hasReportLevelFilters(filters: SessionFilterConfig): boolean {
   );
 }
 
-export async function findInterviewConfigIdByBillId(
-  billId: string
-): Promise<{ id: string } | null> {
-  const supabase = createAdminClient();
-  const { data, error } = await supabase
-    .from("interview_configs")
-    .select("id")
-    .eq("bill_id", billId)
-    .single();
-
-  if (error) {
-    if (error.code === "PGRST116") {
-      return null;
-    }
-    throw new Error(`Failed to fetch interview config: ${error.message}`);
-  }
-
-  return data;
-}
-
 export async function findInterviewSessionsWithReport(
   configId: string,
   from: number,


### PR DESCRIPTION
## Summary
- レポート一括公開で「対象の議案にインタビュー設定が見つかりません」エラーが発生するバグを修正
- 原因: `findInterviewConfigIdByBillId` が `.single()` を使用しており、1つの議案に複数のインタビュー設定がある場合に失敗していた
- 修正: URLパラメータの `configId` を直接使用するように変更し、`billId` との整合性チェックを追加

## Changes
- `BatchPublishButton` に `configId` を渡すように変更（`billId` からの間接解決を廃止）
- Server Action で `configId` を直接使用し、`verifyConfigBelongsToBill` でbill/config整合性を検証
- 不要になった `findInterviewConfigIdByBillId` リポジトリ関数を削除

## Test plan
- [ ] 複数のインタビュー設定がある議案でレポート一括公開が正常に動作すること
- [ ] 対象件数の確認が正常に動作すること
- [ ] `pnpm lint` pass
- [ ] `pnpm typecheck` pass（既存の `@radix-ui/react-tooltip` エラーは本PRとは無関係）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * レポートのバッチ公開機能の処理ロジックを改善しました。設定ID の検証をより厳密に行い、公開対象の確認精度を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->