### PR TITLE
docs: CLAUDE.mdがAGENTS.mdへのシンボリックリンクである旨を明記

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 # Repository Guidelines
 
+> **Note**: `CLAUDE.md` は `AGENTS.md` へのシンボリックリンクです。ルールの追加・編集は必ず `AGENTS.md` を直接編集してください。
+
 ## 必須ルール
 
 ### Worktree必須


### PR DESCRIPTION
## Summary
- `AGENTS.md` の冒頭に、`CLAUDE.md` が `AGENTS.md` へのシンボリックリンクであることを明記するノートを追加
- ルールの追加・編集時に `AGENTS.md` を直接編集するよう案内

## Test plan
- [x] ドキュメント変更のみのため、ビルド・テストへの影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)