### PR TITLE
インタビュー一覧のセッション数の集計バグを修正

### DIFF
--- a/admin/src/app/(protected)/interviews/page.tsx
+++ b/admin/src/app/(protected)/interviews/page.tsx
@@ -3,7 +3,7 @@ import { getCurrentAdmin } from "@/features/auth/server/lib/auth-server";
 import { AllInterviewConfigList } from "@/features/interviews/server/components/all-interview-config-list";
 import {
   getAllInterviewConfigs,
-  getAllSessionCounts,
+  getSessionCountsForConfigs,
 } from "@/features/interviews/server/loaders/get-all-interview-configs";
 import { routes } from "@/lib/routes";
 
@@ -14,10 +14,10 @@ export default async function InterviewsPage() {
     redirect(routes.login());
   }
 
-  const [configs, sessionCounts] = await Promise.all([
-    getAllInterviewConfigs(),
-    getAllSessionCounts(),
-  ]);
+  const configs = await getAllInterviewConfigs();
+  const sessionCounts = await getSessionCountsForConfigs(
+    configs.map((config) => config.id)
+  );
 
   return (
     <div className="container mx-auto py-8">

--- a/admin/src/features/interview-config/server/repositories/interview-config-repository.ts
+++ b/admin/src/features/interview-config/server/repositories/interview-config-repository.ts
@@ -191,26 +191,6 @@ export async function countSessionsByConfigIds(
   return result;
 }
 
-export async function countAllSessionsByConfigId(): Promise<
-  Record<string, number>
-> {
-  const supabase = createAdminClient();
-  const { data, error } = await supabase
-    .from("interview_sessions")
-    .select("interview_config_id");
-
-  if (error) {
-    throw new Error(`Failed to count sessions: ${error.message}`);
-  }
-
-  const result: Record<string, number> = {};
-  for (const row of data) {
-    result[row.interview_config_id] =
-      (result[row.interview_config_id] ?? 0) + 1;
-  }
-  return result;
-}
-
 export async function deleteInterviewConfigRecord(
   configId: string
 ): Promise<void> {

--- a/admin/src/features/interviews/server/loaders/get-all-interview-configs.ts
+++ b/admin/src/features/interviews/server/loaders/get-all-interview-configs.ts
@@ -1,10 +1,10 @@
 import "server-only";
 
 import {
+  countSessionsByConfigIds,
   findAllInterviewConfigs,
   type InterviewConfigWithBill,
 } from "@/features/interview-config/server/repositories/interview-config-repository";
-import { countAllSessionsByConfigId } from "@/features/interview-config/server/repositories/interview-config-repository";
 
 export async function getAllInterviewConfigs(): Promise<
   InterviewConfigWithBill[]
@@ -17,12 +17,11 @@ export async function getAllInterviewConfigs(): Promise<
   }
 }
 
-export async function getAllSessionCounts(): Promise<Record<
-  string,
-  number
-> | null> {
+export async function getSessionCountsForConfigs(
+  configIds: string[]
+): Promise<Record<string, number> | null> {
   try {
-    return await countAllSessionsByConfigId();
+    return await countSessionsByConfigIds(configIds);
   } catch (error) {
     console.error("Failed to fetch session counts:", error);
     return null;


### PR DESCRIPTION
## Summary

- `/admin/interviews` で表示されるセッション数が、実際の数（例: 25件）より大幅に少ない値（例: 3件）になっていた
- 原因: `countAllSessionsByConfigId` が `interview_sessions` を `.select(\"interview_config_id\")` で全件取得して JS 側で集計していたが、Supabase (PostgREST) の `max_rows = 1000` 制限により最大 1000 行しか返らず、テーブル総行数が 1000 を超えると過小カウントになっていた
- 修正: 既存の RPC `count_sessions_by_config_ids`（SQL の `count()` 集計、行数制限の影響を受けない）を呼び出すローダーに差し替え。バグ関数 `countAllSessionsByConfigId` は削除
- 集計対象は従来どおり「全セッション数」を維持（in_progress 含む）。`/admin/bills/[id]/interview` の表示と同じ集計ロジックに統一される

## Test plan

- [x] `pnpm typecheck` 通過
- [x] `pnpm --filter admin test` 通過 (397/397)
- [ ] ステージング/本番環境で `/admin/interviews` を開き、セッション数が `/admin/bills/[id]/interview/[configId]/reports` の総セッション数（フィルタなし）と一致することを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **リファクタリング**
  * インタビュー設定のセッションカウント取得ロジックを改善しました。設定IDごとのスコープ付き読み込み処理に変更し、データ取得フローを最適化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->