### PR TITLE
CLAUDE.md: Figma実装時の値取得ルールを追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,7 @@ Repository レイヤーの詳細は [docs/repository-layer.md](docs/repository-l
 - **アイコン**: インラインSVGは禁止です。必ず `lucide-react` からアイコンコンポーネントをインポートして使用してください。
 - **ボタン**: `<button>` タグの使用は禁止です。必ず `@/components/ui/button` の `Button` コンポーネントを使用してください。
 - **色**: インラインカラーコード（`text-[#xxx]`, `bg-[#xxx]`, `border-[#xxx]` 等の arbitrary value や style 属性での直接指定）は**禁止**です。必ず `globals.css` の `@theme inline` で定義済みのカラートークン（`text-mirai-text`, `bg-primary`, `border-primary-accent` 等）を使用してください。新しい色が必要な場合は、まず `globals.css` にトークンを追加してから使用すること。既存トークン一覧は `web/src/app/globals.css` の `@theme inline` ブロックを参照。
+- **Figma実装**: FigmaのURLからUIを実装する際、スクリーンショットだけで色やサイズを推測しないこと。必ず `get_variable_defs` や `get_design_context` でカラーコード・フォントサイズ・スペーシング等の正確な値を取得し、既存のデザイントークンとの対応を確認してから実装する。
 
 ### admin 内部ルート定義
 - admin アプリの内部リンク（Link href, router.push, redirect）には `@/lib/routes` の関数を使用すること。文字列リテラルでのルート直書きは禁止。


### PR DESCRIPTION
## 仕組み化サマリ

### コード修正
- [x] チェックマークの色を `#34C759` → `#2AA693`（primary/main）に修正（PR #735）
- [x] バナー/ツールチップ背景を `#F2F2F7` → `#F6F6F6`（GRAY）に修正（PR #735）

### 仕組み化した項目
| 指摘 | 対応 | 追加先 |
|------|------|--------|
| Figma実装時にスクショだけで色を推測した | CLAUDE.mdにルール追加 | `CLAUDE.md` Coding Style セクション |

### ルール内容
> **Figma実装**: FigmaのURLからUIを実装する際、スクリーンショットだけで色やサイズを推測しないこと。必ず `get_variable_defs` や `get_design_context` でカラーコード・フォントサイズ・スペーシング等の正確な値を取得し、既存のデザイントークンとの対応を確認してから実装する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)