### PR TITLE
ルビON時にボタン内のルビを非表示にしてUI崩れを修正

### DIFF
--- a/web/src/features/interview-config/client/components/interview-action-buttons.tsx
+++ b/web/src/features/interview-config/client/components/interview-action-buttons.tsx
@@ -38,8 +38,11 @@ export function InterviewActionButtons({
 
     return (
       <>
-        <Link href={chatLink as Route}>
-          <Button className="w-full bg-mirai-gradient text-black border border-black rounded-[100px] h-[48px] px-6 font-bold text-[15px] hover:opacity-90 transition-opacity flex items-center justify-center gap-4">
+        <Button
+          asChild
+          className="w-full bg-mirai-gradient text-black border border-black rounded-[100px] h-[48px] px-6 font-bold text-[15px] hover:opacity-90 transition-opacity flex items-center justify-center gap-4"
+        >
+          <Link href={chatLink as Route}>
             <Image
               src="/icons/messages-square-icon.svg"
               alt=""
@@ -49,8 +52,8 @@ export function InterviewActionButtons({
             />
             <span>AIインタビューを再開する</span>
             <ArrowRight className="size-5" />
-          </Button>
-        </Link>
+          </Link>
+        </Button>
         <RestartInterviewButton
           sessionId={sessionInfo.id}
           billId={billId}

--- a/web/src/lib/rubyful/styles.css
+++ b/web/src/lib/rubyful/styles.css
@@ -11,3 +11,9 @@ rt {
   -webkit-user-select: none;
   -moz-user-select: none;
 }
+
+/* ボタン内のルビを非表示（固定高さのボタンレイアウトが崩れるため） */
+button rt,
+[data-slot="button"] rt {
+  display: none;
+}

--- a/web/src/lib/rubyful/styles.css
+++ b/web/src/lib/rubyful/styles.css
@@ -13,7 +13,7 @@ rt {
 }
 
 /* ボタン内のルビを非表示（固定高さのボタンレイアウトが崩れるため） */
-button rt,
-[data-slot="button"] rt {
+button .rubyful-rt,
+[data-slot="button"] .rubyful-rt {
   display: none;
 }


### PR DESCRIPTION
## Summary
- ルビ（ふりがな）をONにすると、Rubyful V2がボタン内の`<span>`にも`<ruby>`+`<rt>`タグを追加し、固定高さのボタンレイアウトが崩れる問題を修正
- `button .rubyful-rt` および `[data-slot="button"] .rubyful-rt` に `display: none` を適用し、ボタン内ではルビを非表示にする
- 「AIインタビューを再開する」ボタンの `<Link><Button>` ネストを `<Button asChild><Link>` パターンに修正し、`<a>` タグに `data-slot="button"` が正しく付与されるようにした

Resolves GIKAI-305

## スクリーンショット

### インタビュー再開ボタン（ルビON・修正後）
| 再開ボタン表示 |
|:---:|
| <img src="https://pub-d6de2fb179d948d18c6b1ed89fcf1061.r2.dev/pr-741/screenshot-5-resume-fixed.png" width="350" /> |

## Test plan
- [x] `pnpm lint` 通過
- [x] `pnpm typecheck` 通過
- [x] `pnpm build` 通過
- [x] `pnpm test` 通過（744テスト全通過）
- [x] ルビをONにした状態でインタビュー再開ボタンのUIが崩れないことを確認
- [x] DOM検証: `data-slot="button"` が `<a>` タグに付与され、`.rubyful-rt` の `display: none` が効いていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **スタイル**
  * ボタン内のルビ文字注釈が表示されなくなりました。

* **リファクタリング**
  * インタビュー再開アクションボタンのコンポーネント構造を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->