### PR TITLE
ReviewCompleteBadgeにsize/topプロパティを追加しツールチップテキスト色を修正

### DIFF
--- a/web/src/components/ui/tooltip.tsx
+++ b/web/src/components/ui/tooltip.tsx
@@ -44,7 +44,7 @@ function TooltipContent({
         data-slot="tooltip-content"
         sideOffset={sideOffset}
         className={cn(
-          "bg-mirai-surface-gray text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
+          "bg-mirai-surface-gray text-mirai-text animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
           className
         )}
         {...props}

--- a/web/src/features/bills/client/components/bill-detail/review-status-banner.tsx
+++ b/web/src/features/bills/client/components/bill-detail/review-status-banner.tsx
@@ -24,6 +24,10 @@ export function ReviewInProgressBanner() {
 
 interface ReviewCompleteBadgeProps {
   showTooltip?: boolean;
+  /** Icon size in px (e.g. 16). Default uses size-7.5 (30px) */
+  size?: number;
+  /** CSS top offset (e.g. "2px"). Default uses Tailwind top-1.5 */
+  top?: string;
 }
 
 /**
@@ -32,12 +36,27 @@ interface ReviewCompleteBadgeProps {
  */
 export function ReviewCompleteBadge({
   showTooltip = false,
+  size,
+  top,
 }: ReviewCompleteBadgeProps) {
   const [open, setOpen] = useState(false);
 
+  const hasCustomSize = size != null;
+  const hasCustomTop = top != null;
+
   const icon = (
-    <span className="inline-flex items-center relative top-1.5">
-      <CircleCheck className="size-7.5 fill-primary text-white" />
+    <span
+      className={`inline-flex items-center relative ${hasCustomTop ? "" : "top-1.5"}`}
+      style={hasCustomTop ? { top } : undefined}
+    >
+      <CircleCheck
+        className={`${hasCustomSize ? "" : "size-7.5"} fill-primary text-white`}
+        style={
+          hasCustomSize
+            ? { width: `${size}px`, height: `${size}px` }
+            : undefined
+        }
+      />
     </span>
   );
 
@@ -50,10 +69,18 @@ export function ReviewCompleteBadge({
       <TooltipTrigger asChild>
         <button
           type="button"
-          className="inline-flex items-center relative top-1.5"
+          className={`inline-flex items-center relative ${hasCustomTop ? "" : "top-1.5"}`}
+          style={hasCustomTop ? { top } : undefined}
           onClick={() => setOpen(true)}
         >
-          <CircleCheck className="size-7.5 fill-primary text-white" />
+          <CircleCheck
+            className={`${hasCustomSize ? "" : "size-7.5"} fill-primary text-white`}
+            style={
+              hasCustomSize
+                ? { width: `${size}px`, height: `${size}px` }
+                : undefined
+            }
+          />
         </button>
       </TooltipTrigger>
       <TooltipContent

--- a/web/src/features/bills/client/components/bill-list/compact-bill-card.tsx
+++ b/web/src/features/bills/client/components/bill-list/compact-bill-card.tsx
@@ -30,7 +30,7 @@ export function CompactBillCard({ bill, className }: CompactBillCardProps) {
             {bill.is_review_completed && (
               <>
                 {" "}
-                <ReviewCompleteBadge />
+                <ReviewCompleteBadge size={18} top="3px" />
               </>
             )}
           </h3>


### PR DESCRIPTION
## Summary
- `ReviewCompleteBadge` に `size`（px単位）と `top`（CSSオフセット）プロパティを追加し、呼び出し側でサイズ・位置をカスタム可能に
- `compact-bill-card` で小さめのバッジ（size=18, top=3px）を表示
- ツールチップのテキスト色を `text-primary-foreground` → `text-mirai-text` に修正

## Test plan
- [ ] `pnpm dev` で議案一覧ページを確認し、コンパクトカードのレビュー完了バッジが適切なサイズで表示されること
- [ ] 議案詳細ページのレビュー完了バッジが従来通りのサイズで表示されること
- [ ] ツールチップホバー時のテキストが正しい色で表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Style**
  * ツールチップのテキストカラーを更新しました。
  * レビュー完了バッジのサイズと位置をカスタマイズ可能にしました。
  * ビルカードのレビュー完了バッジの表示位置と寸法を調整しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->