### PR TITLE
team-mir.ai Googleログインユーザーに自動でadminロールを付与

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -42,6 +42,7 @@ jobs:
           SUPABASE_SERVICE_ROLE_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU
           NEXT_PUBLIC_SUPABASE_URL: http://127.0.0.1:54421
           NEXT_PUBLIC_SUPABASE_ANON_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0
+          SUPABASE_DB_URL: postgresql://postgres:postgres@127.0.0.1:54432/postgres
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5

--- a/supabase/migrations/20260427100000_auto_admin_role_for_google_workspace_users.sql
+++ b/supabase/migrations/20260427100000_auto_admin_role_for_google_workspace_users.sql
@@ -1,0 +1,34 @@
+-- team-mir.ai ドメインの Google ログインユーザーに自動で admin ロールを付与するトリガー
+CREATE OR REPLACE FUNCTION public.handle_google_workspace_admin_role()
+RETURNS trigger AS $$
+BEGIN
+  IF NEW.email LIKE '%@team-mir.ai'
+    AND NEW.raw_app_meta_data->>'provider' = 'google'
+  THEN
+    NEW.raw_app_meta_data = jsonb_set(
+      COALESCE(NEW.raw_app_meta_data, '{}'::jsonb),
+      '{roles}',
+      '["admin"]'
+    );
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+CREATE TRIGGER on_auth_user_created_set_admin_role
+  BEFORE INSERT ON auth.users
+  FOR EACH ROW EXECUTE FUNCTION public.handle_google_workspace_admin_role();
+
+-- 既存の team-mir.ai Google ログインユーザーにも admin ロールを付与
+UPDATE auth.users
+SET raw_app_meta_data = jsonb_set(
+  COALESCE(raw_app_meta_data, '{}'::jsonb),
+  '{roles}',
+  '["admin"]'
+)
+WHERE email LIKE '%@team-mir.ai'
+  AND raw_app_meta_data->>'provider' = 'google'
+  AND (
+    raw_app_meta_data->'roles' IS NULL
+    OR NOT raw_app_meta_data->'roles' @> '["admin"]'
+  );

--- a/tests/supabase/db-function/handle-google-workspace-admin-role.test.ts
+++ b/tests/supabase/db-function/handle-google-workspace-admin-role.test.ts
@@ -1,0 +1,66 @@
+import { execSync } from "node:child_process";
+import { describe, expect, it, afterEach } from "vitest";
+
+const DB_URL =
+  process.env.SUPABASE_DB_URL ??
+  "postgresql://postgres:postgres@127.0.0.1:54432/postgres";
+
+/**
+ * GoTrue Admin API はトリガーの変更を上書きするため、
+ * 直接 SQL INSERT でトリガーの動作を検証する。
+ */
+function runSQL(sql: string): string {
+  return execSync(`psql "${DB_URL}" -t -A -q -c ${JSON.stringify(sql)}`, {
+    encoding: "utf-8",
+  }).trim();
+}
+
+describe("handle_google_workspace_admin_role トリガー", () => {
+  const createdUserIds: string[] = [];
+
+  function insertUser(email: string, provider: string): string {
+    const id = runSQL(
+      `INSERT INTO auth.users (id, instance_id, email, encrypted_password, email_confirmed_at, raw_app_meta_data, raw_user_meta_data, aud, role, created_at, updated_at) VALUES (gen_random_uuid(), '00000000-0000-0000-0000-000000000000', '${email}', '', now(), '{"provider": "${provider}", "providers": ["${provider}"]}', '{}', 'authenticated', 'authenticated', now(), now()) RETURNING id`
+    );
+    createdUserIds.push(id);
+    return id;
+  }
+
+  function getUserRoles(userId: string): string | null {
+    const result = runSQL(
+      `SELECT raw_app_meta_data->'roles' FROM auth.users WHERE id = '${userId}'`
+    );
+    return result || null;
+  }
+
+  afterEach(() => {
+    for (const id of createdUserIds) {
+      runSQL(`DELETE FROM auth.users WHERE id = '${id}'`);
+    }
+    createdUserIds.length = 0;
+  });
+
+  it("team-mir.ai + Google ログインユーザーに admin ロールが自動付与される", () => {
+    const email = `test-google-${Date.now()}@team-mir.ai`;
+    const userId = insertUser(email, "google");
+
+    const roles = getUserRoles(userId);
+    expect(JSON.parse(roles!)).toEqual(["admin"]);
+  });
+
+  it("team-mir.ai 以外のドメイン + Google ログインユーザーには admin ロールが付与されない", () => {
+    const email = `test-google-${Date.now()}@gmail.com`;
+    const userId = insertUser(email, "google");
+
+    const roles = getUserRoles(userId);
+    expect(roles).toBeNull();
+  });
+
+  it("team-mir.ai + email プロバイダーのユーザーには admin ロールが付与されない", () => {
+    const email = `test-email-${Date.now()}@team-mir.ai`;
+    const userId = insertUser(email, "email");
+
+    const roles = getUserRoles(userId);
+    expect(roles).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- `@team-mir.ai` ドメイン + Google プロバイダーのユーザーが `auth.users` に作成される際、`raw_app_meta_data.roles` に `["admin"]` を自動設定する BEFORE INSERT トリガーを追加
- 既存の該当ユーザーへのバックフィル UPDATE も含む
- トリガーの統合テストを追加（3ケース: 対象ユーザー、別ドメイン、別プロバイダー）

## Background
admin アプリは `app_metadata.roles` に `"admin"` を含むユーザーのみアクセス可能。Google ログインで新規作成されたユーザーにはこれが設定されないため、手動で設定が必要だった。

## Test plan
- [x] ローカルで直接 SQL INSERT でトリガー動作を確認（3パターン）
- [x] `npx vitest run tests/supabase/db-function/handle-google-workspace-admin-role.test.ts` — 3テスト全通過
- [x] `pnpm lint` — 通過
- [x] `pnpm typecheck` — 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * @team-mir.ai ドメインの Google Workspace ユーザーが自動的に管理者ロールを付与されるようになりました。新規ユーザー、既存ユーザーの両方が対象です。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->