### PR TITLE
create_tagツールにdescription/featured_priorityオプションを追加

### DIFF
--- a/admin/src/features/mcp/server/tools/register-tags-tools.ts
+++ b/admin/src/features/mcp/server/tools/register-tags-tools.ts
@@ -30,17 +30,24 @@ export function registerTagsTools(server: McpServer): void {
     "create_tag",
     {
       title: "タグを作成",
-      description: "新しいタグを作成する。labelは必須。",
+      description:
+        "新しいタグを作成する。labelは必須。description / featured_priority は任意。",
       inputSchema: {
         label: z.string().min(1),
+        description: z.string().nullable().optional(),
+        featured_priority: z.number().int().nullable().optional(),
       },
     },
-    async ({ label }) => {
+    async ({ label, description, featured_priority }) => {
       const trimmed = label.trim();
       if (trimmed.length === 0) {
         return jsonResult({ ok: false, error: "タグ名を入力してください" });
       }
-      const result = await createTagRecord({ label: trimmed });
+      const result = await createTagRecord({
+        label: trimmed,
+        description: description ?? null,
+        featured_priority: featured_priority ?? null,
+      });
       if (result.error) {
         return jsonResult({
           ok: false,

--- a/admin/src/features/tags/server/repositories/tag-repository.ts
+++ b/admin/src/features/tags/server/repositories/tag-repository.ts
@@ -27,11 +27,19 @@ export async function findAllTagsWithBillCount() {
   return data;
 }
 
-export async function createTagRecord(input: { label: string }) {
+export async function createTagRecord(input: {
+  label: string;
+  description?: string | null;
+  featured_priority?: number | null;
+}) {
   const supabase = createAdminClient();
   const { data, error } = await supabase
     .from("tags")
-    .insert({ label: input.label })
+    .insert({
+      label: input.label,
+      description: input.description ?? null,
+      featured_priority: input.featured_priority ?? null,
+    })
     .select()
     .single();
 


### PR DESCRIPTION
## Summary
- MCP `create_tag` ツールに `description` / `featured_priority` オプションパラメータを追加
- `createTagRecord` リポジトリ関数の型シグネチャを拡張し、作成時にも `description` / `featured_priority` を渡せるように
- これにより `update_tag` と同等のフィールドが作成時にも1ステップで設定可能に

## Test plan
- [x] `pnpm lint` パス
- [x] `pnpm typecheck` パス（tag関連ファイルにエラーなし）
- [x] `pnpm test` パス (752 tests passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能

* タグ作成機能を拡張し、説明文とフィーチャー優先度を設定できるようになりました。どちらもオプションの項目です。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->