### PR TITLE
ナレッジソース上限を40000文字に緩和しシミュレーションタイムアウトを倍化

### DIFF
--- a/admin/src/features/interview-simulation/shared/constants.ts
+++ b/admin/src/features/interview-simulation/shared/constants.ts
@@ -52,16 +52,16 @@ export type PromptKind = (typeof PROMPT_KIND)[keyof typeof PROMPT_KIND];
  * タイムアウト時は withTimeoutRetry 側で LLM_MAX_ATTEMPTS 回までリトライする。
  */
 export const LLM_TIMEOUT_MS = {
-  /** インタビュアー / インタビュイーの 1 ターン生成。短文なので 20s で十分 */
-  interviewTurn: 20_000,
+  /** インタビュアー / インタビュイーの 1 ターン生成。短文だが knowledge source を含む長文プロンプトに耐える余裕を持たせる */
+  interviewTurn: 40_000,
   /** Summary フェーズのレポート生成（transcript 全体を読むのでやや長め） */
-  summary: 30_000,
+  summary: 60_000,
   /** ペルソナ生成（report 抽出 / bill 生成とも）。推論量が多め */
-  persona: 60_000,
+  persona: 120_000,
   /** 満足度評価（transcript 全体を読む） */
-  satisfaction: 45_000,
+  satisfaction: 90_000,
   /** 総合評価（全ペルソナの情報を横断） */
-  overallEvaluation: 60_000,
+  overallEvaluation: 120_000,
 } as const;
 
 /** LLM 呼び出しの最大試行回数（1 = リトライなし、2 = 1 回リトライ） */

--- a/admin/src/features/interview-simulation/shared/schemas.test.ts
+++ b/admin/src/features/interview-simulation/shared/schemas.test.ts
@@ -162,9 +162,9 @@ describe("multiSimulationRunRequestSchema", () => {
     }
   });
 
-  it("knowledgeSource が 20000 文字を超えると拒否", () => {
+  it("knowledgeSource が 40000 文字を超えると拒否", () => {
     const body = baseValidRequest();
-    body.improvedConfig.knowledgeSource = "a".repeat(20_001);
+    body.improvedConfig.knowledgeSource = "a".repeat(40_001);
     const result = multiSimulationRunRequestSchema.safeParse(body);
     expect(result.success).toBe(false);
   });

--- a/admin/src/features/interview-simulation/shared/schemas.ts
+++ b/admin/src/features/interview-simulation/shared/schemas.ts
@@ -10,7 +10,7 @@ import { MAX_PERSONA_SLOTS } from "./constants";
 const ID_MAX = 100;
 const SHORT_TEXT_MAX = 200;
 const MEDIUM_TEXT_MAX = 2_000;
-const LONG_TEXT_MAX = 20_000;
+const LONG_TEXT_MAX = 40_000;
 const SMALL_ARRAY_MAX = 20;
 const MEDIUM_ARRAY_MAX = 50;
 


### PR DESCRIPTION
## Summary
- ナレッジソース (`knowledgeSource`) の検証上限を 20,000 → 40,000 文字に緩和（`admin/src/features/interview-simulation/shared/schemas.ts` の `LONG_TEXT_MAX`）
- multi-simulation pipeline 内の LLM 個別呼び出しタイムアウトを全体的に倍化（`LLM_TIMEOUT_MS`）。入力トークン増加によるタイムアウト悪化リスクを抑える狙い
  - interviewTurn: 20s → 40s
  - summary: 30s → 60s
  - persona: 60s → 120s
  - satisfaction: 45s → 90s
  - overallEvaluation: 60s → 120s
- 既存の境界値テストを 40_001 文字で拒否される版に更新

## Test plan
- [x] `pnpm --filter admin test`（397 件パス）
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [ ] 実機で 40k 弱のナレッジソースを設定したシミュレーション実行（複数ペルソナ）が完走することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)