### PR TITLE
MCPにプレビューURL発行ツール(generate_preview_url)を追加

### DIFF
--- a/admin/src/features/bills/server/actions/generate-preview-url.ts
+++ b/admin/src/features/bills/server/actions/generate-preview-url.ts
@@ -19,11 +19,7 @@ export async function generatePreviewUrl(
   await requireAdmin();
 
   try {
-    let tokenInfo = await previewTokenService.getValidToken(billId);
-
-    if (!tokenInfo) {
-      tokenInfo = await previewTokenService.createToken(billId);
-    }
+    const tokenInfo = await previewTokenService.getOrCreateToken(billId);
 
     return {
       success: true,

--- a/admin/src/features/bills/server/services/preview-token-service.ts
+++ b/admin/src/features/bills/server/services/preview-token-service.ts
@@ -59,6 +59,15 @@ export const previewTokenService = {
   },
 
   /**
+   * 既存の有効なトークンを取得するか、なければ新規発行する
+   */
+  async getOrCreateToken(billId: string): Promise<PreviewTokenInfo> {
+    const existing = await this.getValidToken(billId);
+    if (existing) return existing;
+    return this.createToken(billId);
+  },
+
+  /**
    * トークンを検証する
    */
   async validateToken(billId: string, token: string): Promise<boolean> {

--- a/admin/src/features/interview-config/server/actions/generate-interview-preview-url.ts
+++ b/admin/src/features/interview-config/server/actions/generate-interview-preview-url.ts
@@ -19,11 +19,7 @@ export async function generateInterviewPreviewUrl(
   await requireAdmin();
 
   try {
-    let tokenInfo = await previewTokenService.getValidToken(billId);
-
-    if (!tokenInfo) {
-      tokenInfo = await previewTokenService.createToken(billId);
-    }
+    const tokenInfo = await previewTokenService.getOrCreateToken(billId);
 
     return {
       success: true,

--- a/admin/src/features/mcp/server/create-handler.ts
+++ b/admin/src/features/mcp/server/create-handler.ts
@@ -6,6 +6,7 @@ import {
 } from "mcp-handler";
 import { registerBillsTools } from "./tools/register-bills-tools";
 import { registerDietSessionsTools } from "./tools/register-diet-sessions-tools";
+import { registerPreviewTools } from "./tools/register-preview-tools";
 import { registerTagsTools } from "./tools/register-tags-tools";
 import { verifyMcpToken } from "./verify-token";
 
@@ -14,6 +15,7 @@ export function createAdminMcpHandler() {
     (server) => {
       registerBillsTools(server);
       registerDietSessionsTools(server);
+      registerPreviewTools(server);
       registerTagsTools(server);
     },
     {

--- a/admin/src/features/mcp/server/tools/register-preview-tools.ts
+++ b/admin/src/features/mcp/server/tools/register-preview-tools.ts
@@ -1,0 +1,45 @@
+import "server-only";
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { previewTokenService } from "@/features/bills/server/services/preview-token-service";
+import { env } from "@/lib/env";
+import { buildPreviewUrl } from "@/lib/utils/build-preview-url";
+import { jsonResult } from "../utils/json-result";
+
+export function registerPreviewTools(server: McpServer): void {
+  server.registerTool(
+    "generate_preview_url",
+    {
+      title: "議案のプレビューURLを発行",
+      description:
+        "指定IDの議案のプレビューURLを発行する。下書き(draft)や公開前(coming_soon)の議案を確認するために使用。既存の有効なトークンがあればそれを再利用し、なければ新規発行する（30日有効）。type で議案詳細ページまたはインタビューページのURLを切り替え可能。",
+      inputSchema: {
+        billId: z.string().uuid().describe("議案ID"),
+        type: z
+          .enum(["bill", "interview"])
+          .default("bill")
+          .describe(
+            "プレビュー対象: bill=議案詳細ページ, interview=インタビューページ"
+          ),
+      },
+    },
+    async ({ billId, type }) => {
+      const tokenInfo = await previewTokenService.getOrCreateToken(billId);
+
+      const path =
+        type === "interview"
+          ? `/preview/bills/${billId}/interview`
+          : `/preview/bills/${billId}`;
+
+      const url = buildPreviewUrl(env.webUrl, path, tokenInfo.token);
+
+      return jsonResult({
+        ok: true,
+        url,
+        token: tokenInfo.token,
+        expiresAt: tokenInfo.expiresAt,
+      });
+    }
+  );
+}


### PR DESCRIPTION
## Summary
- admin MCPサーバーに `generate_preview_url` ツールを追加。議案ID と type（bill/interview）を指定してプレビューURLを発行できる
- `previewTokenService` に `getOrCreateToken` メソッドを追加し、既存の Server Actions（`generatePreviewUrl`, `generateInterviewPreviewUrl`）と MCP ツールの重複ロジックを集約
- 既存のトークン取得・発行パターン（有効なトークンがあれば再利用、なければ新規発行）をサービス層に統一

## Test plan
- [x] `pnpm lint` — 通過（既存 warning のみ）
- [x] `pnpm typecheck` — 通過
- [x] `pnpm test` — 全752テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * MCPサーバーに新しいプレビューURL生成ツールを追加。請求書およびインタビュープレビューのURL生成に対応。

* **リファクタリング**
  * プレビュートークンの取得と作成ロジックを統一メソッドに統合し、複数の機能で利用するように更新。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->