### PR TITLE
ADMIN_URLを.env.exampleのCommonセクションに移動

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,13 +8,13 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzd
 REVALIDATE_SECRET=your-secret-key-here
 # Vercel AI GatewayのAPIキーを設定してください
 AI_GATEWAY_API_KEY=
+# AdminサーバーのURL（web/admin両方で使用）
+ADMIN_URL=http://localhost:3001
 
 #--- Web ---
 # Basic認証をONにする場合は設定してください
 BASIC_AUTH_USER=
 BASIC_AUTH_PASSWORD=
-# AdminサーバーのURLを設定してください
-ADMIN_URL=http://localhost:3001
 # Langfuse設定（プロンプト管理・LLM監視）
 LANGFUSE_PUBLIC_KEY=
 LANGFUSE_SECRET_KEY=
@@ -34,5 +34,5 @@ NEXT_PUBLIC_WEB_URL=http://localhost:3000
 # Google OAuth用の設定（本番・staging環境で必要）
 SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID=
 SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET=
-# OAuthコールバックURL（config.tomlのadditional_redirect_urlsで参照）
+# OAuthコールバックURL（config.tomlのadditional_redirect_urlsで参照、ADMIN_URL + /api/auth/callback）
 ADMIN_AUTH_CALLBACK_URL=http://localhost:3001/api/auth/callback


### PR DESCRIPTION
## Summary
- `ADMIN_URL`をWebセクションからCommonセクションに移動（web/admin両方で使用されるため）
- `ADMIN_AUTH_CALLBACK_URL`のコメントに`ADMIN_URL`との関係を明示

## Test plan
- [x] `pnpm lint` パス
- [x] `pnpm typecheck` パス
- [x] `pnpm build` パス
- [x] `pnpm test` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)