### PR TITLE
billsテーブルにslugカラムを追加

### DIFF
--- a/admin/src/features/bills-edit/client/components/bill-create-form.tsx
+++ b/admin/src/features/bills-edit/client/components/bill-create-form.tsx
@@ -35,6 +35,7 @@ export function BillCreateForm({ dietSessions }: BillCreateFormProps) {
       thumbnail_url: null,
       share_thumbnail_url: null,
       shugiin_url: null,
+      slug: null,
       is_featured: false,
       is_review_completed: false,
       diet_session_id: defaultDietSessionId,

--- a/admin/src/features/bills-edit/client/components/bill-edit-form.tsx
+++ b/admin/src/features/bills-edit/client/components/bill-edit-form.tsx
@@ -43,6 +43,7 @@ export function BillEditForm({ bill, dietSessions }: BillEditFormProps) {
       thumbnail_url: bill.thumbnail_url,
       share_thumbnail_url: bill.share_thumbnail_url,
       shugiin_url: bill.shugiin_url,
+      slug: bill.slug,
       is_featured: bill.is_featured,
       is_review_completed: bill.is_review_completed,
       diet_session_id: defaultDietSessionId,

--- a/admin/src/features/bills-edit/client/components/bill-form-fields.tsx
+++ b/admin/src/features/bills-edit/client/components/bill-form-fields.tsx
@@ -236,6 +236,27 @@ export function BillFormFields({
 
       <FormField
         control={control}
+        name="slug"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>Slug</FormLabel>
+            <FormControl>
+              <Input
+                {...field}
+                value={field.value || ""}
+                placeholder="221-kaku-1-mof-法案名"
+              />
+            </FormControl>
+            <FormDescription>
+              コンテンツ同期用の識別子です（最大200文字）
+            </FormDescription>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      <FormField
+        control={control}
         name="diet_session_id"
         render={({ field }) => (
           <FormItem>

--- a/admin/src/features/bills-edit/shared/types/index.ts
+++ b/admin/src/features/bills-edit/shared/types/index.ts
@@ -42,6 +42,12 @@ const billBaseSchema = z.object({
   is_featured: z.boolean(),
   is_review_completed: z.boolean(),
   diet_session_id: z.string().uuid().nullable().optional(),
+  slug: z
+    .string()
+    .max(200, "slugは200文字以内で入力してください")
+    .transform((val) => (val === "" ? null : val))
+    .nullable()
+    .optional(),
 });
 
 // 更新用スキーマ（既存）

--- a/admin/src/features/bills/shared/utils/prepare-bill-for-duplication.test.ts
+++ b/admin/src/features/bills/shared/utils/prepare-bill-for-duplication.test.ts
@@ -19,6 +19,7 @@ const baseBill: Bill = {
   published_at: null,
   share_thumbnail_url: null,
   shugiin_url: null,
+  slug: null,
   status: "introduced",
   status_note: null,
   status_order: BILL_STATUS_ORDER.introduced,
@@ -47,6 +48,12 @@ describe("prepareBillForDuplication", () => {
   it("is_review_completedをfalseにリセットする", () => {
     const result = prepareBillForDuplication(baseBill);
     expect(result.is_review_completed).toBe(false);
+  });
+
+  it("slugをnullにリセットする", () => {
+    const billWithSlug = { ...baseBill, slug: "test-slug" };
+    const result = prepareBillForDuplication(billWithSlug);
+    expect(result.slug).toBeNull();
   });
 
   it("その他のフィールドを保持する", () => {

--- a/admin/src/features/bills/shared/utils/prepare-bill-for-duplication.ts
+++ b/admin/src/features/bills/shared/utils/prepare-bill-for-duplication.ts
@@ -10,11 +10,13 @@ export function prepareBillForDuplication(originalBill: Bill): BillInsert {
     created_at: __,
     updated_at: ___,
     status_order: ____,
+    slug: _____,
     ...billWithoutId
   } = originalBill;
 
   return {
     ...billWithoutId,
+    slug: null,
     name: `${originalBill.name} (複製)`,
     publish_status: "draft",
     is_review_completed: false,

--- a/packages/supabase/types/supabase.types.ts
+++ b/packages/supabase/types/supabase.types.ts
@@ -89,6 +89,7 @@ export type Database = {
           published_at: string | null
           share_thumbnail_url: string | null
           shugiin_url: string | null
+          slug: string | null
           status: Database["public"]["Enums"]["bill_status_enum"]
           status_note: string | null
           status_order: number | null
@@ -108,6 +109,7 @@ export type Database = {
           published_at?: string | null
           share_thumbnail_url?: string | null
           shugiin_url?: string | null
+          slug?: string | null
           status: Database["public"]["Enums"]["bill_status_enum"]
           status_note?: string | null
           status_order?: number | null
@@ -127,6 +129,7 @@ export type Database = {
           published_at?: string | null
           share_thumbnail_url?: string | null
           shugiin_url?: string | null
+          slug?: string | null
           status?: Database["public"]["Enums"]["bill_status_enum"]
           status_note?: string | null
           status_order?: number | null

--- a/supabase/migrations/20260414100000_add_slug_to_bills.sql
+++ b/supabase/migrations/20260414100000_add_slug_to_bills.sql
@@ -1,0 +1,3 @@
+alter table bills add column slug text;
+
+create unique index idx_bills_slug on bills (slug);

--- a/web/src/app/dev/_lib/mock-data.ts
+++ b/web/src/app/dev/_lib/mock-data.ts
@@ -24,6 +24,7 @@ const baseBill: BillWithContent = {
   published_at: "2026-02-15",
   publish_status: "published",
   shugiin_url: null,
+  slug: null,
   status_note: null,
   status_order: 3,
   publish_status_order: 2,

--- a/web/src/features/interview-session/shared/utils/build-summary-system-prompt.test.ts
+++ b/web/src/features/interview-session/shared/utils/build-summary-system-prompt.test.ts
@@ -14,6 +14,7 @@ const makeBill = (
   is_review_completed: true,
   originating_house: "HR",
   shugiin_url: null,
+  slug: null,
   diet_session_id: null,
   publish_status: "published",
   published_at: null,

--- a/web/src/features/interview-session/shared/utils/interview-logic/bulk-mode.test.ts
+++ b/web/src/features/interview-session/shared/utils/interview-logic/bulk-mode.test.ts
@@ -18,6 +18,7 @@ const makeBill = (
   is_review_completed: true,
   originating_house: "HR",
   shugiin_url: null,
+  slug: null,
   diet_session_id: null,
   publish_status: "published",
   published_at: null,

--- a/web/src/features/interview-session/shared/utils/interview-logic/loop-mode.test.ts
+++ b/web/src/features/interview-session/shared/utils/interview-logic/loop-mode.test.ts
@@ -18,6 +18,7 @@ const makeBill = (
   is_review_completed: true,
   originating_house: "HR",
   shugiin_url: null,
+  slug: null,
   diet_session_id: null,
   publish_status: "published",
   published_at: null,


### PR DESCRIPTION
## Summary
- billsテーブルにnullableな`slug`カラム（UNIQUE制約付き）を追加
- mirai-gikai-contentとのコンテンツ同期キーとして使用予定
- 議案複製時にslugをnullにリセットしてUNIQUE制約違反を防止

## Changes
- `supabase/migrations/20260414100000_add_slug_to_bills.sql`: slugカラムとユニークインデックス追加
- `packages/supabase/types/supabase.types.ts`: 型定義にslug追加
- `admin/src/features/bills/shared/utils/prepare-bill-for-duplication.ts`: 複製時にslugをnull化
- テストファイル・モックデータのBill型にslug追加

## Test plan
- [x] `pnpm lint` 通過
- [x] `pnpm typecheck` 通過
- [x] `pnpm build` 通過
- [x] `pnpm test` 全752テスト通過（slug null化テスト含む）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bills に slug フィールドを追加しました。管理画面の作成/編集フォームで slug を入力できます。
  * slug は空文字が null に変換され、最大200文字に制限されます。
  * データベースで slug に一意制約を追加しました（重複不可）。
* **Behavior Changes**
  * Bill を複製すると slug は自動的に null にリセットされます。
* **Tests**
  * 仕様に合わせてテストデータとテストケースを更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->