### PR TITLE
AI設定生成での質問確定時の二重保存を修正

### DIFF
--- a/admin/src/features/interview-config/client/components/interview-question-list.tsx
+++ b/admin/src/features/interview-config/client/components/interview-question-list.tsx
@@ -68,15 +68,13 @@ export function InterviewQuestionList({
     [interviewConfigId]
   );
 
-  // AI生成質問の反映
+  // 保存は親側で実行するためここでは state 反映のみ（二重保存による race condition 防止）
   useEffect(() => {
     if (aiGeneratedQuestions && aiGeneratedQuestions.length > 0) {
       setQuestions(aiGeneratedQuestions);
-      saveQuestions(aiGeneratedQuestions);
       onAiQuestionsApplied?.();
-      toast.success(`AIが${aiGeneratedQuestions.length}件の質問を生成しました`);
     }
-  }, [aiGeneratedQuestions, saveQuestions, onAiQuestionsApplied]);
+  }, [aiGeneratedQuestions, onAiQuestionsApplied]);
 
   const handleAdd = (newQuestion: InterviewQuestionInput) => {
     const newQuestions = [...questions, newQuestion];


### PR DESCRIPTION
## Summary
- 「AIで設定を生成」で「質問を確定してフォームに反映」を押したときに、質問一覧の内容が反映されない（または重複する）ことがあるバグを修正。
- 親 `InterviewConfigEditClient` の `handleQuestionsConfirmed` と、子 `InterviewQuestionList` の useEffect が、同一 configId に対して並行で `saveInterviewQuestions`(DELETE→INSERT) を呼んでいた。`interview_questions` には `(interview_config_id, question_order)` のユニーク制約がないため、インターリーブによって以下が発生していた:
  - A: DELETE → B: DELETE → A: INSERT → B: INSERT → **行が重複**
  - A: DELETE → A: INSERT → B: DELETE(Aの結果を消す) → B: INSERT
  - `router.refresh()` が B の DELETE 中に server fetch を走らせる
- 修正方針: 保存は親側 (`handleQuestionsConfirmed`) に一本化し、子側の useEffect は `aiGeneratedQuestions` をローカル state に反映する責務のみに絞る。親が `await saveInterviewQuestions` → `router.refresh()` を順序通り実行でき、race が根本から消える。

## Test plan
- [x] 「AIで設定を生成」→ テーマ確定 → 質問確定 を実行し、質問一覧に提案質問がそのまま反映されること
- [x] 確定後にページリロードしても質問が重複せず、提案通りの件数で保存されていること
- [x] 既存の質問を手動で追加/更新/削除する操作が引き続き正常に保存されること
- [x] トースト「N件の質問を保存しました」が1回だけ表示されること（子側の重複トーストが出ない）

🤖 Generated with [Claude Code](https://claude.com/claude-code)