### PR TITLE
admin AIインタビュー設定にシステムプロンプトプレビュータブを追加

### DIFF
--- a/admin/src/app/(protected)/bills/[id]/interview/[configId]/edit/page.tsx
+++ b/admin/src/app/(protected)/bills/[id]/interview/[configId]/edit/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import { getBillById } from "@/features/bills-edit/server/loaders/get-bill-by-id";
+import { getBillPromptInputForBill } from "@/features/interview-config/server/loaders/get-bill-prompt-input";
 import { InterviewConfigEditClient } from "@/features/interview-config/client/components/interview-config-edit-client";
 import { getInterviewConfigById } from "@/features/interview-config/server/loaders/get-interview-config";
 import { getInterviewQuestions } from "@/features/interview-config/server/loaders/get-interview-questions";
@@ -30,10 +31,12 @@ export default async function InterviewEditPage({
     notFound();
   }
 
-  const [questions, completedReportsResult] = await Promise.all([
-    getInterviewQuestions(config.id),
-    getCompletedReportsForBill(bill.id),
-  ]);
+  const [questions, completedReportsResult, billPromptInput] =
+    await Promise.all([
+      getInterviewQuestions(config.id),
+      getCompletedReportsForBill(bill.id),
+      getBillPromptInputForBill(bill),
+    ]);
 
   return (
     <div>
@@ -61,6 +64,7 @@ export default async function InterviewEditPage({
         billId={bill.id}
         config={config}
         questions={questions}
+        billPromptInput={billPromptInput}
         completedReports={completedReportsResult.reports}
         completedReportsTruncated={completedReportsResult.isTruncated}
         completedReportsLimit={completedReportsResult.limit}

--- a/admin/src/app/(protected)/bills/[id]/interview/new/page.tsx
+++ b/admin/src/app/(protected)/bills/[id]/interview/new/page.tsx
@@ -5,6 +5,7 @@ import { notFound } from "next/navigation";
 
 import { getBillById } from "@/features/bills-edit/server/loaders/get-bill-by-id";
 import { InterviewConfigEditClient } from "@/features/interview-config/client/components/interview-config-edit-client";
+import { getBillPromptInputForBill } from "@/features/interview-config/server/loaders/get-bill-prompt-input";
 import { routes } from "@/lib/routes";
 
 interface InterviewNewPageProps {
@@ -22,6 +23,8 @@ export default async function InterviewNewPage({
   if (!bill) {
     notFound();
   }
+
+  const billPromptInput = await getBillPromptInputForBill(bill);
 
   return (
     <div>
@@ -48,6 +51,7 @@ export default async function InterviewNewPage({
         billId={bill.id}
         config={null}
         questions={[]}
+        billPromptInput={billPromptInput}
         completedReports={[]}
       />
     </div>

--- a/admin/src/features/interview-config/client/components/interview-config-edit-client.tsx
+++ b/admin/src/features/interview-config/client/components/interview-config-edit-client.tsx
@@ -85,7 +85,7 @@ export function InterviewConfigEditClient({
           const result = await createInterviewConfig(billId, {
             name: formValues?.name || "AI生成設定",
             status: "closed",
-            mode: formValues?.mode || "loop",
+            mode: formValues?.mode ?? "loop",
             themes,
             knowledge_source: formValues?.knowledge_source || "",
             chat_model: formValues?.chat_model || null,
@@ -152,7 +152,7 @@ export function InterviewConfigEditClient({
       const result = await updateInterviewConfig(targetConfigId, {
         name: formValues?.name || initialConfig?.name || "AI生成設定",
         status: initialConfig?.status || "closed",
-        mode: formValues?.mode || initialConfig?.mode || "loop",
+        mode: formValues?.mode ?? initialConfig?.mode ?? "loop",
         themes,
         knowledge_source:
           formValues?.knowledge_source || initialConfig?.knowledge_source || "",

--- a/admin/src/features/interview-config/client/components/interview-config-edit-client.tsx
+++ b/admin/src/features/interview-config/client/components/interview-config-edit-client.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { PromptBillInput } from "@mirai-gikai/shared/interview-prompts/types";
 import { useRouter } from "next/navigation";
 import { useCallback, useRef, useState } from "react";
 import { toast } from "sonner";
@@ -15,17 +16,21 @@ import {
 } from "../../server/actions/upsert-interview-config";
 import type {
   InterviewConfig,
+  InterviewConfigFormValues,
   InterviewQuestion,
   InterviewQuestionInput,
 } from "../../shared/types";
 import { ConfigGenerationChat } from "./config-generation-chat";
 import { InterviewConfigForm } from "./interview-config-form";
 import { InterviewQuestionList } from "./interview-question-list";
+import { SystemPromptPreview } from "./system-prompt-preview";
 
 interface InterviewConfigEditClientProps {
   billId: string;
   config: InterviewConfig | null;
   questions: InterviewQuestion[];
+  /** プロンプトプレビュー用の Bill 情報 */
+  billPromptInput: PromptBillInput;
   completedReports: CompletedReportListItem[];
   /** レポート一覧が上限で切り詰められたか（シミュレーション UI の警告表示用） */
   completedReportsTruncated?: boolean;
@@ -37,6 +42,7 @@ export function InterviewConfigEditClient({
   billId,
   config: initialConfig,
   questions,
+  billPromptInput,
   completedReports,
   completedReportsTruncated = false,
   completedReportsLimit,
@@ -53,17 +59,9 @@ export function InterviewConfigEditClient({
   >(null);
 
   // フォームの値を取得するためのref
-  const getFormValuesRef = useRef<
-    | (() => {
-        name: string;
-        knowledge_source: string;
-        mode: string;
-        themes: string[];
-        chat_model: string | null;
-        estimated_duration: number | null;
-      })
-    | null
-  >(null);
+  const getFormValuesRef = useRef<(() => InterviewConfigFormValues) | null>(
+    null
+  );
   // 質問一覧の現在値を取得するための ref（シミュレーション機能で使用）
   const getQuestionsRef = useRef<(() => InterviewQuestionInput[]) | null>(null);
 
@@ -87,7 +85,7 @@ export function InterviewConfigEditClient({
           const result = await createInterviewConfig(billId, {
             name: formValues?.name || "AI生成設定",
             status: "closed",
-            mode: (formValues?.mode as "loop" | "bulk") || "loop",
+            mode: formValues?.mode || "loop",
             themes,
             knowledge_source: formValues?.knowledge_source || "",
             chat_model: formValues?.chat_model || null,
@@ -154,10 +152,7 @@ export function InterviewConfigEditClient({
       const result = await updateInterviewConfig(targetConfigId, {
         name: formValues?.name || initialConfig?.name || "AI生成設定",
         status: initialConfig?.status || "closed",
-        mode:
-          (formValues?.mode as "loop" | "bulk") ||
-          initialConfig?.mode ||
-          "loop",
+        mode: formValues?.mode || initialConfig?.mode || "loop",
         themes,
         knowledge_source:
           formValues?.knowledge_source || initialConfig?.knowledge_source || "",
@@ -182,6 +177,7 @@ export function InterviewConfigEditClient({
     <Tabs defaultValue="edit" className="w-full">
       <TabsList>
         <TabsTrigger value="edit">設定編集</TabsTrigger>
+        <TabsTrigger value="prompt">プロンプトプレビュー</TabsTrigger>
         <TabsTrigger value="simulation" disabled={!configId}>
           シミュレーション
           {!configId && "（保存後に有効）"}
@@ -235,6 +231,20 @@ export function InterviewConfigEditClient({
             />
           </div>
         </div>
+      </TabsContent>
+
+      <TabsContent
+        value="prompt"
+        forceMount
+        className="mt-4 data-[state=inactive]:hidden"
+      >
+        <SystemPromptPreview
+          bill={billPromptInput}
+          initialConfig={initialConfig}
+          initialQuestions={questions}
+          getFormValuesRef={getFormValuesRef}
+          getQuestionsRef={getQuestionsRef}
+        />
       </TabsContent>
 
       {configId ? (

--- a/admin/src/features/interview-config/client/components/interview-config-form.tsx
+++ b/admin/src/features/interview-config/client/components/interview-config-form.tsx
@@ -39,6 +39,7 @@ import {
 import {
   arrayToText,
   type InterviewConfig,
+  type InterviewConfigFormValues,
   type InterviewConfigInput,
   interviewConfigSchema,
   textToArray,
@@ -55,17 +56,7 @@ interface InterviewConfigFormProps {
   aiGeneratedThemes?: string[] | null;
   onAiThemesApplied?: () => void;
   onConfigCreated?: (configId: string) => Promise<void>;
-  getFormValuesRef?: MutableRefObject<
-    | (() => {
-        name: string;
-        knowledge_source: string;
-        mode: string;
-        themes: string[];
-        chat_model: string | null;
-        estimated_duration: number | null;
-      })
-    | null
-  >;
+  getFormValuesRef?: MutableRefObject<(() => InterviewConfigFormValues) | null>;
 }
 
 export function InterviewConfigForm({

--- a/admin/src/features/interview-config/client/components/system-prompt-preview.tsx
+++ b/admin/src/features/interview-config/client/components/system-prompt-preview.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { buildBulkModeSystemPrompt } from "@mirai-gikai/shared/interview-prompts/bulk-mode";
+import { buildLoopModeSystemPrompt } from "@mirai-gikai/shared/interview-prompts/loop-mode";
+import type {
+  InterviewQuestion as PromptInterviewQuestion,
+  PromptBillInput,
+} from "@mirai-gikai/shared/interview-prompts/types";
+import { Copy, RefreshCw } from "lucide-react";
+import { type MutableRefObject, useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type {
+  InterviewConfig,
+  InterviewConfigFormValues,
+  InterviewQuestion,
+  InterviewQuestionInput,
+} from "../../shared/types";
+
+interface SystemPromptPreviewProps {
+  bill: PromptBillInput;
+  initialConfig: InterviewConfig | null;
+  initialQuestions: InterviewQuestion[];
+  getFormValuesRef: MutableRefObject<(() => InterviewConfigFormValues) | null>;
+  getQuestionsRef: MutableRefObject<(() => InterviewQuestionInput[]) | null>;
+}
+
+interface BuildPromptParams {
+  bill: PromptBillInput;
+  mode: string;
+  themes: string[];
+  knowledgeSource: string;
+  estimatedDuration: number | null;
+  questions: PromptInterviewQuestion[];
+}
+
+function buildPrompt({
+  bill,
+  mode,
+  themes,
+  knowledgeSource,
+  estimatedDuration,
+  questions,
+}: BuildPromptParams): string {
+  const params = {
+    bill,
+    interviewConfig: { themes, knowledge_source: knowledgeSource },
+    questions,
+    currentStage: "chat" as const,
+    askedQuestionIds: new Set<string>(),
+    remainingMinutes: estimatedDuration ?? null,
+  };
+  return mode === "bulk"
+    ? buildBulkModeSystemPrompt(params)
+    : buildLoopModeSystemPrompt(params);
+}
+
+export function SystemPromptPreview({
+  bill,
+  initialConfig,
+  initialQuestions,
+  getFormValuesRef,
+  getQuestionsRef,
+}: SystemPromptPreviewProps) {
+  const [prompt, setPrompt] = useState(() =>
+    buildPrompt({
+      bill,
+      mode: initialConfig?.mode ?? "loop",
+      themes: initialConfig?.themes ?? [],
+      knowledgeSource: initialConfig?.knowledge_source ?? "",
+      estimatedDuration: initialConfig?.estimated_duration ?? null,
+      questions: initialQuestions.map((q) => ({
+        id: q.id,
+        question: q.question,
+        quick_replies: q.quick_replies,
+        follow_up_guide: q.follow_up_guide,
+      })),
+    })
+  );
+
+  const refresh = () => {
+    const values = getFormValuesRef.current?.();
+    const questionInputs = getQuestionsRef.current?.() ?? [];
+    // 編集中の質問は ID 未確定なため、プロンプト中の表示用に擬似 ID を付与する
+    const questions: PromptInterviewQuestion[] = questionInputs.map((q, i) => ({
+      id: `preview-${i + 1}`,
+      question: q.question ?? "",
+      quick_replies: q.quick_replies ?? null,
+      follow_up_guide: q.follow_up_guide ?? null,
+    }));
+    setPrompt(
+      buildPrompt({
+        bill,
+        mode: values?.mode ?? "loop",
+        themes: values?.themes ?? [],
+        knowledgeSource: values?.knowledge_source ?? "",
+        estimatedDuration: values?.estimated_duration ?? null,
+        questions,
+      })
+    );
+  };
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(prompt);
+      toast.success("プロンプトをコピーしました");
+    } catch {
+      toast.error("コピーに失敗しました");
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0">
+        <CardTitle>システムプロンプトプレビュー</CardTitle>
+        <div className="flex gap-2">
+          <Button type="button" variant="outline" size="sm" onClick={refresh}>
+            <RefreshCw className="mr-2 h-4 w-4" />
+            再生成
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={handleCopy}
+          >
+            <Copy className="mr-2 h-4 w-4" />
+            コピー
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <p className="text-sm text-gray-600 mb-3">
+          フォームと質問の現在値からインタビュー時のシステムプロンプトを構築して表示します（chat
+          ステージ・未質問状態を仮定）。フォームを編集したら「再生成」を押してください。
+        </p>
+        <pre className="text-xs whitespace-pre-wrap break-words bg-gray-50 border rounded p-3 max-h-[600px] overflow-auto">
+          {prompt}
+        </pre>
+      </CardContent>
+    </Card>
+  );
+}

--- a/admin/src/features/interview-config/client/components/system-prompt-preview.tsx
+++ b/admin/src/features/interview-config/client/components/system-prompt-preview.tsx
@@ -28,7 +28,7 @@ interface SystemPromptPreviewProps {
 
 interface BuildPromptParams {
   bill: PromptBillInput;
-  mode: string;
+  mode: "loop" | "bulk";
   themes: string[];
   knowledgeSource: string;
   estimatedDuration: number | null;

--- a/admin/src/features/interview-config/server/loaders/get-bill-prompt-input.ts
+++ b/admin/src/features/interview-config/server/loaders/get-bill-prompt-input.ts
@@ -1,0 +1,36 @@
+import "server-only";
+
+import type { PromptBillInput } from "@mirai-gikai/shared/interview-prompts/types";
+import { findBillContentsByBillId } from "@/features/bills-edit/server/repositories/bill-edit-repository";
+import type { Bill } from "@/features/bills-edit/shared/types";
+
+/**
+ * プロンプトプレビュー用の Bill 情報を組み立てる。
+ *
+ * 実行時のインタビュー側では難易度が動的に切り替わるが、プレビューでは
+ * シミュレーション側と揃えて "normal" 難易度のコンテンツを使用する。
+ *
+ * Bill 自体は呼び出し側で既に取得済みである前提で受け取り、bill_contents の
+ * 取得のみ行う（同一リクエスト内での bill 重複取得を避けるため）。
+ */
+export async function getBillPromptInputForBill(
+  bill: Bill
+): Promise<PromptBillInput> {
+  try {
+    const contents = await findBillContentsByBillId(bill.id);
+    const normalContent = contents.find((c) => c.difficulty_level === "normal");
+    return {
+      name: bill.name,
+      bill_content: normalContent
+        ? {
+            title: normalContent.title,
+            summary: normalContent.summary,
+            content: normalContent.content,
+          }
+        : null,
+    };
+  } catch (error) {
+    console.error("Failed to fetch bill contents for prompt preview:", error);
+    return { name: bill.name, bill_content: null };
+  }
+}

--- a/admin/src/features/interview-config/server/loaders/get-bill-prompt-input.ts
+++ b/admin/src/features/interview-config/server/loaders/get-bill-prompt-input.ts
@@ -30,7 +30,10 @@ export async function getBillPromptInputForBill(
         : null,
     };
   } catch (error) {
-    console.error("Failed to fetch bill contents for prompt preview:", error);
+    console.error(
+      `Failed to fetch bill contents for prompt preview (billId=${bill.id}):`,
+      error
+    );
     return { name: bill.name, bill_content: null };
   }
 }

--- a/admin/src/features/interview-config/shared/types/index.ts
+++ b/admin/src/features/interview-config/shared/types/index.ts
@@ -64,4 +64,17 @@ export type InterviewQuestionsInput = z.infer<
   typeof interviewQuestionsInputSchema
 >;
 
+/**
+ * 編集中フォームの現在値を親 / 兄弟コンポーネントから読み取るための共通型。
+ * `getFormValuesRef` 経由で受け渡しされる。
+ */
+export type InterviewConfigFormValues = {
+  name: string;
+  knowledge_source: string;
+  mode: "loop" | "bulk";
+  themes: string[];
+  chat_model: string | null;
+  estimated_duration: number | null;
+};
+
 export { arrayToText, textToArray } from "../utils/array-text-conversion";


### PR DESCRIPTION
## 概要

AIインタビューでLLMに送信されるシステムプロンプト全文をadmin上で確認できるようにする。

現在マスタープロンプトは `packages/shared/src/interview-prompts/{loop,bulk}-mode.ts` にハードコードされており、全AIインタビューで共通。プロンプト本体はDBに持っていない。一方で「`Loop Mode` のプロンプトに `その文脈に沿った追加の質問を2〜3問重ねてください` という指示があり、しつこく感じるケースがある」など、設定値（mode / themes / knowledge_source / questions）と最終的なプロンプト文面の対応関係が見えづらい状況だった。

そこで第1段階として、ハードコードされた現在のプロンプトを admin 上で view できるタブを追加する。第2段階で「狭い設定値だけ追加」（深掘り回数の調整など）に進める想定。

## 変更内容

- `admin/src/features/interview-config/client/components/system-prompt-preview.tsx` を新規追加。`@mirai-gikai/shared` の `buildLoopModeSystemPrompt` / `buildBulkModeSystemPrompt` を呼び出してシステムプロンプトを描画する。`chat` ステージ・未質問状態を仮定。
- インタビュー設定編集画面に「プロンプトプレビュー」タブを追加（`設定編集` と `シミュレーション` の間）。
- 「再生成」ボタンで、未保存のフォーム値（mode / themes / knowledge_source / estimated_duration）と編集中の質問を反映してプロンプトを再描画。「コピー」ボタンでクリップボードへコピー。
- プロンプトプレビュー用に bill_contents（`normal` 難易度）を取得する `getBillPromptInputForBill` loader を追加。`bill` を引数で受け取り、ページ側で既に取得済みの `Bill` を再フェッチしないようにしている。
- フォームの現在値共有用に `InterviewConfigFormValues` を `shared/types/index.ts` に切り出し、3ファイル（form / edit-client / system-prompt-preview）で再利用。`mode` を `"loop" | "bulk"` union に絞ったことで、`createConfigIfNeeded` / `handleThemesConfirmed` 内の `as "loop" | "bulk"` 型アサーションを削除。

## スコープ外（次フェーズ）

- プロンプトの編集・per-config 化
- 「2〜3問」のような深掘り強度を狭い設定値として追加

## 検証

- [x] `pnpm typecheck` 通過
- [x] `pnpm --filter admin test` 通過 (416 tests)
- [x] `pnpm test`（全ワークスペース）通過 (752 tests)
- [x] `pnpm lint` 警告数差分ゼロ（baseline と同じ129件、追加 / 既存ファイルとも新規警告なし）
- [ ] `pnpm build` はサンドボックス環境からGoogle Fontsへの接続が遮断されている影響で完走せず（既存issueで本変更とは無関係）。CI上で確認

## テスト計画

- [ ] admin で既存のインタビュー設定編集画面を開き、「プロンプトプレビュー」タブが表示されることを確認
- [ ] タブ初期表示で保存済みの設定値に基づくプロンプト全文が表示されることを確認
- [ ] mode を loop ↔ bulk に切り替え、「再生成」を押すとプロンプトの「インタビューモード」セクションが切り替わることを確認
- [ ] themes / knowledge_source / 質問を編集 → 「再生成」で反映されることを確認
- [ ] 「コピー」でクリップボードにコピーされ、トーストが表示されることを確認
- [ ] 新規作成画面（保存前）でも「プロンプトプレビュー」タブが利用可能なことを確認

https://claude.ai/code/session_01BakSQb3WdXFt4fVKD9itjz

---
_Generated by [Claude Code](https://claude.ai/code/session_01BakSQb3WdXFt4fVKD9itjz)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * インタビュー設定編集画面に「プロンプトプレビュー」タブを追加。現在の設定に基づいて自動生成されるシステムプロンプトをリアルタイムで確認できるようになりました。
  * プロンプトの再生成とクリップボードへのコピー機能を実装。コピー時には成功・失敗を画面上に通知します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->