### PR TITLE
法案記事にレビューステータス機能を追加

### DIFF
--- a/admin/src/features/bills-edit/client/components/bill-create-form.tsx
+++ b/admin/src/features/bills-edit/client/components/bill-create-form.tsx
@@ -36,6 +36,7 @@ export function BillCreateForm({ dietSessions }: BillCreateFormProps) {
       share_thumbnail_url: null,
       shugiin_url: null,
       is_featured: false,
+      is_review_completed: false,
       diet_session_id: defaultDietSessionId,
     },
   });

--- a/admin/src/features/bills-edit/client/components/bill-edit-form.tsx
+++ b/admin/src/features/bills-edit/client/components/bill-edit-form.tsx
@@ -44,6 +44,7 @@ export function BillEditForm({ bill, dietSessions }: BillEditFormProps) {
       share_thumbnail_url: bill.share_thumbnail_url,
       shugiin_url: bill.shugiin_url,
       is_featured: bill.is_featured,
+      is_review_completed: bill.is_review_completed,
       diet_session_id: defaultDietSessionId,
     },
   });

--- a/admin/src/features/bills-edit/client/components/bill-form-fields.tsx
+++ b/admin/src/features/bills-edit/client/components/bill-form-fields.tsx
@@ -285,6 +285,27 @@ export function BillFormFields({
           </FormItem>
         )}
       />
+
+      <FormField
+        control={control}
+        name="is_review_completed"
+        render={({ field }) => (
+          <FormItem className="flex flex-row items-start space-x-3 space-y-0 rounded-md border p-4">
+            <FormControl>
+              <Checkbox
+                checked={field.value}
+                onCheckedChange={field.onChange}
+              />
+            </FormControl>
+            <div className="space-y-1 leading-none">
+              <FormLabel>記事レビュー完了</FormLabel>
+              <FormDescription>
+                未完了の場合、記事にレビュー中バナーが表示されます
+              </FormDescription>
+            </div>
+          </FormItem>
+        )}
+      />
     </>
   );
 }

--- a/admin/src/features/bills-edit/shared/types/index.ts
+++ b/admin/src/features/bills-edit/shared/types/index.ts
@@ -40,6 +40,7 @@ const billBaseSchema = z.object({
     })
     .optional(),
   is_featured: z.boolean(),
+  is_review_completed: z.boolean(),
   diet_session_id: z.string().uuid().nullable().optional(),
 });
 

--- a/admin/src/features/bills/shared/utils/prepare-bill-for-duplication.test.ts
+++ b/admin/src/features/bills/shared/utils/prepare-bill-for-duplication.test.ts
@@ -13,6 +13,7 @@ const baseBill: Bill = {
   updated_at: "2025-01-02T00:00:00Z",
   diet_session_id: "session-001",
   is_featured: true,
+  is_review_completed: true,
   originating_house: "HR",
   publish_status: "published",
   published_at: null,

--- a/admin/src/features/bills/shared/utils/prepare-bill-for-duplication.test.ts
+++ b/admin/src/features/bills/shared/utils/prepare-bill-for-duplication.test.ts
@@ -44,6 +44,11 @@ describe("prepareBillForDuplication", () => {
     expect(result.publish_status).toBe("draft");
   });
 
+  it("is_review_completedをfalseにリセットする", () => {
+    const result = prepareBillForDuplication(baseBill);
+    expect(result.is_review_completed).toBe(false);
+  });
+
   it("その他のフィールドを保持する", () => {
     const result = prepareBillForDuplication(baseBill);
     expect(result.diet_session_id).toBe("session-001");

--- a/admin/src/features/bills/shared/utils/prepare-bill-for-duplication.ts
+++ b/admin/src/features/bills/shared/utils/prepare-bill-for-duplication.ts
@@ -17,6 +17,7 @@ export function prepareBillForDuplication(originalBill: Bill): BillInsert {
     ...billWithoutId,
     name: `${originalBill.name} (複製)`,
     publish_status: "draft",
+    is_review_completed: false,
   };
 }
 

--- a/packages/supabase/types/supabase.types.ts
+++ b/packages/supabase/types/supabase.types.ts
@@ -81,6 +81,7 @@ export type Database = {
           diet_session_id: string | null
           id: string
           is_featured: boolean
+          is_review_completed: boolean
           name: string
           originating_house: Database["public"]["Enums"]["house_enum"]
           publish_status: Database["public"]["Enums"]["bill_publish_status"]
@@ -99,6 +100,7 @@ export type Database = {
           diet_session_id?: string | null
           id?: string
           is_featured?: boolean
+          is_review_completed?: boolean
           name: string
           originating_house: Database["public"]["Enums"]["house_enum"]
           publish_status?: Database["public"]["Enums"]["bill_publish_status"]
@@ -117,6 +119,7 @@ export type Database = {
           diet_session_id?: string | null
           id?: string
           is_featured?: boolean
+          is_review_completed?: boolean
           name?: string
           originating_house?: Database["public"]["Enums"]["house_enum"]
           publish_status?: Database["public"]["Enums"]["bill_publish_status"]

--- a/supabase/migrations/20260406100000_add_is_review_completed_to_bills.sql
+++ b/supabase/migrations/20260406100000_add_is_review_completed_to_bills.sql
@@ -1,0 +1,7 @@
+-- bills テーブルに記事レビュー完了フラグを追加
+ALTER TABLE bills ADD COLUMN is_review_completed BOOLEAN NOT NULL DEFAULT false;
+
+-- 既に公開済みの議案はレビュー完了済みとする
+UPDATE bills SET is_review_completed = true WHERE publish_status = 'published';
+
+COMMENT ON COLUMN bills.is_review_completed IS '記事のレビューが完了しているかどうか（falseの場合、記事にレビュー中バナーが表示される）';

--- a/web/src/app/dev/_lib/mock-data.ts
+++ b/web/src/app/dev/_lib/mock-data.ts
@@ -18,6 +18,7 @@ const baseBill: BillWithContent = {
   status: "in_originating_house",
   originating_house: "HR",
   is_featured: false,
+  is_review_completed: true,
   thumbnail_url: null,
   share_thumbnail_url: null,
   published_at: "2026-02-15",

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -100,6 +100,9 @@
   --color-mirai-badge-yellow: #fffd96;
   --color-mirai-info-blue: #b2d3e8;
 
+  /* Review */
+  --color-mirai-review-complete: #34c759;
+
   /* Progress */
   --color-mirai-progress-track: #d9d9d9;
   --color-mirai-progress-fill: #a9e89d;

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -73,6 +73,7 @@
   --color-mirai-surface-muted: #e5e5ea;
   --color-mirai-surface-tag: #e8e8e8;
   --color-mirai-surface-warm: #eae6dd;
+  --color-mirai-surface-gray: #f6f6f6;
 
   /* Border */
   --color-mirai-border: #d2d2d2;
@@ -99,9 +100,6 @@
   --color-mirai-highlight: #f4ff5f;
   --color-mirai-badge-yellow: #fffd96;
   --color-mirai-info-blue: #b2d3e8;
-
-  /* Review */
-  --color-mirai-review-complete: #34c759;
 
   /* Progress */
   --color-mirai-progress-track: #d9d9d9;

--- a/web/src/features/bills/client/components/bill-detail/review-status-banner.tsx
+++ b/web/src/features/bills/client/components/bill-detail/review-status-banner.tsx
@@ -12,7 +12,7 @@ import {
  */
 export function ReviewInProgressBanner() {
   return (
-    <div className="flex gap-2 items-start rounded-2xl bg-mirai-surface-grouped px-4 py-2">
+    <div className="flex gap-2 items-start rounded-2xl bg-mirai-surface-gray px-4 py-2">
       <Info className="size-5 shrink-0 text-mirai-text mt-0.5" />
       <p className="text-xs font-medium leading-[1.5] text-mirai-text">
         この記事は複数有識者によるレビューが完了していません。今後内容が変更されることがあります。
@@ -29,13 +29,13 @@ export function ReviewCompleteBadge() {
     <Tooltip>
       <TooltipTrigger asChild>
         <span className="inline-flex items-center align-baseline">
-          <CircleCheck className="size-5 fill-mirai-review-complete text-white" />
+          <CircleCheck className="size-5 fill-primary text-white" />
         </span>
       </TooltipTrigger>
       <TooltipContent
         side="bottom"
         align="start"
-        className="bg-mirai-surface-grouped text-mirai-text font-medium text-xs rounded-lg px-4 py-2"
+        className="bg-mirai-surface-gray text-mirai-text font-medium text-xs rounded-lg px-4 py-2"
       >
         この記事は複数有識者によるレビューが完了しています
       </TooltipContent>

--- a/web/src/features/bills/client/components/bill-detail/review-status-banner.tsx
+++ b/web/src/features/bills/client/components/bill-detail/review-status-banner.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { CircleCheck, Info } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+/**
+ * レビュー未完了時に記事上部に表示するバナー
+ */
+export function ReviewInProgressBanner() {
+  return (
+    <div className="flex gap-2 items-start rounded-2xl bg-mirai-surface-grouped px-4 py-2">
+      <Info className="size-5 shrink-0 text-mirai-text mt-0.5" />
+      <p className="text-xs font-medium leading-[1.5] text-mirai-text">
+        この記事は複数有識者によるレビューが完了していません。今後内容が変更されることがあります。
+      </p>
+    </div>
+  );
+}
+
+/**
+ * レビュー完了時にタイトル横に表示するチェックマーク（ツールチップ付き）
+ */
+export function ReviewCompleteBadge() {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className="inline-flex items-center align-baseline">
+          <CircleCheck className="size-5 fill-mirai-review-complete text-white" />
+        </span>
+      </TooltipTrigger>
+      <TooltipContent
+        side="bottom"
+        align="start"
+        className="bg-mirai-surface-grouped text-mirai-text font-medium text-xs rounded-lg px-4 py-2"
+      >
+        この記事は複数有識者によるレビューが完了しています
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/web/src/features/bills/server/components/bill-detail/bill-detail-header.tsx
+++ b/web/src/features/bills/server/components/bill-detail/bill-detail-header.tsx
@@ -7,7 +7,10 @@ import { getInterviewLPLink } from "@/features/interview-config/shared/utils/int
 import { routes } from "@/lib/routes";
 import { formatDateWithDots } from "@/lib/utils/date";
 import { BillDetailShareButton } from "../../../client/components/bill-detail/bill-detail-share-button";
-import { ReviewCompleteBadge } from "../../../client/components/bill-detail/review-status-banner";
+import {
+  ReviewCompleteBadge,
+  ReviewInProgressBanner,
+} from "../../../client/components/bill-detail/review-status-banner";
 import { BillStatusBadge } from "../../../client/components/bill-list/bill-status-badge";
 import { BillTag } from "../../../client/components/bill-list/bill-tag";
 import { getBillShareData } from "../../../client/utils/share";
@@ -44,6 +47,12 @@ export async function BillDetailHeader({
         </div>
       ) : (
         <div className="w-full h-20 bg-white-100" />
+      )}
+
+      {!bill.is_review_completed && (
+        <div className="px-4 pt-4">
+          <ReviewInProgressBanner />
+        </div>
       )}
 
       <div className="px-4 pt-8 mb-3">

--- a/web/src/features/bills/server/components/bill-detail/bill-detail-header.tsx
+++ b/web/src/features/bills/server/components/bill-detail/bill-detail-header.tsx
@@ -7,6 +7,7 @@ import { getInterviewLPLink } from "@/features/interview-config/shared/utils/int
 import { routes } from "@/lib/routes";
 import { formatDateWithDots } from "@/lib/utils/date";
 import { BillDetailShareButton } from "../../../client/components/bill-detail/bill-detail-share-button";
+import { ReviewCompleteBadge } from "../../../client/components/bill-detail/review-status-banner";
 import { BillStatusBadge } from "../../../client/components/bill-list/bill-status-badge";
 import { BillTag } from "../../../client/components/bill-list/bill-tag";
 import { getBillShareData } from "../../../client/utils/share";
@@ -47,7 +48,15 @@ export async function BillDetailHeader({
 
       <div className="px-4 pt-8 mb-3">
         {displayTitle && (
-          <h1 className="text-2xl font-bold mb-3">{displayTitle}</h1>
+          <h1 className="text-2xl font-bold mb-3">
+            {displayTitle}
+            {bill.is_review_completed && (
+              <>
+                {" "}
+                <ReviewCompleteBadge />
+              </>
+            )}
+          </h1>
         )}
         <div className="flex flex-row gap-4">
           <BillStatusBadge status={bill.status} className="w-fit" />

--- a/web/src/features/bills/server/components/bill-detail/bill-detail-layout.tsx
+++ b/web/src/features/bills/server/components/bill-detail/bill-detail-layout.tsx
@@ -8,6 +8,7 @@ import { BillDetailClient } from "../../../client/components/bill-detail/bill-de
 import { BillDisclaimer } from "../../../client/components/bill-detail/bill-disclaimer";
 import { BillStatusProgress } from "../../../client/components/bill-detail/bill-status-progress";
 import { MiraiStanceCard } from "../../../client/components/bill-detail/mirai-stance-card";
+import { ReviewInProgressBanner } from "../../../client/components/bill-detail/review-status-banner";
 import type { BillWithContent } from "../../../shared/types";
 import { BillShareButtons } from "../share/bill-share-buttons";
 import { BillContent } from "./bill-content";
@@ -36,6 +37,11 @@ export async function BillDetailLayout({
         - BillDetailClientでクライアントサイド機能（テキスト選択、チャット連携）を提供
         - このパターンによりSSRを保持しつつインタラクティブ機能を実装
       */}
+      {!bill.is_review_completed && (
+        <div className="px-4 pt-4">
+          <ReviewInProgressBanner />
+        </div>
+      )}
       <BillDetailClient
         bill={bill}
         currentDifficulty={currentDifficulty}

--- a/web/src/features/bills/server/components/bill-detail/bill-detail-layout.tsx
+++ b/web/src/features/bills/server/components/bill-detail/bill-detail-layout.tsx
@@ -8,7 +8,6 @@ import { BillDetailClient } from "../../../client/components/bill-detail/bill-de
 import { BillDisclaimer } from "../../../client/components/bill-detail/bill-disclaimer";
 import { BillStatusProgress } from "../../../client/components/bill-detail/bill-status-progress";
 import { MiraiStanceCard } from "../../../client/components/bill-detail/mirai-stance-card";
-import { ReviewInProgressBanner } from "../../../client/components/bill-detail/review-status-banner";
 import type { BillWithContent } from "../../../shared/types";
 import { BillShareButtons } from "../share/bill-share-buttons";
 import { BillContent } from "./bill-content";
@@ -37,11 +36,6 @@ export async function BillDetailLayout({
         - BillDetailClientでクライアントサイド機能（テキスト選択、チャット連携）を提供
         - このパターンによりSSRを保持しつつインタラクティブ機能を実装
       */}
-      {!bill.is_review_completed && (
-        <div className="px-4 pt-4">
-          <ReviewInProgressBanner />
-        </div>
-      )}
       <BillDetailClient
         bill={bill}
         currentDifficulty={currentDifficulty}

--- a/web/src/features/interview-session/shared/utils/build-summary-system-prompt.test.ts
+++ b/web/src/features/interview-session/shared/utils/build-summary-system-prompt.test.ts
@@ -11,6 +11,7 @@ const makeBill = (
   id: "bill-1",
   name: "テスト法案",
   is_featured: false,
+  is_review_completed: true,
   originating_house: "HR",
   shugiin_url: null,
   diet_session_id: null,

--- a/web/src/features/interview-session/shared/utils/interview-logic/bulk-mode.test.ts
+++ b/web/src/features/interview-session/shared/utils/interview-logic/bulk-mode.test.ts
@@ -15,6 +15,7 @@ const makeBill = (
   id: "bill-1",
   name: "テスト法案",
   is_featured: false,
+  is_review_completed: true,
   originating_house: "HR",
   shugiin_url: null,
   diet_session_id: null,

--- a/web/src/features/interview-session/shared/utils/interview-logic/loop-mode.test.ts
+++ b/web/src/features/interview-session/shared/utils/interview-logic/loop-mode.test.ts
@@ -15,6 +15,7 @@ const makeBill = (
   id: "bill-1",
   name: "テスト法案",
   is_featured: false,
+  is_review_completed: true,
   originating_house: "HR",
   shugiin_url: null,
   diet_session_id: null,


### PR DESCRIPTION
## Summary
- `bills` テーブルに `is_review_completed` カラムを追加（デフォルト: `false`、既存の公開済み議案は `true` に設定）
- レビュー未完了時: 記事ヘッダー上部にインフォバナー「この記事は複数有識者によるレビューが完了していません。今後内容が変更されることがあります。」を表示
- レビュー完了時: タイトル末尾に緑チェックマーク（ホバー/タップでツールチップ「この記事は複数有識者によるレビューが完了しています」を表示）
- TOPページのカード一覧（BillCard・CompactBillCard）にもレビュー完了バッジを表示
- admin: 議案編集フォームに「記事レビュー完了」チェックボックスを追加

## スクリーンショット

| レビュー中 | レビュー完了 | ツールチップ | カード一覧 |
|:---:|:---:|:---:|:---:|
| <img src="https://pub-d6de2fb179d948d18c6b1ed89fcf1061.r2.dev/pr-735/review-in-progress.png?v=1775537124" width="200" /> | <img src="https://pub-d6de2fb179d948d18c6b1ed89fcf1061.r2.dev/pr-735/review-completed.png?v=1775537124" width="200" /> | <img src="https://pub-d6de2fb179d948d18c6b1ed89fcf1061.r2.dev/pr-735/review-tooltip.png?v=1775537124" width="200" /> | <img src="https://pub-d6de2fb179d948d18c6b1ed89fcf1061.r2.dev/pr-735/top-card-badge.png?v=1775537124" width="200" /> |

## Test plan
- [x] `pnpm lint` — PASS
- [x] `pnpm typecheck` — PASS
- [x] `pnpm build` — PASS（web, admin）
- [x] `pnpm test` — 744 tests PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)