### PR TITLE
billCreate/UpdateSchemaのknowledge_source / use_knowledge_source_in_chatをoptionalに

### DIFF
--- a/admin/src/features/bills-edit/shared/types/index.ts
+++ b/admin/src/features/bills-edit/shared/types/index.ts
@@ -56,8 +56,9 @@ const billBaseSchema = z.object({
     .optional(),
   knowledge_source: z
     .string()
-    .max(40_000, "ナレッジソースは40,000文字以内で入力してください"),
-  use_knowledge_source_in_chat: z.boolean(),
+    .max(40_000, "ナレッジソースは40,000文字以内で入力してください")
+    .optional(),
+  use_knowledge_source_in_chat: z.boolean().optional(),
 });
 
 // 更新用スキーマ（既存）


### PR DESCRIPTION
## Summary
- billsの作成・更新スキーマで `knowledge_source` と `use_knowledge_source_in_chat` を `.optional()` に変更
- DB側はそれぞれ TEXT NULL / BOOLEAN NOT NULL DEFAULT false なので、未指定なら NULL / false がデフォルトとして入る
- 管理画面のフォームは既存どおり \`""\` / \`false\` を defaultValues として渡しており動作変更なし
- MCPツール（create_bill / update_bill）経由でこのフィールドを省略可能になる

## 変更ファイル
- \`admin/src/features/bills-edit/shared/types/index.ts\`: 2フィールドに \`.optional()\` を追加（3行差分）

## Test plan
- [x] \`pnpm typecheck\`
- [x] \`pnpm lint\`
- [x] \`pnpm test\` (web: 766 passed)
- [ ] \`pnpm build\` はローカル.env未更新（PUBLISHABLE_KEY未設定）のためスキップ。CIで担保。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **リファクター**
  * 請求書の作成・編集時における検証ルールを改善しました。ナレッジソース関連の設定入力をオプショナルにすることで、より柔軟なフォーム操作が可能になります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->