### PR TITLE
admin: 開発環境でplacehold.coの画像を許可

### DIFF
--- a/admin/next.config.ts
+++ b/admin/next.config.ts
@@ -1,5 +1,7 @@
 import type { NextConfig } from "next";
 
+const isDev = process.env.NODE_ENV === "development";
+
 const nextConfig: NextConfig = {
   experimental: {
     serverSourceMaps: true,
@@ -25,6 +27,14 @@ const nextConfig: NextConfig = {
         hostname: "*.supabase.co",
         pathname: "/storage/v1/object/public/bill-thumbnails/**",
       },
+      ...(isDev
+        ? [
+            {
+              protocol: "https" as const,
+              hostname: "placehold.co",
+            },
+          ]
+        : []),
     ],
   },
 };


### PR DESCRIPTION
## Summary
- adminの`next.config.ts`に`placehold.co`のremotePatternを開発環境限定で追加
- webでは既に設定済みだがadminには未設定だったため、シードデータのプレースホルダー画像がnext/imageでエラーになっていた

## Test plan
- [x] `pnpm lint` 通過
- [x] `pnpm typecheck` 通過
- [ ] `pnpm dev`でadminのサムネイル編集画面にてプレースホルダー画像が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 開発環境における画像リソース処理の設定を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->