### PR TITLE
seed の placehold.co URL を .png 明示に変更

### DIFF
--- a/packages/seed/main/data.ts
+++ b/packages/seed/main/data.ts
@@ -66,7 +66,7 @@ export const bills: BillInsert[] = [
     submitted_date: "2025-08-01T09:00:00+09:00",
     publish_status: "published",
     is_featured: true,
-    thumbnail_url: "https://placehold.co/600x400",
+    thumbnail_url: "https://placehold.co/600x400.png",
   },
   {
     name: "こども家庭庁予算大幅増額法案",
@@ -76,7 +76,7 @@ export const bills: BillInsert[] = [
     submitted_date: "2025-01-20T10:00:00+09:00",
     publish_status: "published",
     is_featured: true,
-    thumbnail_url: "https://placehold.co/600x400",
+    thumbnail_url: "https://placehold.co/600x400.png",
   },
   {
     name: "18歳選挙権完全実施法案",
@@ -86,7 +86,7 @@ export const bills: BillInsert[] = [
     submitted_date: "2025-02-01T09:00:00+09:00",
     publish_status: "published",
     is_featured: false,
-    thumbnail_url: "https://placehold.co/600x400",
+    thumbnail_url: "https://placehold.co/600x400.png",
   },
   {
     name: "学校給食無償化促進法案",
@@ -96,7 +96,7 @@ export const bills: BillInsert[] = [
     submitted_date: "2025-01-10T09:00:00+09:00",
     publish_status: "published",
     is_featured: false,
-    thumbnail_url: "https://placehold.co/600x400",
+    thumbnail_url: "https://placehold.co/600x400.png",
   },
   // 第218回国会用の追加法案（デザイン確認用）- ループで生成
   ...Array.from({ length: 4 }, (_, i) => ({
@@ -109,7 +109,7 @@ export const bills: BillInsert[] = [
     submitted_date: `2025-08-0${i + 1}T09:00:00+09:00`,
     publish_status: "published" as const,
     is_featured: false,
-    thumbnail_url: "https://placehold.co/600x400",
+    thumbnail_url: "https://placehold.co/600x400.png",
   })),
   {
     name: "船荷証券の電子化に関する法律案",
@@ -119,7 +119,7 @@ export const bills: BillInsert[] = [
     submitted_date: "2025-09-15T09:00:00+09:00",
     publish_status: "published",
     is_featured: false,
-    thumbnail_url: "https://placehold.co/600x400",
+    thumbnail_url: "https://placehold.co/600x400.png",
   },
   {
     name: "中学生・高校生向けプログラミング教育必修化法案",
@@ -129,7 +129,7 @@ export const bills: BillInsert[] = [
     submitted_date: "2024-11-15T10:00:00+09:00",
     publish_status: "published",
     is_featured: false,
-    thumbnail_url: "https://placehold.co/600x400",
+    thumbnail_url: "https://placehold.co/600x400.png",
   },
 ];
 


### PR DESCRIPTION
## Summary
- \`packages/seed/main/data.ts\` の placeholder thumbnail URL に \`.png\` 拡張を付与。

## 背景
placehold.co が拡張子なしリクエストに対して SVG (\`image/svg+xml\`) を返すように変更された結果、Next.js の \`<Image>\` が \`dangerouslyAllowSVG\` 無効状態で SVG を弾き、admin の \`/bills\` などサムネイル表示画面で Internal Server Error が出ていた。

\`\`\`
⨯ The requested resource \"https://placehold.co/600x400\" has type \"image/svg+xml\" but dangerouslyAllowSVG is disabled.
\`\`\`

## 対応
seed データの URL を \`https://placehold.co/600x400\` → \`https://placehold.co/600x400.png\` に変更し PNG を強制取得する。

## Test plan
- [x] \`pnpm typecheck\`
- [x] \`pnpm lint\`
- [ ] \`pnpm db:reset && pnpm seed && pnpm dev\` 後に \`http://localhost:3001/bills\` がエラーなく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * サムネイル画像の URL フォーマットを修正し、プレースホルダー画像が正しく表示されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->