### PR TITLE
Worktree必須ルールにdevelopクリーンアップ手順を追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,15 @@ cd ../mirai-gikai-<branch-name> && pnpm install --frozen-lockfile
 ```
 
 - **目的**: developブランチを常にクリーンに保ち、作業の分離と並列作業を容易にする
+- **developに変更が残っている場合のリカバリ**: worktreeを作成する前に、developブランチの変更を必ずクリーンアップすること。作業途中の変更をdevelopに残したままworktreeを作成・作業することは禁止。
+  ```bash
+  # 変更を退避してからworktreeを作成
+  git stash --include-untracked
+  git worktree add ../mirai-gikai-<branch-name> -b <branch-name>
+  # worktreeに移動して退避した変更を適用
+  cd ../mirai-gikai-<branch-name>
+  git stash pop
+  ```
 
 ### 実装完了後は即PR作成
 実装完了後は「コミットしますか？」等の確認を挟まず、コミット → push → PR作成まで一気に進めること。ユーザーへの確認は不要。


### PR DESCRIPTION
## Summary
- AGENTS.mdのWorktree必須セクションに、developブランチに変更が残っている場合のリカバリ手順を追記
- `git stash --include-untracked` で退避→worktree作成→`git stash pop` で適用する流れを明記
- 作業途中の変更をdevelopに残したままworktreeを作成・作業することを明示的に禁止

## 仕組み化サマリ

### 仕組み化した項目
| 指摘 | 対応 | 追加先 |
|------|------|--------|
| developに変更が残ったままworktreeを作成してしまう | CLAUDE.mdにリカバリ手順ルール追加 | `AGENTS.md` Worktree必須セクション |

## Test plan
- [x] `pnpm lint` 通過
- [x] `pnpm typecheck` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)