### PR TITLE
TOPページのカード一覧にレビュー完了バッジを追加

### DIFF
--- a/web/src/features/bills/client/components/bill-list/bill-card.tsx
+++ b/web/src/features/bills/client/components/bill-list/bill-card.tsx
@@ -3,6 +3,7 @@ import { RubySafeLineClamp } from "@/components/ruby-safe-line-clamp";
 import { Card, CardHeader, CardTitle } from "@/components/ui/card";
 import { formatDateWithDots } from "@/lib/utils/date";
 import type { BillWithContent } from "../../../shared/types";
+import { ReviewCompleteBadge } from "../bill-detail/review-status-banner";
 import { BillStatusBadge } from "./bill-status-badge";
 import { BillTag } from "./bill-tag";
 
@@ -47,6 +48,12 @@ export function BillCard({ bill }: BillCardProps) {
             <div className="flex flex-col gap-3">
               <CardTitle className="text-2xl/8 tracking-normal">
                 {displayTitle}
+                {bill.is_review_completed && (
+                  <>
+                    {" "}
+                    <ReviewCompleteBadge />
+                  </>
+                )}
               </CardTitle>
               <div className="flex flex-row gap-4">
                 <BillStatusBadge status={bill.status} className="w-fit" />

--- a/web/src/features/bills/client/components/bill-list/compact-bill-card.tsx
+++ b/web/src/features/bills/client/components/bill-list/compact-bill-card.tsx
@@ -2,6 +2,7 @@ import Image from "next/image";
 import { Card } from "@/components/ui/card";
 import { formatDateWithDots } from "@/lib/utils/date";
 import type { BillWithContent } from "../../../shared/types";
+import { ReviewCompleteBadge } from "../bill-detail/review-status-banner";
 import { BillStatusBadge } from "./bill-status-badge";
 
 interface CompactBillCardProps {
@@ -26,6 +27,12 @@ export function CompactBillCard({ bill, className }: CompactBillCardProps) {
         <div className="flex-1 p-4 flex flex-col gap-2">
           <h3 className="font-bold text-[15px] leading-[1.6] line-clamp-2">
             {displayTitle}
+            {bill.is_review_completed && (
+              <>
+                {" "}
+                <ReviewCompleteBadge />
+              </>
+            )}
           </h3>
           <div className="flex items-center gap-3">
             <BillStatusBadge status={bill.status} className="w-fit" />


### PR DESCRIPTION
## Summary
- BillCard（通常カード）・CompactBillCard（コンパクトカード）のタイトル横に、レビュー完了時の緑チェックマークバッジを表示
- #735 で追加した `is_review_completed` フラグを利用

## スクリーンショット

| カード一覧（レビュー完了あり） |
|:---:|
| <img src="https://pub-d6de2fb179d948d18c6b1ed89fcf1061.r2.dev/pr-735/top-card-badge.png" width="300" /> |

## Test plan
- [x] `pnpm lint` — PASS
- [x] `pnpm typecheck` — PASS
- [x] `pnpm build` — PASS
- [x] `pnpm test` — 744 tests PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能
* 請求書カードにレビュー完了バッジを追加。レビュー完了済みの請求書には、バッジが表示されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->