### PR TITLE
レビューステータスバナーの文言を調整

### DIFF
--- a/web/src/features/bills/client/components/bill-detail/review-status-banner.tsx
+++ b/web/src/features/bills/client/components/bill-detail/review-status-banner.tsx
@@ -15,7 +15,7 @@ export function ReviewInProgressBanner() {
     <div className="flex gap-2 items-start rounded-2xl bg-mirai-surface-gray px-4 py-2">
       <Info className="size-5 shrink-0 text-mirai-text mt-0.5" />
       <p className="text-xs font-medium leading-[1.5] text-mirai-text">
-        この記事は複数有識者によるレビューが完了していません。今後内容が変更されることがあります。
+        この記事は現在、複数有識者によるレビュー中です。今後内容が変更されることがあります。
       </p>
     </div>
   );


### PR DESCRIPTION
## Summary
- レビュー未完了時のバナー文言を「この記事は複数有識者によるレビューが完了していません」から「この記事は現在、複数有識者によるレビュー中です」に変更
- より自然で柔らかい表現に調整

## Test plan
- [x] `pnpm lint` 通過
- [x] `pnpm typecheck` 通過
- [ ] 法案記事のレビュー未完了状態でバナー文言が正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * レビューステータスバナーの表示テキストを更新しました。「レビュー未完了」から「現在レビュー中」へ状態表示を変更し、より正確なレビュー進行状況を表示するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->