### PR TITLE
adminにGoogleログイン機能を追加

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,3 +29,10 @@ CHAT_MONTHLY_TOTAL_COST_LIMIT_USD=
 # --- Admin ---
 # WebサーバーのURLを設定してください
 NEXT_PUBLIC_WEB_URL=http://localhost:3000
+
+# --- Supabase Auth (Google OAuth) ---
+# Google OAuth用の設定（本番・staging環境で必要）
+SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID=
+SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET=
+# OAuthコールバックURL（config.tomlのadditional_redirect_urlsで参照）
+ADMIN_AUTH_CALLBACK_URL=http://localhost:3001/api/auth/callback

--- a/admin/src/app/api/auth/callback/route.ts
+++ b/admin/src/app/api/auth/callback/route.ts
@@ -1,0 +1,56 @@
+import type { Database } from "@mirai-gikai/supabase";
+import { createServerClient } from "@supabase/ssr";
+import { type NextRequest, NextResponse } from "next/server";
+import { checkAdminPermission } from "@/lib/auth/permissions";
+import { env } from "@/lib/env";
+import { routes } from "@/lib/routes";
+
+export async function GET(request: NextRequest) {
+  const { searchParams, origin } = new URL(request.url);
+  const code = searchParams.get("code");
+
+  if (!code) {
+    return NextResponse.redirect(
+      `${origin}${routes.login()}?error=missing_code`
+    );
+  }
+
+  const response = NextResponse.redirect(`${origin}${routes.bills()}`);
+
+  const supabase = createServerClient<Database>(
+    env.supabaseUrl,
+    env.supabaseAnonKey,
+    {
+      cookies: {
+        getAll() {
+          return request.cookies.getAll();
+        },
+        setAll(cookiesToSet) {
+          for (const { name, value, options } of cookiesToSet) {
+            response.cookies.set(name, value, options);
+          }
+        },
+      },
+    }
+  );
+
+  const { error } = await supabase.auth.exchangeCodeForSession(code);
+
+  if (error) {
+    return NextResponse.redirect(`${origin}${routes.login()}?error=auth_error`);
+  }
+
+  // admin 権限チェック: 権限がなければサインアウトしてログインページにリダイレクト
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user || !checkAdminPermission(user)) {
+    await supabase.auth.signOut();
+    return NextResponse.redirect(
+      `${origin}${routes.login()}?error=unauthorized`
+    );
+  }
+
+  return response;
+}

--- a/admin/src/app/api/auth/callback/route.ts
+++ b/admin/src/app/api/auth/callback/route.ts
@@ -1,9 +1,7 @@
-import type { Database } from "@mirai-gikai/supabase";
-import { createServerClient } from "@supabase/ssr";
 import { type NextRequest, NextResponse } from "next/server";
 import { checkAdminPermission } from "@/lib/auth/permissions";
-import { env } from "@/lib/env";
 import { routes } from "@/lib/routes";
+import { createAuthClient } from "@/lib/supabase/auth";
 
 export async function GET(request: NextRequest) {
   const { searchParams, origin } = new URL(request.url);
@@ -15,60 +13,24 @@ export async function GET(request: NextRequest) {
     );
   }
 
-  const response = NextResponse.redirect(`${origin}${routes.bills()}`);
-
-  const supabase = createServerClient<Database>(
-    env.supabaseUrl,
-    env.supabaseAnonKey,
-    {
-      cookies: {
-        getAll() {
-          return request.cookies.getAll();
-        },
-        setAll(cookiesToSet) {
-          for (const { name, value, options } of cookiesToSet) {
-            response.cookies.set(name, value, options);
-          }
-        },
-      },
-    }
-  );
-
-  const { error } = await supabase.auth.exchangeCodeForSession(code);
+  const auth = await createAuthClient();
+  const { error } = await auth.exchangeCodeForSession(code);
 
   if (error) {
-    return redirectWithCookies(
-      response,
-      `${origin}${routes.login()}?error=auth_error`
-    );
+    return NextResponse.redirect(`${origin}${routes.login()}?error=auth_error`);
   }
 
   // admin 権限チェック: 権限がなければサインアウトしてログインページにリダイレクト
   const {
     data: { user },
-  } = await supabase.auth.getUser();
+  } = await auth.getUser();
 
   if (!user || !checkAdminPermission(user)) {
-    await supabase.auth.signOut();
-    return redirectWithCookies(
-      response,
+    await auth.signOut();
+    return NextResponse.redirect(
       `${origin}${routes.login()}?error=unauthorized`
     );
   }
 
-  return response;
-}
-
-/**
- * response に蓄積された Set-Cookie を新しいリダイレクト先に引き継ぐ
- */
-function redirectWithCookies(
-  source: NextResponse,
-  location: string
-): NextResponse {
-  const redirect = NextResponse.redirect(location);
-  for (const cookie of source.cookies.getAll()) {
-    redirect.cookies.set(cookie);
-  }
-  return redirect;
+  return NextResponse.redirect(`${origin}${routes.bills()}`);
 }

--- a/admin/src/app/api/auth/callback/route.ts
+++ b/admin/src/app/api/auth/callback/route.ts
@@ -37,7 +37,10 @@ export async function GET(request: NextRequest) {
   const { error } = await supabase.auth.exchangeCodeForSession(code);
 
   if (error) {
-    return NextResponse.redirect(`${origin}${routes.login()}?error=auth_error`);
+    return redirectWithCookies(
+      response,
+      `${origin}${routes.login()}?error=auth_error`
+    );
   }
 
   // admin 権限チェック: 権限がなければサインアウトしてログインページにリダイレクト
@@ -47,10 +50,25 @@ export async function GET(request: NextRequest) {
 
   if (!user || !checkAdminPermission(user)) {
     await supabase.auth.signOut();
-    return NextResponse.redirect(
+    return redirectWithCookies(
+      response,
       `${origin}${routes.login()}?error=unauthorized`
     );
   }
 
   return response;
+}
+
+/**
+ * response に蓄積された Set-Cookie を新しいリダイレクト先に引き継ぐ
+ */
+function redirectWithCookies(
+  source: NextResponse,
+  location: string
+): NextResponse {
+  const redirect = NextResponse.redirect(location);
+  for (const cookie of source.cookies.getAll()) {
+    redirect.cookies.set(cookie);
+  }
+  return redirect;
 }

--- a/admin/src/features/auth/client/components/login-form.tsx
+++ b/admin/src/features/auth/client/components/login-form.tsx
@@ -3,6 +3,7 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { AlertCircle } from "lucide-react";
 import { useSearchParams } from "next/navigation";
+import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { Button } from "@/components/ui/button";
 import {
@@ -17,10 +18,13 @@ import { Input } from "@/components/ui/input";
 
 import { type LoginFormData, loginSchema } from "../../shared/types";
 import { useLogin } from "../hooks/use-login";
+import { signInWithGoogle } from "../lib/auth-client";
 
 export function LoginForm() {
   const searchParams = useSearchParams();
   const { login, isLoading, error } = useLogin();
+  const [isGoogleLoading, setIsGoogleLoading] = useState(false);
+  const [googleError, setGoogleError] = useState<string | null>(null);
 
   const form = useForm<LoginFormData>({
     resolver: zodResolver(loginSchema),
@@ -36,65 +40,129 @@ export function LoginForm() {
     login(values);
   };
 
+  const handleGoogleLogin = async () => {
+    try {
+      setGoogleError(null);
+      setIsGoogleLoading(true);
+      await signInWithGoogle();
+    } catch (err) {
+      setGoogleError(
+        err instanceof Error ? err.message : "Googleログインに失敗しました。"
+      );
+      setIsGoogleLoading(false);
+    }
+  };
+
+  const displayError = error || googleError;
+
   return (
-    <Form {...form}>
-      <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-4">
-        <FormField
-          control={form.control}
-          name="email"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>メールアドレス</FormLabel>
-              <FormControl>
-                <Input
-                  type="email"
-                  autoComplete="email"
-                  placeholder="admin@example.com"
-                  disabled={isLoading}
-                  {...field}
-                />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
+    <div className="space-y-6">
+      <Button
+        type="button"
+        variant="outline"
+        className="w-full"
+        onClick={handleGoogleLogin}
+        disabled={isLoading || isGoogleLoading}
+      >
+        <GoogleIcon />
+        {isGoogleLoading ? "リダイレクト中..." : "Googleでログイン"}
+      </Button>
+
+      <div className="relative">
+        <div className="absolute inset-0 flex items-center">
+          <span className="w-full border-t" />
+        </div>
+        <div className="relative flex justify-center text-xs uppercase">
+          <span className="bg-card px-2 text-muted-foreground">または</span>
+        </div>
+      </div>
+
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-4">
+          <FormField
+            control={form.control}
+            name="email"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>メールアドレス</FormLabel>
+                <FormControl>
+                  <Input
+                    type="email"
+                    autoComplete="email"
+                    placeholder="admin@example.com"
+                    disabled={isLoading || isGoogleLoading}
+                    {...field}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="password"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>パスワード</FormLabel>
+                <FormControl>
+                  <Input
+                    type="password"
+                    autoComplete="current-password"
+                    placeholder="••••••••"
+                    disabled={isLoading || isGoogleLoading}
+                    {...field}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          {(displayError || urlError) && (
+            <div className="flex items-center space-x-2 p-3 text-sm text-red-800 bg-red-50 border border-red-200 rounded-md">
+              <AlertCircle className="h-4 w-4" />
+              <span>
+                {displayError ||
+                  (urlError === "unauthorized"
+                    ? "管理者権限がありません"
+                    : "認証エラーが発生しました")}
+              </span>
+            </div>
           )}
-        />
 
-        <FormField
-          control={form.control}
-          name="password"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>パスワード</FormLabel>
-              <FormControl>
-                <Input
-                  type="password"
-                  autoComplete="current-password"
-                  placeholder="••••••••"
-                  disabled={isLoading}
-                  {...field}
-                />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
+          <Button
+            type="submit"
+            className="w-full"
+            disabled={isLoading || isGoogleLoading}
+          >
+            {isLoading ? "ログイン中..." : "メールアドレスでログイン"}
+          </Button>
+        </form>
+      </Form>
+    </div>
+  );
+}
 
-        {(error || urlError) && (
-          <div className="flex items-center space-x-2 p-3 text-sm text-red-800 bg-red-50 border border-red-200 rounded-md">
-            <AlertCircle className="h-4 w-4" />
-            <span>
-              {error ||
-                (urlError === "unauthorized"
-                  ? "管理者権限がありません"
-                  : "認証エラーが発生しました")}
-            </span>
-          </div>
-        )}
-
-        <Button type="submit" className="w-full" disabled={isLoading}>
-          {isLoading ? "ログイン中..." : "ログイン"}
-        </Button>
-      </form>
-    </Form>
+function GoogleIcon() {
+  return (
+    <svg className="mr-2 h-4 w-4" viewBox="0 0 24 24" aria-hidden="true">
+      <path
+        d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
+        fill="#4285F4"
+      />
+      <path
+        d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+        fill="#34A853"
+      />
+      <path
+        d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+        fill="#FBBC05"
+      />
+      <path
+        d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+        fill="#EA4335"
+      />
+    </svg>
   );
 }

--- a/admin/src/features/auth/client/lib/auth-client.ts
+++ b/admin/src/features/auth/client/lib/auth-client.ts
@@ -25,6 +25,19 @@ export async function signIn(email: string, password: string) {
   return data;
 }
 
+export async function signInWithGoogle() {
+  const { error } = await authClient.signInWithOAuth({
+    provider: "google",
+    options: {
+      redirectTo: `${window.location.origin}/api/auth/callback`,
+    },
+  });
+
+  if (error) {
+    throw new Error("Googleログインに失敗しました。");
+  }
+}
+
 export async function signOut() {
   const { error } = await authClient.signOut();
   if (error) {

--- a/admin/src/middleware.ts
+++ b/admin/src/middleware.ts
@@ -6,6 +6,11 @@ import { updateSession } from "@/lib/supabase/middleware";
 export async function middleware(request: NextRequest) {
   const { supabaseResponse, user } = await updateSession(request);
 
+  // OAuth コールバックはそのまま通す（Route Handler で処理する）
+  if (request.nextUrl.pathname === "/api/auth/callback") {
+    return supabaseResponse;
+  }
+
   // ログインページへのアクセスで、既にログイン済みの場合
   if (request.nextUrl.pathname === "/login") {
     if (user && checkAdminPermission(user)) {

--- a/docs/20260407_1800_adminGoogleログイン設定手順.md
+++ b/docs/20260407_1800_adminGoogleログイン設定手順.md
@@ -14,13 +14,12 @@ admin アプリに Google ログインを導入するための GCP 設定手順�
 2. 対象プロジェクトを選択（なければ新規作成）
 3. **APIs & Services > OAuth consent screen** に移動
 4. 以下を設定:
-   - **User Type**: `Internal`（組織内ユーザーのみの場合）または `External`
+   - **User Type**: `Internal`（Google Workspace 組織内ユーザーのみ）
    - **App name**: `みらい議会 Admin`
    - **User support email**: 管理者メールアドレス
    - **Authorized domains**: admin アプリのドメイン（例: `vercel.app`）
    - **Developer contact email**: 管理者メールアドレス
 5. **Scopes** で `email` と `profile` を追加
-6. `External` の場合、**Test users** に許可するメールアドレスを追加（本番公開前）
 
 ## 2. OAuth クライアント ID の作成
 

--- a/docs/20260407_1800_adminGoogleログイン設定手順.md
+++ b/docs/20260407_1800_adminGoogleログイン設定手順.md
@@ -1,0 +1,102 @@
+# admin Google ログイン設定手順
+
+admin アプリに Google ログインを導入するための GCP 設定手順。
+
+## 前提
+
+- Google Cloud Console へのアクセス権があること
+- Supabase Dashboard へのアクセス権があること
+- 対象環境（staging / production）の GitHub Secrets を編集できること
+
+## 1. GCP OAuth 同意画面の設定
+
+1. [Google Cloud Console](https://console.cloud.google.com/) にアクセス
+2. 対象プロジェクトを選択（なければ新規作成）
+3. **APIs & Services > OAuth consent screen** に移動
+4. 以下を設定:
+   - **User Type**: `Internal`（組織内ユーザーのみの場合）または `External`
+   - **App name**: `みらい議会 Admin`
+   - **User support email**: 管理者メールアドレス
+   - **Authorized domains**: admin アプリのドメイン（例: `vercel.app`）
+   - **Developer contact email**: 管理者メールアドレス
+5. **Scopes** で `email` と `profile` を追加
+6. `External` の場合、**Test users** に許可するメールアドレスを追加（本番公開前）
+
+## 2. OAuth クライアント ID の作成
+
+1. **APIs & Services > Credentials** に移動
+2. **Create Credentials > OAuth client ID** をクリック
+3. 以下を設定:
+   - **Application type**: `Web application`
+   - **Name**: `みらい議会 Admin - <環境名>`（例: `みらい議会 Admin - Production`）
+   - **Authorized JavaScript origins**:
+     - ローカル: `http://localhost:3001`
+     - staging: `https://<staging-admin-domain>`
+     - production: `https://<production-admin-domain>`
+   - **Authorized redirect URIs**:
+     - `https://<supabase-project-ref>.supabase.co/auth/v1/callback`
+     - ローカル開発用: `http://127.0.0.1:54421/auth/v1/callback`
+4. **Create** をクリック
+5. 表示される **Client ID** と **Client Secret** を控える
+
+> **注意**: Authorized redirect URIs は admin アプリの URL ではなく、**Supabase の Auth エンドポイント** を指定する。Supabase が Google との OAuth フローを仲介し、その後 admin アプリの `/api/auth/callback` にリダイレクトする。
+
+## 3. 環境変数の設定
+
+### ローカル開発
+
+`.env` に以下を追加:
+
+```env
+SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID=<GCPで取得したClient ID>
+SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET=<GCPで取得したClient Secret>
+```
+
+設定後、Supabase を再起動:
+
+```bash
+npx supabase stop
+npx supabase start
+```
+
+### staging / production
+
+GitHub リポジトリの **Settings > Environments** で、各環境に以下の Secrets を追加:
+
+| Secret 名 | 値 |
+|---|---|
+| `SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID` | GCP で取得した Client ID |
+| `SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET` | GCP で取得した Client Secret |
+| `ADMIN_AUTH_CALLBACK_URL` | `https://<admin-domain>/api/auth/callback` |
+
+`ADMIN_AUTH_CALLBACK_URL` は `supabase/config.toml` の `additional_redirect_urls` で `env()` 経由で参照される。
+
+## 4. Supabase Dashboard での確認（本番のみ）
+
+`supabase config push` で `config.toml` の設定がリモートに反映されるが、念のため Supabase Dashboard でも確認:
+
+1. **Authentication > Providers > Google** が Enabled になっていること
+2. Client ID と Client Secret が正しく設定されていること
+3. **Authentication > URL Configuration > Redirect URLs** に admin のコールバック URL が含まれていること
+
+## 5. 動作確認
+
+1. admin アプリのログインページにアクセス
+2. 「Google でログイン」ボタンが表示されることを確認
+3. ボタンをクリックし、Google アカウント選択画面が表示されることを確認
+4. ログイン後、admin 権限のあるユーザーはダッシュボードにリダイレクトされることを確認
+5. admin 権限のないユーザーはログインページに `管理者権限がありません` エラーで戻されることを確認
+
+## トラブルシューティング
+
+### ローカルで Google ログインボタンを押しても反応しない
+
+`SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID` が未設定の可能性がある。`.env` に設定後、`npx supabase stop && npx supabase start` で再起動する。
+
+### `redirect_uri_mismatch` エラー
+
+GCP の **Authorized redirect URIs** に Supabase の Auth コールバック URL が登録されていない。`https://<supabase-project-ref>.supabase.co/auth/v1/callback` を追加する。
+
+### ログイン後に `unauthorized` エラー
+
+Google アカウントに admin 権限（`app_metadata.roles` に `"admin"` を含む）が付与されていない。Supabase Dashboard の **Authentication > Users** で対象ユーザーの `app_metadata` を確認・更新する。

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -119,7 +119,7 @@ enabled = true
 # in emails.
 site_url = "http://127.0.0.1:3000"
 # A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
-additional_redirect_urls = ["https://127.0.0.1:3000"]
+additional_redirect_urls = ["https://127.0.0.1:3000", "http://127.0.0.1:3001/api/auth/callback", "http://localhost:3001/api/auth/callback"]
 # How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
 jwt_expiry = 3600
 # Path to JWT signing key. DO NOT commit your signing keys file to git.
@@ -272,6 +272,14 @@ redirect_uri = ""
 url = ""
 # If enabled, the nonce check will be skipped. Required for local sign in with Google auth.
 skip_nonce_check = false
+
+[auth.external.google]
+enabled = true
+client_id = "env(SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID)"
+secret = "env(SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET)"
+redirect_uri = ""
+url = ""
+skip_nonce_check = true
 
 # Allow Solana wallet holders to sign in to your project via the Sign in with Solana (SIWS, EIP-4361) standard.
 # You can configure "web3" rate limit in the [auth.rate_limit] section and set up [auth.captcha] if self-hosting.

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -119,7 +119,7 @@ enabled = true
 # in emails.
 site_url = "http://127.0.0.1:3000"
 # A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
-additional_redirect_urls = ["https://127.0.0.1:3000", "http://127.0.0.1:3001/api/auth/callback", "http://localhost:3001/api/auth/callback"]
+additional_redirect_urls = ["https://127.0.0.1:3000", "http://127.0.0.1:3001/api/auth/callback", "http://localhost:3001/api/auth/callback", "env(ADMIN_AUTH_CALLBACK_URL)"]
 # How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
 jwt_expiry = 3600
 # Path to JWT signing key. DO NOT commit your signing keys file to git.

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -279,7 +279,7 @@ client_id = "env(SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID)"
 secret = "env(SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET)"
 redirect_uri = ""
 url = ""
-skip_nonce_check = true
+skip_nonce_check = false
 
 # Allow Solana wallet holders to sign in to your project via the Sign in with Solana (SIWS, EIP-4361) standard.
 # You can configure "web3" rate limit in the [auth.rate_limit] section and set up [auth.captcha] if self-hosting.


### PR DESCRIPTION
## Summary
- Supabase config.toml に Google OAuth provider 設定を追加
- OAuth コールバック用 Route Handler（`/api/auth/callback`）を作成し、セッション交換後に admin 権限チェックを実施
- ログインフォームに Google ログインボタンを追加（メール/パスワードログインとの「または」区切り付き）
- ミドルウェアで OAuth コールバックルートを認証チェックから除外

## 環境変数
本番環境で以下の環境変数の設定が必要:
- `SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID` - Google OAuth クライアントID
- `SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET` - Google OAuth クライアントシークレット

また、Supabase Dashboard の Auth > URL Configuration で `additional_redirect_urls` に本番の admin URL（`https://<admin-domain>/api/auth/callback`）を追加する必要があります。

## スクリーンショット

| モバイル (390x844) | デスクトップ (1280x800) |
|:---:|:---:|
| <img src="https://pub-d6de2fb179d948d18c6b1ed89fcf1061.r2.dev/pr-744/login-mobile.png" width="250" /> | <img src="https://pub-d6de2fb179d948d18c6b1ed89fcf1061.r2.dev/pr-744/login-desktop.png" width="350" /> |

## Test plan
- [ ] ローカル環境で Google ログインボタンが表示されることを確認
- [ ] Google アカウントでログインフローが正常に動作することを確認
- [ ] admin 権限のない Google ユーザーがログインするとサインアウトされ、エラーメッセージが表示されることを確認
- [ ] 従来のメール/パスワードログインが引き続き動作することを確認
- [ ] `pnpm lint` / `pnpm typecheck` / `pnpm build` / `pnpm test` すべてパス済み

Resolves GIKAI-313

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * Google認証でのログインを追加しました。ログイン画面にGoogleボタンを追加し、メール/パスワードと併用可能です。
  * OAuthコールバック処理を導入し、認証後に管理画面の請求一覧へ遷移します。
* **セキュリティ/権限**
  * 認証後に管理者権限を確認し、未承認の場合はログイン画面へリダイレクトします。
* **設定**
  * OAuthコールバック用のリダイレクト許可URLとGoogleプロバイダ設定を追加しました。
* **修正**
  * コールバック用リクエストを専用に処理するようミドルウェア挙動を調整しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->