### PR TITLE
掲載コンテンツ説明から議員立法の言及を削除

### DIFF
--- a/web/src/features/bills/client/components/bill-detail/bill-disclaimer.tsx
+++ b/web/src/features/bills/client/components/bill-detail/bill-disclaimer.tsx
@@ -9,9 +9,9 @@ export function BillDisclaimer() {
       <div className="space-y-3">
         <h3 className="text-sm font-bold text-black">掲載コンテンツについて</h3>
         <p className="text-xs leading-relaxed text-mirai-text-note">
-          掲載されている法案情報は、国会に提出された議案などの公開情報を基に、チームみらいがAIを活用しながら背景情報を整理したものです。主に内閣提出法案（
+          掲載されている法案情報は、国会に提出された議案などの公開情報を基に、チームみらいがAIを活用しながら背景情報を整理したものです。掲載法案は主に、内閣提出法案（
           <ManualRuby ruby="かくほう">閣法</ManualRuby>
-          ）を対象としており、議員立法については既に実質的な審議が開始されたものや、される見込みが高いものを対象にしています。
+          ）を対象としております。
         </p>
       </div>
 


### PR DESCRIPTION
## Summary
- 法案詳細ページの「掲載コンテンツについて」セクションから議員立法に関する説明を削除
- 「掲載法案は主に、内閣提出法案（閣法）を対象としております。」に文言を簡潔化

Resolves https://linear.app/team-mirai-dev/issue/GIKAI-337

## Test plan
- [x] `pnpm lint` pass
- [x] `pnpm typecheck` pass
- [x] `pnpm build` pass
- [x] `pnpm test` pass (752 tests all passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **修正**
  * 掲載法案に関する免責事項を更新しました。対象となる法案の説明をアップデートしています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->