### PR TITLE
pnpm v10.33.0にアップデートしminimumReleaseAgeを設定

### DIFF
--- a/.github/workflows/code_check.yml
+++ b/.github/workflows/code_check.yml
@@ -16,8 +16,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
-        with:
-          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -17,8 +17,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
-        with:
-          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/package.json
+++ b/package.json
@@ -33,5 +33,6 @@
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": "pnpm run lint:fix"
-  }
+  },
+  "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,5 @@ packages:
   - "packages/*"
   - "admin"
   - "web"
+
+minimumReleaseAge: 4320


### PR DESCRIPTION
## Summary
- pnpm を v10.13.1 → v10.33.0 にアップデート
- `minimumReleaseAge: 4320`（3日間）を `pnpm-workspace.yaml` に追加
- サプライチェーン攻撃対策として、公開から3日未満のパッケージバージョンのインストールを防止

## 変更ファイル
- `package.json`: `packageManager` フィールドを v10.33.0 に更新
- `pnpm-workspace.yaml`: `minimumReleaseAge: 4320` を追加

## Test plan
- [x] `pnpm install --frozen-lockfile` 正常完了
- [x] `pnpm lint` パス
- [x] `pnpm typecheck` パス
- [x] `pnpm build` パス
- [x] `pnpm test` パス（77ファイル, 752テスト全パス）

## 参考
- https://pnpm.io/ja/settings#minimumreleaseage

🤖 Generated with [Claude Code](https://claude.com/claude-code)