### PR TITLE
CompactBillCardのバッジサイズ調整とReportCardの切り詰め削除

### DIFF
--- a/web/src/features/bills/client/components/bill-list/compact-bill-card.tsx
+++ b/web/src/features/bills/client/components/bill-list/compact-bill-card.tsx
@@ -30,7 +30,7 @@ export function CompactBillCard({ bill, className }: CompactBillCardProps) {
             {bill.is_review_completed && (
               <>
                 {" "}
-                <ReviewCompleteBadge size={18} top="3px" />
+                <ReviewCompleteBadge size={14} top="1px" />
               </>
             )}
           </h3>

--- a/web/src/features/interview-report/shared/components/report-card.tsx
+++ b/web/src/features/interview-report/shared/components/report-card.tsx
@@ -24,17 +24,11 @@ export interface ReportCardData {
 
 interface ReportCardProps {
   report: ReportCardData;
-  summaryMaxLength?: number;
   children?: React.ReactNode;
   href?: string;
 }
 
-export function ReportCard({
-  report,
-  summaryMaxLength = 80,
-  children,
-  href,
-}: ReportCardProps) {
+export function ReportCard({ report, children, href }: ReportCardProps) {
   const stanceLabel = report.stance
     ? stanceLabels[report.stance] || report.stance
     : null;
@@ -53,10 +47,6 @@ export function ReportCard({
   const relativeTime = formatRelativeTime(report.created_at);
 
   const summary = report.summary || "";
-  const truncatedSummary =
-    summary.length > summaryMaxLength
-      ? `${summary.slice(0, summaryMaxLength)}...`
-      : summary;
 
   return (
     <article className="relative bg-white rounded-lg p-4 hover:bg-gray-50 transition-colors">
@@ -65,7 +55,7 @@ export function ReportCard({
         prefetch={false}
         className="absolute inset-0 rounded-lg"
         aria-label={
-          [stanceLabel, report.role_title || roleLabel, truncatedSummary]
+          [stanceLabel, report.role_title || roleLabel, summary]
             .filter(Boolean)
             .join(" / ") || "レポートを見る"
         }
@@ -111,8 +101,8 @@ export function ReportCard({
               </span>
             </div>
 
-            {truncatedSummary && (
-              <p className="text-sm leading-6 text-black">{truncatedSummary}</p>
+            {summary && (
+              <p className="text-sm leading-6 text-black">{summary}</p>
             )}
           </div>
 


### PR DESCRIPTION
## Summary
- CompactBillCardのReviewCompleteBadgeサイズを18→14px、top位置を3px→1pxに調整し、テキストとのバランスを改善
- ReportCardの`summaryMaxLength` propと切り詰めロジックを削除し、summaryを全文表示に変更

## Test plan
- [x] `pnpm lint` — pass
- [x] `pnpm typecheck` — pass
- [x] `pnpm build` — pass
- [x] `pnpm test` — 752 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **スタイル改善**
  * レビュー完了バッジの表示サイズと位置を調整しました

* **機能改善**
  * レポートサマリーの表示が改善されました。短縮表示ではなく、完全なサマリーテキストが表示されるようになりました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->