### PR TITLE
MCPにslugで議案を検索するget_bill_by_slugツールを追加

### DIFF
--- a/admin/src/features/bills-edit/server/repositories/bill-edit-repository.ts
+++ b/admin/src/features/bills-edit/server/repositories/bill-edit-repository.ts
@@ -48,6 +48,21 @@ export async function findBillTagIdsByBillId(billId: string) {
   return data?.map((item) => item.tag_id) ?? [];
 }
 
+export async function findBillBySlug(slug: string) {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("bills")
+    .select("*")
+    .eq("slug", slug)
+    .single();
+
+  if (error) {
+    throw new Error(`Failed to fetch bill by slug: ${error.message}`);
+  }
+
+  return data;
+}
+
 export async function createBillRecord(insertData: BillInsert) {
   const supabase = createAdminClient();
   const { data, error } = await supabase

--- a/admin/src/features/mcp/server/tools/register-bills-tools.ts
+++ b/admin/src/features/mcp/server/tools/register-bills-tools.ts
@@ -7,6 +7,7 @@ import {
   createBillsTags,
   deleteBillsTags,
   findBillById,
+  findBillBySlug,
   findBillContentsByBillId,
   findBillsTagsByBillId,
   updateBillRecord,
@@ -55,6 +56,26 @@ export function registerBillsTools(server: McpServer): void {
         findBillById(billId),
         findBillContentsByBillId(billId),
         findBillsTagsByBillId(billId),
+      ]);
+      return jsonResult({ bill, contents, tagIds });
+    }
+  );
+
+  server.registerTool(
+    "get_bill_by_slug",
+    {
+      title: "slugで議案を検索",
+      description:
+        "指定slugの議案本体、bill_contents（ふつう/難しい）、紐づくtag_idを返す。slugが一致する議案がない場合はエラーになる。",
+      inputSchema: {
+        slug: z.string().max(200).describe("議案のslug"),
+      },
+    },
+    async ({ slug }) => {
+      const bill = await findBillBySlug(slug);
+      const [contents, tagIds] = await Promise.all([
+        findBillContentsByBillId(bill.id),
+        findBillsTagsByBillId(bill.id),
       ]);
       return jsonResult({ bill, contents, tagIds });
     }


### PR DESCRIPTION
## Summary
- MCPサーバーに `get_bill_by_slug` ツールを追加し、slugで議案を検索できるようにした
- `bill-edit-repository.ts` に `findBillBySlug` リポジトリ関数を追加
- 既存の `get_bill`（ID検索）と同じレスポンス形式（bill, contents, tagIds）を返す

## Test plan
- [x] `pnpm typecheck` パス（既存のpublished_at関連エラーのみ、新規コードにエラーなし）
- [x] `pnpm lint` パス
- [x] Codex Review パス
- [x] テストガイドラインチェック パス
- [x] コード品質チェック パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

**新機能**
- スラッグによるビル検索機能が実装されました。特定のビルを識別子で素早く検索できます。
- ビル詳細情報の一括取得機能が追加されました。ビル本体、複数難易度のコンテンツ、関連タグを効率的に取得でき、ビル管理の使いやすさが向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->