### PR TITLE
deploy.ymlにsupabase config push用の環境変数を追加

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,9 @@ jobs:
           supabase config push
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID: ${{ secrets.SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID }}
+          SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET: ${{ secrets.SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET }}
+          ADMIN_AUTH_CALLBACK_URL: ${{ secrets.ADMIN_AUTH_CALLBACK_URL }}
 
       # 成功したら Vercel デプロイを開始
       - name: Trigger Vercel Deploy Hook


### PR DESCRIPTION
## Summary
- `supabase config push` 実行時に `config.toml` の `env()` で参照される環境変数（Google OAuth credentials, admin callback URL）がステップの `env` に渡されていなかった問題を修正
- `SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID`, `SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET`, `ADMIN_AUTH_CALLBACK_URL` の3変数を追加

## Background
`supabase/config.toml` で以下のように `env()` を使用しているが、GitHub Actions の該当ステップでこれらのシークレットが環境変数として渡されていなかったため、`supabase config push` 時に値が解決されなかった。

```toml
[auth.external.google]
client_id = "env(SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID)"
secret = "env(SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET)"

additional_redirect_urls = [..., "env(ADMIN_AUTH_CALLBACK_URL)"]
```

## Test plan
- [ ] GitHub Actions の `Migrate DB then Deploy` が正常に完了すること
- [ ] Supabase ダッシュボードの Authentication > Providers > Google で Client ID が反映されていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)