### PR TITLE
シミュ実行API の themes 文字数上限を 2000 に緩和

### DIFF
--- a/admin/src/features/interview-simulation/shared/schemas.test.ts
+++ b/admin/src/features/interview-simulation/shared/schemas.test.ts
@@ -183,9 +183,9 @@ describe("multiSimulationRunRequestSchema", () => {
     expect(result.success).toBe(false);
   });
 
-  it("themes 要素が 200 文字を超えると拒否", () => {
+  it("themes 要素が 2_000 文字を超えると拒否", () => {
     const body = baseValidRequest();
-    body.improvedConfig.themes = ["a".repeat(201)];
+    body.improvedConfig.themes = ["a".repeat(2_001)];
     const result = multiSimulationRunRequestSchema.safeParse(body);
     expect(result.success).toBe(false);
   });

--- a/admin/src/features/interview-simulation/shared/schemas.ts
+++ b/admin/src/features/interview-simulation/shared/schemas.ts
@@ -312,7 +312,7 @@ export const multiSimulationRunRequestSchema = z
       .object({
         mode: z.enum(["loop", "bulk"]),
         themes: z
-          .array(z.string().max(SHORT_TEXT_MAX))
+          .array(z.string().max(MEDIUM_TEXT_MAX))
           .max(SMALL_ARRAY_MAX)
           .nullable(),
         knowledgeSource: z.string().max(LONG_TEXT_MAX).nullable(),


### PR DESCRIPTION
## Summary
- `シミュレート開始` クリック時に `improvedConfig.themes.0: Too big: expected string to have <=200 characters` で 400 になっていた
- `multiSimulationRunRequestSchema` の `improvedConfig.themes` 要素の上限を `SHORT_TEXT_MAX` (200) から `MEDIUM_TEXT_MAX` (2000) に緩和
- themes は LLM 生成・手編集の自由記述フィールドで、sibling の `question` / `follow_up_guide` と同じ `MEDIUM_TEXT_MAX` に揃える
- `quick_replies` は UI chip 相当なので `SHORT_TEXT_MAX` のまま維持

## Test plan
- [x] `pnpm --filter admin test` 397/397 passed
- [x] `pnpm typecheck` passed
- [x] `pnpm lint` passed（新規警告なし）
- [x] CI 通過確認
- [x] シミュ画面から実テーマ（200文字超）を含む config で `シミュレート開始` が成功することを実機確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **機能改善**
  * インタビューシミュレーション設定でテーマ入力のテキスト長制限を拡大しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->