### PR TITLE
法案成立時に関連インタビューを自動クローズ

### DIFF
--- a/admin/src/features/bills-edit/client/components/bill-form-fields.tsx
+++ b/admin/src/features/bills-edit/client/components/bill-form-fields.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { AlertTriangle } from "lucide-react";
 import type { Control } from "react-hook-form";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
@@ -26,6 +27,7 @@ import {
 } from "@/features/bills/shared/types";
 import type { DietSession } from "@/features/diet-sessions/shared/types";
 import type { BillCreateInput } from "../../shared/types";
+import { shouldAutoCloseInterviewOnBillStatus } from "../../shared/utils/should-auto-close-interview";
 import { ThumbnailUpload } from "./thumbnail-upload";
 
 const BILL_STATUS_OPTIONS: Array<{ value: BillStatus; label: string }> = [
@@ -98,6 +100,14 @@ export function BillFormFields({
               <FormDescription>
                 現在の審議状況を選択してください
               </FormDescription>
+              {shouldAutoCloseInterviewOnBillStatus(field.value) && (
+                <p className="text-sm text-amber-700 bg-amber-50 p-3 rounded flex items-start gap-2">
+                  <AlertTriangle className="size-4 mt-0.5 shrink-0" />
+                  <span>
+                    保存すると、この議案に紐づく公開中のインタビューは自動でクローズされます。
+                  </span>
+                </p>
+              )}
               <FormMessage />
             </FormItem>
           )}

--- a/admin/src/features/bills-edit/server/actions/update-bill.ts
+++ b/admin/src/features/bills-edit/server/actions/update-bill.ts
@@ -1,11 +1,14 @@
 "use server";
 
 import { requireAdmin } from "@/features/auth/server/lib/auth-server";
+import { closeOtherPublicConfigs } from "@/features/interview-config/server/repositories/interview-config-repository";
 import {
   invalidateWebCache,
   WEB_CACHE_TAGS,
+  type WebCacheTag,
 } from "@/lib/utils/cache-invalidation";
 import { getErrorMessage } from "@/lib/utils/get-error-message";
+import { shouldAutoCloseInterviewOnBillStatus } from "../../shared/utils/should-auto-close-interview";
 import { type BillUpdateInput, billUpdateSchema } from "../../shared/types";
 import { updateBillRecord } from "../repositories/bill-edit-repository";
 
@@ -26,8 +29,15 @@ export async function updateBill(id: string, input: BillUpdateInput) {
       updated_at: new Date().toISOString(),
     });
 
+    // 法案成立時は関連する公開中インタビューを自動でクローズする
+    const tagsToInvalidate: WebCacheTag[] = [WEB_CACHE_TAGS.BILLS];
+    if (shouldAutoCloseInterviewOnBillStatus(validatedData.status)) {
+      await closeOtherPublicConfigs(id);
+      tagsToInvalidate.push(WEB_CACHE_TAGS.INTERVIEW_CONFIGS);
+    }
+
     // web側のキャッシュを無効化
-    await invalidateWebCache([WEB_CACHE_TAGS.BILLS]);
+    await invalidateWebCache(tagsToInvalidate);
   } catch (error) {
     console.error("Update bill error:", error);
     throw new Error(

--- a/admin/src/features/bills-edit/shared/utils/should-auto-close-interview.test.ts
+++ b/admin/src/features/bills-edit/shared/utils/should-auto-close-interview.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { shouldAutoCloseInterviewOnBillStatus } from "./should-auto-close-interview";
+
+describe("shouldAutoCloseInterviewOnBillStatus", () => {
+  it("enacted のときは true を返す", () => {
+    expect(shouldAutoCloseInterviewOnBillStatus("enacted")).toBe(true);
+  });
+
+  it.each([
+    ["preparing"],
+    ["introduced"],
+    ["in_originating_house"],
+    ["in_receiving_house"],
+    ["rejected"],
+  ] as const)("%s のときは false を返す", (status) => {
+    expect(shouldAutoCloseInterviewOnBillStatus(status)).toBe(false);
+  });
+});

--- a/admin/src/features/bills-edit/shared/utils/should-auto-close-interview.ts
+++ b/admin/src/features/bills-edit/shared/utils/should-auto-close-interview.ts
@@ -1,0 +1,11 @@
+import type { BillUpdateInput } from "../types";
+
+/**
+ * 法案のステータス変更時に、関連する公開中インタビューを自動クローズすべきかを判定する。
+ * 現状は法案成立 (enacted) 時のみ対象。
+ */
+export function shouldAutoCloseInterviewOnBillStatus(
+  status: BillUpdateInput["status"]
+): boolean {
+  return status === "enacted";
+}

--- a/admin/src/features/interview-config/server/repositories/interview-config-repository.ts
+++ b/admin/src/features/interview-config/server/repositories/interview-config-repository.ts
@@ -109,7 +109,10 @@ export async function closeOtherPublicConfigs(
     query.neq("id", excludeConfigId);
   }
 
-  await query;
+  const { error } = await query;
+  if (error) {
+    throw new Error(`Failed to close interview configs: ${error.message}`);
+  }
 }
 
 export async function createInterviewConfigRecord(params: {

--- a/tests/supabase/close-other-public-configs.test.ts
+++ b/tests/supabase/close-other-public-configs.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { closeOtherPublicConfigs } from "../../admin/src/features/interview-config/server/repositories/interview-config-repository";
+import { adminClient, cleanupTestBill, createTestBill } from "./utils";
+
+describe("closeOtherPublicConfigs", () => {
+  const createdBillIds: string[] = [];
+
+  afterEach(async () => {
+    for (const id of createdBillIds) {
+      await cleanupTestBill(id);
+    }
+    createdBillIds.length = 0;
+  });
+
+  async function createConfig(
+    billId: string,
+    status: "public" | "closed",
+    name: string
+  ) {
+    const { data, error } = await adminClient
+      .from("interview_configs")
+      .insert({ bill_id: billId, status, name })
+      .select()
+      .single();
+    if (error || !data) {
+      throw new Error(`interview_config 作成失敗: ${error?.message}`);
+    }
+    return data;
+  }
+
+  it("excludeなしで呼ぶと、対象billのpublicなconfigはclosedになる", async () => {
+    const bill = await createTestBill();
+    createdBillIds.push(bill.id);
+    const config = await createConfig(bill.id, "public", "公開中設定");
+
+    await closeOtherPublicConfigs(bill.id);
+
+    const { data: updated } = await adminClient
+      .from("interview_configs")
+      .select("status")
+      .eq("id", config.id)
+      .single();
+    expect(updated?.status).toBe("closed");
+  });
+
+  it("既にclosedなconfigのupdated_atは変化しない", async () => {
+    const bill = await createTestBill();
+    createdBillIds.push(bill.id);
+    const config = await createConfig(bill.id, "closed", "クローズ済み設定");
+    const originalUpdatedAt = config.updated_at;
+
+    // UPDATE BEFORE トリガでupdated_atが上書きされないことを確認するため、
+    // 時刻が進んだ状態で呼び出す
+    await new Promise((r) => setTimeout(r, 50));
+    await closeOtherPublicConfigs(bill.id);
+
+    const { data: after } = await adminClient
+      .from("interview_configs")
+      .select("updated_at")
+      .eq("id", config.id)
+      .single();
+    expect(after?.updated_at).toBe(originalUpdatedAt);
+  });
+
+  it("別billのpublic configは影響を受けない", async () => {
+    const billA = await createTestBill();
+    const billB = await createTestBill();
+    createdBillIds.push(billA.id, billB.id);
+    const configA = await createConfig(billA.id, "public", "bill Aの設定");
+    const configB = await createConfig(billB.id, "public", "bill Bの設定");
+
+    await closeOtherPublicConfigs(billA.id);
+
+    const { data: afterA } = await adminClient
+      .from("interview_configs")
+      .select("status")
+      .eq("id", configA.id)
+      .single();
+    const { data: afterB } = await adminClient
+      .from("interview_configs")
+      .select("status")
+      .eq("id", configB.id)
+      .single();
+    expect(afterA?.status).toBe("closed");
+    expect(afterB?.status).toBe("public");
+  });
+
+  it("excludeConfigIdを渡すと、該当configは除外される", async () => {
+    // 注: interview_configs には bill_id に対して public が 1 件という
+    // 部分unique制約があるため、同一billで public を2件作れない。
+    // そのため、別billで public を作り、exclude の挙動を確認する。
+    const bill = await createTestBill();
+    createdBillIds.push(bill.id);
+    const kept = await createConfig(bill.id, "public", "残す設定");
+
+    await closeOtherPublicConfigs(bill.id, kept.id);
+
+    const { data: after } = await adminClient
+      .from("interview_configs")
+      .select("status")
+      .eq("id", kept.id)
+      .single();
+    expect(after?.status).toBe("public");
+  });
+
+  it("対象のconfigが存在しなくてもエラーにならない", async () => {
+    const bill = await createTestBill();
+    createdBillIds.push(bill.id);
+
+    await expect(closeOtherPublicConfigs(bill.id)).resolves.toBeUndefined();
+  });
+});

--- a/tests/supabase/server-only-stub.ts
+++ b/tests/supabase/server-only-stub.ts
@@ -1,0 +1,6 @@
+// `server-only` パッケージの vitest 解決用 stub。
+// 本体は非 react-server 環境で import すると throw するため、
+// admin/src 配下のサーバ専用モジュールを統合テストから import できるよう、
+// vitest の alias でこの空ファイルに差し替える。
+// （テスト対象ロジックをモックしているわけではなく、Next.js のランタイム
+// ガードを無効化しているだけ）

--- a/tests/supabase/vitest.config.mts
+++ b/tests/supabase/vitest.config.mts
@@ -24,6 +24,7 @@ export default defineConfig({
         __dirname,
         "../../packages/supabase/src"
       ),
+      "server-only": path.resolve(__dirname, "server-only-stub.ts"),
     },
   },
 });


### PR DESCRIPTION
## Summary
- bill の status が `enacted` に更新されたタイミングで、紐づく公開中の `interview_configs` を自動で `closed` に遷移させる
- 判定条件は純粋関数 `shouldAutoCloseInterviewOnBillStatus` として `shared/utils/` に切り出してユニットテストでカバー
- 閉じた後は `INTERVIEW_CONFIGS` キャッシュタグも invalidate し、web 側で古い public 状態が残らないようにする
- 既存 `closeOtherPublicConfigs` が error を握り潰していたバグを修正（`throw` に統一）
- 議案編集フォームで成立を選択した際にヘルパーテキスト（保存時の自動クローズ挙動の注記）を表示

## 実装概要
- `updateBill` アクションで `shouldAutoCloseInterviewOnBillStatus(validatedData.status)` が true なら `closeOtherPublicConfigs(id)` を呼び出す
- 新規関数は追加せず、既存の `closeOtherPublicConfigs` を再利用（exclude 引数なしで呼ぶと同一 bill の全 public を閉じる挙動）
- 統合テスト用に `tests/supabase/vitest.config.mts` に `server-only` の alias stub を追加し、admin/src のリポジトリ関数を tests/supabase/ から import できるようにした

## スクリーンショット

| 成立選択時（ヘルパーテキスト表示） | 他ステータス選択時（非表示） |
|:---:|:---:|
| <img src="https://pub-d6de2fb179d948d18c6b1ed89fcf1061.r2.dev/pr-775/enacted-helper.png" width="400" /> | <img src="https://pub-d6de2fb179d948d18c6b1ed89fcf1061.r2.dev/pr-775/non-enacted.png" width="400" /> |

## Test plan
- [x] `pnpm lint` 通過
- [x] `pnpm typecheck` 通過
- [x] `pnpm build` 通過
- [x] `pnpm test`（admin 396 tests, web 752 tests）通過
- [x] `pnpm test:integration` 通過（新規 `close-other-public-configs.test.ts` 5 ケース含む）
- [x] 新規 `should-auto-close-interview.test.ts` で enacted のみ true を返すこと、他ステータス（preparing/introduced/in_originating_house/in_receiving_house/rejected）で false を返すことを検証
- [x] 議案編集画面で成立を選択するとヘルパーテキストが表示され、他ステータスでは非表示になることをブラウザで確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 法案ステータスが「成立」に変更された場合、関連する公開インタビュー設定が自動でクローズされるようになりました。
  * ステータス欄に保存時に公開インタビューが自動クローズされる旨の警告表示を追加しました。

* **バグ修正**
  * インタビュー設定クローズ処理のエラーハンドリングを強化し、失敗時に適切に例外が報告されるようにしました。
  * キャッシュ無効化の対象が拡張され、関連インタビュー設定も適切に無効化されるようになりました。

* **テスト**
  * 自動クローズ判定のユニットテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->