### PR TITLE
MCPツール改善: list_billsフィルタ追加・list_diet_sessions追加

### DIFF
--- a/admin/src/features/mcp/server/create-handler.ts
+++ b/admin/src/features/mcp/server/create-handler.ts
@@ -5,6 +5,7 @@ import {
   experimental_withMcpAuth as withMcpAuth,
 } from "mcp-handler";
 import { registerBillsTools } from "./tools/register-bills-tools";
+import { registerDietSessionsTools } from "./tools/register-diet-sessions-tools";
 import { registerTagsTools } from "./tools/register-tags-tools";
 import { verifyMcpToken } from "./verify-token";
 
@@ -12,6 +13,7 @@ export function createAdminMcpHandler() {
   const baseHandler = createMcpHandler(
     (server) => {
       registerBillsTools(server);
+      registerDietSessionsTools(server);
       registerTagsTools(server);
     },
     {

--- a/admin/src/features/mcp/server/tools/register-bills-tools.ts
+++ b/admin/src/features/mcp/server/tools/register-bills-tools.ts
@@ -83,7 +83,12 @@ export function registerBillsTools(server: McpServer): void {
       inputSchema: billCreateSchema.shape,
     },
     async (input) => {
-      const inserted = await createBillRecord(input);
+      const inserted = await createBillRecord({
+        ...input,
+        submitted_date: input.submitted_date
+          ? `${input.submitted_date}T00:00:00+09:00`
+          : null,
+      });
       await invalidateBillsCache();
       return jsonResult({ ok: true, bill: inserted });
     }
@@ -103,6 +108,9 @@ export function registerBillsTools(server: McpServer): void {
     async ({ billId, ...rest }) => {
       await updateBillRecord(billId, {
         ...rest,
+        submitted_date: rest.submitted_date
+          ? `${rest.submitted_date}T00:00:00+09:00`
+          : null,
         updated_at: new Date().toISOString(),
       });
       await invalidateBillsCache();

--- a/admin/src/features/mcp/server/tools/register-bills-tools.ts
+++ b/admin/src/features/mcp/server/tools/register-bills-tools.ts
@@ -31,12 +31,26 @@ export function registerBillsTools(server: McpServer): void {
     {
       title: "議案一覧を取得",
       description:
-        "mirai議会adminに登録されているすべての議案を返す。各議案にdiet_session名も含む。",
-      inputSchema: {},
+        "mirai議会adminに登録されている議案を返す。各議案にdiet_session名も含む。publish_status / status でフィルタ可能。",
+      inputSchema: {
+        publish_status: z
+          .enum(["draft", "published", "coming_soon"])
+          .optional()
+          .describe("公開ステータスでフィルタ"),
+        status: billUpdateSchema.shape.status
+          .optional()
+          .describe("審議ステータスでフィルタ"),
+      },
     },
-    async () => {
+    async ({ publish_status, status }) => {
       const bills = await findBillsWithDietSessions();
-      return jsonResult(bills);
+      const filtered = bills.filter((bill) => {
+        if (publish_status && bill.publish_status !== publish_status)
+          return false;
+        if (status && bill.status !== status) return false;
+        return true;
+      });
+      return jsonResult(filtered);
     }
   );
 
@@ -69,12 +83,7 @@ export function registerBillsTools(server: McpServer): void {
       inputSchema: billCreateSchema.shape,
     },
     async (input) => {
-      const inserted = await createBillRecord({
-        ...input,
-        published_at: input.published_at
-          ? new Date(input.published_at).toISOString()
-          : null,
-      });
+      const inserted = await createBillRecord(input);
       await invalidateBillsCache();
       return jsonResult({ ok: true, bill: inserted });
     }
@@ -94,9 +103,6 @@ export function registerBillsTools(server: McpServer): void {
     async ({ billId, ...rest }) => {
       await updateBillRecord(billId, {
         ...rest,
-        published_at: rest.published_at
-          ? new Date(rest.published_at).toISOString()
-          : null,
         updated_at: new Date().toISOString(),
       });
       await invalidateBillsCache();

--- a/admin/src/features/mcp/server/tools/register-diet-sessions-tools.ts
+++ b/admin/src/features/mcp/server/tools/register-diet-sessions-tools.ts
@@ -1,0 +1,21 @@
+import "server-only";
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { findAllDietSessions } from "@/features/diet-sessions/server/repositories/diet-session-repository";
+import { jsonResult } from "../utils/json-result";
+
+export function registerDietSessionsTools(server: McpServer): void {
+  server.registerTool(
+    "list_diet_sessions",
+    {
+      title: "国会会期一覧を取得",
+      description:
+        "登録されているすべての国会会期を返す。議案作成時のdiet_session_id指定に利用できる。",
+      inputSchema: {},
+    },
+    async () => {
+      const sessions = await findAllDietSessions();
+      return jsonResult(sessions);
+    }
+  );
+}


### PR DESCRIPTION
## Summary
- `list_bills` ツールに `publish_status` / `status` オプションフィルタを追加し、ステータスで議案を絞り込めるようにした
- `list_diet_sessions` ツールを新規追加し、議案作成時に `diet_session_id` を調べられるようにした
- `published_at` → `submitted_date` リネーム（#762）の対応漏れを修正（`create_bill` / `update_bill` ツール内の変換ロジック）

## 変更内容
- `register-bills-tools.ts`: `list_bills` に `publish_status` / `status` フィルタ追加、`create_bill` / `update_bill` の `published_at` 参照を削除
- `register-diet-sessions-tools.ts`: 新規追加。既存の `findAllDietSessions` リポジトリ関数を再利用
- `create-handler.ts`: `registerDietSessionsTools` の登録を追加

## Test plan
- [x] `pnpm lint` パス
- [x] `pnpm typecheck` パス
- [x] `pnpm build` パス
- [x] `pnpm test` パス (752 tests passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 食事セッション機能を追加しました。食事セッションの一覧取得が可能です。

* **機能改善**
  * 請求書一覧に公開状態およびステータスでの絞り込みを追加しました。
  * 請求書の作成・更新処理を改善し、提出日扱いの日時形式と更新時刻の扱いを見直しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->