### PR TITLE
update_bill MCP ツールを部分更新に対応

### DIFF
--- a/admin/src/features/mcp/server/tools/register-bills-tools.ts
+++ b/admin/src/features/mcp/server/tools/register-bills-tools.ts
@@ -120,18 +120,23 @@ export function registerBillsTools(server: McpServer): void {
     {
       title: "議案を更新",
       description:
-        "指定IDの議案のメタ情報（name, status, originating_house 等）を更新する。",
+        "指定IDの議案のメタ情報（name, status, originating_house 等）を部分更新する。指定したフィールドのみが更新され、省略したフィールドは変更されない。",
       inputSchema: {
         billId: z.string().uuid(),
-        ...billUpdateSchema.shape,
+        ...billUpdateSchema.partial().shape,
       },
     },
-    async ({ billId, ...rest }) => {
+    async ({ billId, submitted_date, ...rest }) => {
+      const definedFields = Object.fromEntries(
+        Object.entries(rest).filter(([, value]) => value !== undefined)
+      );
       await updateBillRecord(billId, {
-        ...rest,
-        submitted_date: rest.submitted_date
-          ? `${rest.submitted_date}T00:00:00+09:00`
-          : null,
+        ...definedFields,
+        ...(submitted_date !== undefined && {
+          submitted_date: submitted_date
+            ? `${submitted_date}T00:00:00+09:00`
+            : null,
+        }),
         updated_at: new Date().toISOString(),
       });
       await invalidateBillsCache();

--- a/tests/mcp/bills-tools.test.ts
+++ b/tests/mcp/bills-tools.test.ts
@@ -239,6 +239,90 @@ describe("MCP bills tools", () => {
       expect(data?.is_review_completed).toBe(true);
     });
 
+    it("billId 以外を省略すると updated_at だけが更新される", async () => {
+      const bill = await createTestBill({
+        name: "部分更新元",
+        status: "introduced",
+        originating_house: "HR",
+      });
+      billIds.push(bill.id);
+
+      const result = await registry.callTool<{ ok: boolean }>("update_bill", {
+        billId: bill.id,
+      });
+      expect(result.ok).toBe(true);
+
+      const { data } = await adminClient
+        .from("bills")
+        .select("name, status, originating_house")
+        .eq("id", bill.id)
+        .single();
+      expect(data?.name).toBe("部分更新元");
+      expect(data?.status).toBe("introduced");
+      expect(data?.originating_house).toBe("HR");
+    });
+
+    it("一部のフィールドのみ指定した場合、他のフィールドは変更されない", async () => {
+      const bill = await createTestBill({
+        name: "更新前の名前",
+        status: "introduced",
+        originating_house: "HR",
+        is_featured: false,
+      });
+      billIds.push(bill.id);
+      await adminClient
+        .from("bills")
+        .update({
+          submitted_date: "2025-04-01T00:00:00+09:00",
+          status_note: "初期備考",
+        })
+        .eq("id", bill.id);
+
+      const result = await registry.callTool<{ ok: boolean }>("update_bill", {
+        billId: bill.id,
+        name: "更新後の名前のみ",
+      });
+      expect(result.ok).toBe(true);
+
+      const { data } = await adminClient
+        .from("bills")
+        .select(
+          "name, status, originating_house, is_featured, submitted_date, status_note"
+        )
+        .eq("id", bill.id)
+        .single();
+      expect(data?.name).toBe("更新後の名前のみ");
+      expect(data?.status).toBe("introduced");
+      expect(data?.originating_house).toBe("HR");
+      expect(data?.is_featured).toBe(false);
+      expect(data?.status_note).toBe("初期備考");
+      expect(new Date(data?.submitted_date ?? "").toISOString()).toBe(
+        new Date("2025-04-01T00:00:00+09:00").toISOString()
+      );
+    });
+
+    it("submitted_date に空文字を指定すると null に更新される", async () => {
+      const bill = await createTestBill();
+      billIds.push(bill.id);
+      await adminClient
+        .from("bills")
+        .update({ submitted_date: "2025-04-01T00:00:00+09:00" })
+        .eq("id", bill.id);
+
+      const result = await registry.callTool<{ ok: boolean }>("update_bill", {
+        billId: bill.id,
+        submitted_date: "",
+      });
+      expect(result.ok).toBe(true);
+
+      const { data } = await adminClient
+        .from("bills")
+        .select("submitted_date")
+        .eq("id", bill.id)
+        .single();
+      expect(data?.submitted_date).toBeNull();
+    });
+
     it("knowledge_source / use_knowledge_source_in_chat を省略しても更新できる", async () => {
       const bill = await createTestBill({ name: "ナレッジ無し更新前" });
       billIds.push(bill.id);


### PR DESCRIPTION
## Summary

- `update_bill` MCP ツールに渡すフィールドを optional 化し、指定したフィールドのみを更新する部分更新（partial update）に対応した
- 入力スキーマを `billUpdateSchema.partial()` に切り替え、ハンドラ側で `undefined` のフィールドを更新ペイロードから除外
- `submitted_date` の挙動は従来どおり: `"YYYY-MM-DD"` で更新、空文字 `""` で `null` クリア、省略時は変更なし

## Why

LLM 経由で MCP ツールを呼ぶ際、現在の `update_bill` は全必須フィールドの再指定を強制するため、たとえば「`name` だけ直したい」というケースで他フィールドの値を毎回流し込む必要があり、誤上書きや冗長な引数が発生する。部分更新を許可することで安全かつ簡潔に呼べるようにする。

## Test plan

- [x] `pnpm typecheck` 通過
- [x] `pnpm lint`（既存の警告のみ、エラーなし）
- [x] `pnpm test`（web 788 / 全 workspace 通過）
- [x] `tests/mcp/bills-tools.test.ts` の `update_bill` を実 Supabase に対して実行（11 / 11 passed）
- 追加した統合テスト
  - `billId` 以外を省略すると既存フィールドが保持される
  - 一部フィールドのみ指定した場合、他フィールドは変更されない
  - `submitted_date: ""` を指定すると `null` に更新される

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 請求書更新機能が改善されました。必要なフィールドのみを更新できるようになり、すべてのフィールドを指定する必要がなくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->