### PR TITLE
AIインタビュー入力でIME変換のEnterが誤送信されるSafariのバグを修正

### DIFF
--- a/web/src/components/ai-elements/prompt-input.test.tsx
+++ b/web/src/components/ai-elements/prompt-input.test.tsx
@@ -264,6 +264,62 @@ describe("PromptInputTextarea キーボードショートカット", () => {
 
     expect(requestSubmitSpy).not.toHaveBeenCalled();
   });
+
+  it("submitOnEnter=true: compositionend直後のEnter（Safari二重発火）では送信されない", () => {
+    const onSubmit = vi.fn();
+    render(
+      <PromptInput onSubmit={onSubmit}>
+        <PromptInputBody>
+          <PromptInputTextarea submitOnEnter={true} />
+        </PromptInputBody>
+      </PromptInput>
+    );
+
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+    const form = textarea.closest("form") as HTMLFormElement;
+    const requestSubmitSpy = vi.fn();
+    form.requestSubmit = requestSubmitSpy;
+
+    // Safari は IME 変換確定時に compositionend → 余分な keydown(Enter) を発火する
+    fireEvent.compositionEnd(textarea, { data: "テスト" });
+    fireEvent.keyDown(textarea, {
+      key: "Enter",
+      code: "Enter",
+    });
+
+    expect(requestSubmitSpy).not.toHaveBeenCalled();
+  });
+
+  it("submitOnEnter=true: compositionend後しばらく経ったEnterは送信される", () => {
+    vi.useFakeTimers();
+    try {
+      const onSubmit = vi.fn();
+      render(
+        <PromptInput onSubmit={onSubmit}>
+          <PromptInputBody>
+            <PromptInputTextarea submitOnEnter={true} />
+          </PromptInputBody>
+        </PromptInput>
+      );
+
+      const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+      const form = textarea.closest("form") as HTMLFormElement;
+      const requestSubmitSpy = vi.fn();
+      form.requestSubmit = requestSubmitSpy;
+
+      fireEvent.compositionEnd(textarea, { data: "テスト" });
+      // ガード時間を超えて経過させる
+      vi.advanceTimersByTime(500);
+      fireEvent.keyDown(textarea, {
+        key: "Enter",
+        code: "Enter",
+      });
+
+      expect(requestSubmitSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe("PromptInputSubmit", () => {

--- a/web/src/components/ai-elements/prompt-input.tsx
+++ b/web/src/components/ai-elements/prompt-input.tsx
@@ -16,6 +16,7 @@ import {
   type ChangeEventHandler,
   Children,
   type ComponentProps,
+  type CompositionEventHandler,
   createContext,
   type FormEvent,
   type FormEventHandler,
@@ -464,17 +465,37 @@ export type PromptInputTextareaProps = ComponentProps<typeof Textarea> & {
   submitOnEnter?: boolean;
 };
 
+// Safari (WebKit) は IME 変換確定の Enter で compositionend 直後に
+// isComposing=false / keyCode=13 の余分な keydown を発火するため、
+// その短い時間窓内の Enter は送信扱いにしない。
+// Safari の余分な keydown は ~1 フレーム以内に発火するので、
+// 100ms は十分安全側に倒した値。
+const COMPOSITION_END_GUARD_MS = 100;
+
 export const PromptInputTextarea = ({
   onChange,
+  onCompositionEnd,
   className,
   placeholder = "What would you like to know?",
   submitOnEnter = false,
   ...props
 }: PromptInputTextareaProps) => {
+  const compositionEndAtRef = useRef<number>(0);
+
+  const handleCompositionEnd: CompositionEventHandler<HTMLTextAreaElement> = (
+    e
+  ) => {
+    compositionEndAtRef.current = Date.now();
+    onCompositionEnd?.(e);
+  };
+
   const handleKeyDown: KeyboardEventHandler<HTMLTextAreaElement> = (e) => {
     if (e.key === "Enter") {
-      // Don't submit if IME composition is in progress
       if (e.nativeEvent.isComposing) {
+        return;
+      }
+
+      if (Date.now() - compositionEndAtRef.current < COMPOSITION_END_GUARD_MS) {
         return;
       }
 
@@ -512,6 +533,7 @@ export const PromptInputTextarea = ({
       onChange={(e) => {
         onChange?.(e);
       }}
+      onCompositionEnd={handleCompositionEnd}
       onKeyDown={handleKeyDown}
       placeholder={placeholder}
       {...props}


### PR DESCRIPTION
## Summary
- Safari (macOS) で AIインタビュー入力中、日本語IME変換確定の Enter が「投稿」として扱われてしまう不具合を修正
- 原因: WebKit は IME 確定の Enter で `compositionend` 直後に `isComposing=false` の余分な `keydown` を発火するため、既存の `e.nativeEvent.isComposing` ガードを通り抜けて `form.requestSubmit()` が呼ばれていた
- 対応: `compositionend` の発生時刻を `useRef` で記録し、その後 `COMPOSITION_END_GUARD_MS` (100ms) 以内の Enter は送信扱いにしないガードを追加

## 動作確認
- [x] `pnpm lint`: 変更ファイルに新規 error なし
- [x] `pnpm typecheck`: pass
- [x] `pnpm build`: pass
- [x] `pnpm test`: 既存と同じ 589 tests passed (web)
- [x] ローカル Safari (macOS) で AIインタビューに日本語入力 → IME 変換 Enter → 文字確定のみで投稿されないことを確認

## Test plan
- [ ] Safari (macOS) で AIインタビュー入力中、日本語を入力 → スペースで変換 → Enter で確定、誤投稿されないこと
- [ ] 同じ操作後、続けて Enter を押すとちゃんと投稿されること
- [ ] Chrome / Firefox で従来通りの挙動（Enter で投稿、Shift+Enter で改行、IME 中の Enter は送信されない）が崩れていないこと
- [ ] モバイル (`isDesktop=false`) で Enter が改行扱いのまま変わっていないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
- Safari/WebKitのIME（入力メソッドエディタ）でのテキスト入力時に、Enterキーの反応精度を向上させました。composition終了直後のEnterイベント誤検知を防ぎ、正確なSubmit挙動を実現します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->