### PR TITLE
Supabase認証キーをlegacyから新形式へ移行

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,11 @@
 #--- Common ---
 # npx supabase statusで確認できる情報を設定してください
 SUPABASE_URL=http://127.0.0.1:54421
-SUPABASE_SERVICE_ROLE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU
+# `npx supabase status` の "Secret" を設定してください
+SUPABASE_SECRET_KEY=
 NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54421
-NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0
+# `npx supabase status` の "Publishable" を設定してください
+NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=
 # Web側のキャッシュを無効化するためのシークレットキー
 REVALIDATE_SECRET=your-secret-key-here
 # Vercel AI GatewayのAPIキーを設定してください

--- a/.github/workflows/code_check.yml
+++ b/.github/workflows/code_check.yml
@@ -36,7 +36,7 @@ jobs:
         run: pnpm run build
         env:
           NEXT_PUBLIC_SUPABASE_URL: http://localhost:54321
-          NEXT_PUBLIC_SUPABASE_ANON_KEY: dummy-anon-key-for-build-check
+          NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: sb_publishable_dummy-for-build-check
 
       - name: Run Test with Coverage
         run: pnpm run test:coverage

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -35,13 +35,19 @@ jobs:
       - name: Start Supabase
         run: supabase start -x studio,imgproxy,logflare,vector,realtime,edge-runtime,supavisor,inbucket
 
+      - name: Export Supabase env vars
+        run: |
+          {
+            echo "SUPABASE_URL=http://127.0.0.1:54421"
+            echo "NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54421"
+            supabase status -o env \
+              | grep -E '^(PUBLISHABLE_KEY|SECRET_KEY)=' \
+              | sed -e 's/^PUBLISHABLE_KEY="\(.*\)"$/NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=\1/' \
+                    -e 's/^SECRET_KEY="\(.*\)"$/SUPABASE_SECRET_KEY=\1/'
+          } >> "$GITHUB_ENV"
+
       - name: Run Integration Tests with Coverage
         run: pnpm test:integration:coverage
-        env:
-          SUPABASE_URL: http://127.0.0.1:54421
-          SUPABASE_SERVICE_ROLE_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU
-          NEXT_PUBLIC_SUPABASE_URL: http://127.0.0.1:54421
-          NEXT_PUBLIC_SUPABASE_ANON_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,7 +169,7 @@ Repository レイヤーの詳細は [docs/repository-layer.md](docs/repository-l
 - ローカル開発前に `npx supabase start` を実行し、`.env.example` を `.env` にコピーして値を整えます。
 - スキーマ変更時は `supabase/migrations` のマイグレーションと `packages/supabase/types/supabase.types.ts` の再生成ファイルをセットでコミットします。
 - `pnpm seed` は `admin@example.com / admin123456` を含む検証データを投入するため、開発用途に限定してください。
-- **RLSとアクセスパターン**: マイグレーションでは必ず `alter table <テーブル名> enable row level security;` を記述してRLSを有効化すること。ただし **ポリシーは定義しない**（デフォルト全拒否）。データアクセスはすべて `createAdminClient()`（Service Role Key）経由で行い、認可ロジックはアプリケーション層（Server Actions / Loaders）で実装する。
+- **RLSとアクセスパターン**: マイグレーションでは必ず `alter table <テーブル名> enable row level security;` を記述してRLSを有効化すること。ただし **ポリシーは定義しない**（デフォルト全拒否）。データアクセスはすべて `createAdminClient()`（Supabase Secret Key）経由で行い、認可ロジックはアプリケーション層（Server Actions / Loaders）で実装する。
 
 ## ドキュメント作成ルール
 - 要件定義や実装計画をまとめる際は論点を先に洗い出し、不明点を確認してから Markdown で整理します。

--- a/admin/src/lib/env.ts
+++ b/admin/src/lib/env.ts
@@ -6,9 +6,9 @@
 if (!process.env.NEXT_PUBLIC_SUPABASE_URL) {
   throw new Error("環境変数 NEXT_PUBLIC_SUPABASE_URL が設定されていません");
 }
-if (!process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY) {
+if (!process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY) {
   throw new Error(
-    "環境変数 NEXT_PUBLIC_SUPABASE_ANON_KEY が設定されていません"
+    "環境変数 NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY が設定されていません"
   );
 }
 
@@ -18,7 +18,7 @@ export const env = {
     : process.env.ADMIN_URL || "http://localhost:3001",
   webUrl: process.env.NEXT_PUBLIC_WEB_URL || "http://localhost:3000",
   supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL,
-  supabaseAnonKey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+  supabasePublishableKey: process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY,
   revalidateSecret: process.env.REVALIDATE_SECRET,
   langfuse: {
     publicKey: process.env.LANGFUSE_PUBLIC_KEY,

--- a/admin/src/lib/supabase/auth.ts
+++ b/admin/src/lib/supabase/auth.ts
@@ -16,7 +16,7 @@ export async function createAuthClient() {
 
   const serverClient = createServerClient<Database>(
     env.supabaseUrl,
-    env.supabaseAnonKey,
+    env.supabasePublishableKey,
     {
       cookies: {
         getAll() {

--- a/admin/src/lib/supabase/middleware.ts
+++ b/admin/src/lib/supabase/middleware.ts
@@ -10,7 +10,7 @@ export async function updateSession(request: NextRequest) {
 
   const supabase = createServerClient<Database>(
     env.supabaseUrl,
-    env.supabaseAnonKey,
+    env.supabasePublishableKey,
     {
       cookies: {
         getAll() {

--- a/packages/seed/shared/helper.ts
+++ b/packages/seed/shared/helper.ts
@@ -6,7 +6,7 @@ export type AdminClient = ReturnType<typeof createAdminClient>;
 export function createAdminClient() {
   return createClient<Database>(
     process.env.SUPABASE_URL!,
-    process.env.SUPABASE_SERVICE_ROLE_KEY!
+    process.env.SUPABASE_SECRET_KEY!
   );
 }
 

--- a/packages/supabase/src/admin.ts
+++ b/packages/supabase/src/admin.ts
@@ -1,10 +1,10 @@
 import { createClient } from "@supabase/supabase-js";
 import type { Database } from "../types/supabase.types";
 
-// Service role client for server-side operations that bypass RLS
+// Secret key client for server-side operations that bypass RLS
 export function createAdminClient() {
   return createClient<Database>(
     process.env.SUPABASE_URL!,
-    process.env.SUPABASE_SERVICE_ROLE_KEY!
+    process.env.SUPABASE_SECRET_KEY!
   );
 }

--- a/packages/supabase/src/browser.ts
+++ b/packages/supabase/src/browser.ts
@@ -8,6 +8,6 @@ import type { Database } from "../types/supabase.types";
 export function createClient() {
   return createBrowserClient<Database>(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!
   );
 }

--- a/tests/supabase/setup.ts
+++ b/tests/supabase/setup.ts
@@ -1,13 +1,16 @@
 import { createClient } from "@supabase/supabase-js";
 
 const SUPABASE_URL = process.env.SUPABASE_URL ?? "http://127.0.0.1:54421";
-const SERVICE_ROLE_KEY =
-  process.env.SUPABASE_SERVICE_ROLE_KEY ??
-  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU";
+const SECRET_KEY = process.env.SUPABASE_SECRET_KEY;
 
 export async function setup() {
+  if (!SECRET_KEY) {
+    throw new Error(
+      "環境変数 SUPABASE_SECRET_KEY が未設定です。ローカル実行時は `.env` をコピーし、`npx supabase status` で値を確認してください。"
+    );
+  }
   // Supabase 接続確認
-  const client = createClient(SUPABASE_URL, SERVICE_ROLE_KEY);
+  const client = createClient(SUPABASE_URL, SECRET_KEY);
   const { error } = await client.from("diet_sessions").select("id").limit(1);
   if (error) {
     throw new Error(

--- a/tests/supabase/utils.ts
+++ b/tests/supabase/utils.ts
@@ -1,30 +1,33 @@
 import { createClient } from "@supabase/supabase-js";
 import type { Database } from "../../packages/supabase/types/supabase.types";
 
-// ── 環境変数（ローカルSupabaseの既定値をデフォルトに） ──
+// ── 環境変数（`.env` または CI が供給。`npx supabase status` で確認） ──
 const SUPABASE_URL = process.env.SUPABASE_URL ?? "http://127.0.0.1:54421";
-const SERVICE_ROLE_KEY =
-  process.env.SUPABASE_SERVICE_ROLE_KEY ??
-  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU";
-const ANON_KEY =
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ??
-  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0";
+const SECRET_KEY = requireEnv("SUPABASE_SECRET_KEY");
+const PUBLISHABLE_KEY = requireEnv("NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY");
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(
+      `環境変数 ${name} が未設定です。ローカル実行時は \`.env\` をコピーし、\`npx supabase status\` で値を確認してください。`
+    );
+  }
+  return value;
+}
 
 // ── クライアント ──
-/** service_role 権限のクライアント（RLS バイパス） */
-export const adminClient = createClient<Database>(
-  SUPABASE_URL,
-  SERVICE_ROLE_KEY
-);
+/** secret key クライアント（RLS バイパス） */
+export const adminClient = createClient<Database>(SUPABASE_URL, SECRET_KEY);
 
-/** anon 権限のクライアント（RLS 適用） */
+/** publishable key クライアント（RLS 適用） */
 export function getAnonClient() {
-  return createClient<Database>(SUPABASE_URL, ANON_KEY);
+  return createClient<Database>(SUPABASE_URL, PUBLISHABLE_KEY);
 }
 
 /** 認証済みクライアントを取得 */
 export async function getAuthenticatedClient(email: string, password: string) {
-  const client = createClient<Database>(SUPABASE_URL, ANON_KEY);
+  const client = createClient<Database>(SUPABASE_URL, PUBLISHABLE_KEY);
   const { error } = await client.auth.signInWithPassword({
     email,
     password,

--- a/web/.env.example
+++ b/web/.env.example
@@ -1,6 +1,6 @@
 # Supabase
 NEXT_PUBLIC_SUPABASE_URL=your_supabase_project_url
-NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
+NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=your_supabase_publishable_key
 
 # Admin URL (for preview page link back to admin)
 NEXT_PUBLIC_ADMIN_URL=http://localhost:3002

--- a/web/.env.example
+++ b/web/.env.example
@@ -1,6 +1,6 @@
 # Supabase
-NEXT_PUBLIC_SUPABASE_URL=your_supabase_project_url
 NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=your_supabase_publishable_key
+NEXT_PUBLIC_SUPABASE_URL=your_supabase_project_url
 
 # Admin URL (for preview page link back to admin)
 NEXT_PUBLIC_ADMIN_URL=http://localhost:3002

--- a/web/src/features/chat/server/utils/supabase-server.ts
+++ b/web/src/features/chat/server/utils/supabase-server.ts
@@ -9,16 +9,20 @@ import { env } from "@/lib/env";
 export async function createChatSupabaseServerClient() {
   const cookieStore = await cookies();
 
-  return createServerClient<Database>(env.supabaseUrl, env.supabaseAnonKey, {
-    cookies: {
-      getAll() {
-        return cookieStore.getAll();
+  return createServerClient<Database>(
+    env.supabaseUrl,
+    env.supabasePublishableKey,
+    {
+      cookies: {
+        getAll() {
+          return cookieStore.getAll();
+        },
+        setAll() {
+          // Route Handlers cannot mutate cookies; ignore writes.
+        },
       },
-      setAll() {
-        // Route Handlers cannot mutate cookies; ignore writes.
-      },
-    },
-  });
+    }
+  );
 }
 
 export async function getChatSupabaseUser() {

--- a/web/src/lib/env.ts
+++ b/web/src/lib/env.ts
@@ -7,9 +7,9 @@ if (!process.env.NEXT_PUBLIC_SUPABASE_URL) {
   throw new Error("環境変数 NEXT_PUBLIC_SUPABASE_URL が設定されていません");
 }
 
-if (!process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY) {
+if (!process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY) {
   throw new Error(
-    "環境変数 NEXT_PUBLIC_SUPABASE_ANON_KEY が設定されていません"
+    "環境変数 NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY が設定されていません"
   );
 }
 
@@ -58,7 +58,7 @@ export const env = {
   webUrl: process.env.NEXT_PUBLIC_WEB_URL || "http://localhost:3000",
   adminUrl: process.env.ADMIN_URL || "http://localhost:3001",
   supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL,
-  supabaseAnonKey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+  supabasePublishableKey: process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY,
   revalidateSecret: process.env.REVALIDATE_SECRET,
   analytics: {
     gaTrackingId: process.env.NEXT_PUBLIC_GA_TRACKING_ID,

--- a/web/src/lib/supabase/middleware.ts
+++ b/web/src/lib/supabase/middleware.ts
@@ -13,30 +13,35 @@ export async function updateSupabaseSession(request: NextRequest) {
   });
 
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  const supabasePublishableKey =
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY;
 
-  if (!supabaseUrl || !supabaseAnonKey) {
+  if (!supabaseUrl || !supabasePublishableKey) {
     return supabaseResponse;
   }
 
-  const supabase = createServerClient<Database>(supabaseUrl, supabaseAnonKey, {
-    cookies: {
-      getAll() {
-        return request.cookies.getAll();
+  const supabase = createServerClient<Database>(
+    supabaseUrl,
+    supabasePublishableKey,
+    {
+      cookies: {
+        getAll() {
+          return request.cookies.getAll();
+        },
+        setAll(cookiesToSet) {
+          for (const { name, value } of cookiesToSet) {
+            request.cookies.set(name, value);
+          }
+          supabaseResponse = NextResponse.next({
+            request,
+          });
+          for (const { name, value, options } of cookiesToSet) {
+            supabaseResponse.cookies.set(name, value, options);
+          }
+        },
       },
-      setAll(cookiesToSet) {
-        for (const { name, value } of cookiesToSet) {
-          request.cookies.set(name, value);
-        }
-        supabaseResponse = NextResponse.next({
-          request,
-        });
-        for (const { name, value, options } of cookiesToSet) {
-          supabaseResponse.cookies.set(name, value, options);
-        }
-      },
-    },
-  });
+    }
+  );
 
   // トークンリフレッシュをトリガーする
   // getUser() はサーバーに問い合わせてトークンの有効性を確認し、


### PR DESCRIPTION
## Summary
- Supabaseの認証キーを旧形式（JWT）から新形式（Publishable/Secret）へ移行
  - `SUPABASE_SERVICE_ROLE_KEY` → `SUPABASE_SECRET_KEY`
  - `NEXT_PUBLIC_SUPABASE_ANON_KEY` → `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY`
- アプリコード・テストヘルパー・CI・ドキュメントを一括更新
- CIでは実キーをハードコードせず、`supabase status -o env` から動的に取得（GitHub Secret Scanning対策）

## 移行手順（マージ後必須）
本PRはクリーンカットオーバーで後方互換を持たないため、マージと同時に以下を実施する必要があります。

1. Supabase Dashboard（prod / staging）で新キー（Publishable / Secret）の値を取得
2. Vercelの各環境（production / preview / development × web / admin）で以下を設定
   - `SUPABASE_SECRET_KEY` を新規追加
   - `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` を新規追加
3. 両アプリを再デプロイ
4. 動作確認後、**旧環境変数を削除**
   - `SUPABASE_SERVICE_ROLE_KEY`
   - `NEXT_PUBLIC_SUPABASE_ANON_KEY`

## 変更差分の性質
- 環境変数名のリネームと、それに伴う参照先の機械的更新のみ
- ロジック変更なし
- `@supabase/supabase-js` / `@supabase/ssr` は新形式キーを引数としてそのまま受け入れるため、API呼び出しは変更なし

## Test plan
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] `pnpm test`（589 passed、14エラーは `html-encoding-sniffer` 起因の既存問題）
- [x] `pnpm test:integration`（120 passed、6 failed は `submitted_date` リネーム進行中の既存問題、developと同一）
- [x] ローカルで `pnpm dev` 起動 → web / admin 両方が新キーで動作することを確認
- [x] admin の Email ログインで `/bills` へ遷移することを確認（publishable key での認証フロー検証）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Supabase環境変数の名前を更新しました。`.env`ファイルで`NEXT_PUBLIC_SUPABASE_ANON_KEY`から`NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY`への変更と、バックエンド認証キー関連の設定更新が必要です。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->