### PR TITLE
MCPのupdate_tagツールをPATCH方式に変更

### DIFF
--- a/admin/src/features/mcp/server/tools/register-tags-tools.ts
+++ b/admin/src/features/mcp/server/tools/register-tags-tools.ts
@@ -64,23 +64,23 @@ export function registerTagsTools(server: McpServer): void {
     {
       title: "タグを更新",
       description:
-        "指定IDのタグを更新する。label(必須) と任意で description / featured_priority を変更できる。",
+        "指定IDのタグを更新する（PATCH方式）。指定したフィールドのみ更新され、省略したフィールドは既存値を維持する。明示的にnullを渡すとクリアできる。",
       inputSchema: {
         id: z.string().uuid(),
-        label: z.string().min(1),
+        label: z.string().min(1).optional(),
         description: z.string().nullable().optional(),
         featured_priority: z.number().int().nullable().optional(),
       },
     },
     async ({ id, label, description, featured_priority }) => {
-      const trimmed = label.trim();
-      if (trimmed.length === 0) {
+      const trimmed = label?.trim();
+      if (trimmed !== undefined && trimmed.length === 0) {
         return jsonResult({ ok: false, error: "タグ名を入力してください" });
       }
       const result = await updateTagRecord(id, {
         label: trimmed,
-        description: description ?? null,
-        featured_priority: featured_priority ?? null,
+        description,
+        featured_priority,
       });
       if (result.error) {
         return jsonResult({

--- a/admin/src/features/tags/server/repositories/tag-repository.ts
+++ b/admin/src/features/tags/server/repositories/tag-repository.ts
@@ -1,6 +1,9 @@
 import "server-only";
 
 import { createAdminClient } from "@mirai-gikai/supabase";
+import type { Database } from "@mirai-gikai/supabase";
+
+type TagUpdate = Database["public"]["Tables"]["tags"]["Update"];
 
 export async function findAllTagsWithBillCount() {
   const supabase = createAdminClient();
@@ -59,19 +62,34 @@ export async function createTagRecord(input: {
 export async function updateTagRecord(
   id: string,
   input: {
-    label: string;
+    label?: string;
     description?: string | null;
     featured_priority?: number | null;
   }
 ) {
   const supabase = createAdminClient();
+
+  // PATCH方式: undefinedのフィールドはupdate対象に含めず既存値を維持する
+  const updateData: TagUpdate = {};
+  if (input.label !== undefined) updateData.label = input.label;
+  if (input.description !== undefined)
+    updateData.description = input.description;
+  if (input.featured_priority !== undefined)
+    updateData.featured_priority = input.featured_priority;
+
+  if (Object.keys(updateData).length === 0) {
+    return {
+      data: null,
+      error: {
+        code: "EMPTY_UPDATE",
+        message: "更新するフィールドがありません",
+      },
+    };
+  }
+
   const { data, error } = await supabase
     .from("tags")
-    .update({
-      label: input.label,
-      description: input.description,
-      featured_priority: input.featured_priority,
-    })
+    .update(updateData)
     .eq("id", id)
     .select()
     .single();

--- a/admin/src/features/tags/shared/utils/map-tag-db-error.test.ts
+++ b/admin/src/features/tags/shared/utils/map-tag-db-error.test.ts
@@ -15,6 +15,14 @@ describe("mapTagDbError", () => {
     expect(mapTagDbError(error, "削除")).toBe("タグが見つかりません");
   });
 
+  it("EMPTY_UPDATEコード（空更新）で専用メッセージを返す", () => {
+    const error = {
+      code: "EMPTY_UPDATE",
+      message: "更新するフィールドがありません",
+    };
+    expect(mapTagDbError(error, "更新")).toBe("更新するフィールドがありません");
+  });
+
   it("未知のエラーコードでは操作名付きの汎用メッセージを返す", () => {
     const error = { code: "42501", message: "permission denied" };
     expect(mapTagDbError(error, "作成")).toBe(

--- a/admin/src/features/tags/shared/utils/map-tag-db-error.ts
+++ b/admin/src/features/tags/shared/utils/map-tag-db-error.ts
@@ -16,5 +16,8 @@ export function mapTagDbError(error: DbError, operation: TagOperation): string {
   if (error.code === "PGRST116") {
     return "タグが見つかりません";
   }
+  if (error.code === "EMPTY_UPDATE") {
+    return "更新するフィールドがありません";
+  }
   return `タグの${operation}に失敗しました: ${error.message}`;
 }


### PR DESCRIPTION
## Summary
- MCP `update_tag` ツールを PATCH 方式に変更。省略したフィールドは既存値を維持し、明示的に `null` を渡した場合のみクリアされるようにした
- 従来は `description ?? null` で未指定フィールドが `null` に変換されており、tag rename 時に `description` と `featured_priority` が消失するバグがあった
- リポジトリ層の `updateTagRecord` を型安全な `TagUpdate` 型に変更し、空 update のガード処理を追加

## Changes
- `admin/src/features/mcp/server/tools/register-tags-tools.ts`: `label` を optional に変更、`?? null` を除去
- `admin/src/features/tags/server/repositories/tag-repository.ts`: PATCH 方式の update object 構築、`TagUpdate` 型の利用、空 update ガード追加

## Test plan
- [x] `pnpm lint` 通過
- [x] `pnpm typecheck` 通過
- [x] `pnpm build` 通過
- [x] `pnpm test` 全テスト通過（752 tests）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **改善**
  * タグ更新がパーシャルアップデートに対応しました。指定された項目のみが更新され、未指定項目は既存のまま保持されます。
* **バグ修正**
  * フィールド未指定による空更新を検出して明確なエラーを返すようになりました（「更新するフィールドがありません」）。
* **テスト**
  * 上記エラー処理を検証するユニットテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->