### PR TITLE
レポートOGPの長い法案名崩れを修正

### DIFF
--- a/web/src/app/api/og/report/route.test.tsx
+++ b/web/src/app/api/og/report/route.test.tsx
@@ -1,0 +1,89 @@
+import type { ReactElement, ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getReportOgData } from "@/features/interview-report/server/loaders/get-report-og-data";
+import { GET } from "./route";
+
+type StyledElementProps = {
+  children?: ReactNode;
+  style?: Record<string, unknown>;
+};
+
+const mocks = vi.hoisted(() => ({
+  getReportOgData: vi.fn(),
+  imageResponse: vi.fn(
+    (element: ReactElement, _init: ConstructorParameters<typeof Response>[1]) =>
+      new Response(JSON.stringify(element), { status: 200 })
+  ),
+}));
+
+vi.mock(
+  "@/features/interview-report/server/loaders/get-report-og-data",
+  () => ({
+    getReportOgData: mocks.getReportOgData,
+  })
+);
+
+vi.mock("next/og", () => ({
+  ImageResponse: mocks.imageResponse,
+}));
+
+function findBillNameElement(
+  node: ReactNode,
+  text: string
+): ReactElement<StyledElementProps> | null {
+  if (!node || typeof node !== "object" || !("props" in node)) {
+    return null;
+  }
+
+  const element = node as ReactElement<StyledElementProps>;
+  if (
+    element.props.children === text &&
+    element.props.style?.color === "#0f8472"
+  ) {
+    return element;
+  }
+
+  const children = element.props.children;
+  if (Array.isArray(children)) {
+    for (const child of children) {
+      const found = findBillNameElement(child, text);
+      if (found) return found;
+    }
+    return null;
+  }
+
+  return findBillNameElement(children, text);
+}
+
+describe("GET /api/og/report", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("長い法案名をロゴ領域に重ならない幅で描画する", async () => {
+    const billName =
+      "ロケットの打上げルールを見直して、日本の宇宙産業を強化するための法案";
+    vi.mocked(getReportOgData).mockResolvedValue({
+      summary:
+        "試験打上げまで許可対象を広げるなら、手続きはシンプルにしてほしい",
+      billName,
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response("", { status: 500 }))
+    );
+
+    await GET(new Request("http://localhost/api/og/report?id=report-1"));
+
+    const [element] = mocks.imageResponse.mock.calls[0];
+    const billNameElement = findBillNameElement(element, billName);
+
+    expect(billNameElement?.props.style).toMatchObject({
+      width: 820,
+      maxHeight: 96,
+      overflow: "hidden",
+      wordBreak: "break-all",
+    });
+  });
+});

--- a/web/src/app/api/og/report/route.test.tsx
+++ b/web/src/app/api/og/report/route.test.tsx
@@ -76,6 +76,7 @@ describe("GET /api/og/report", () => {
 
     await GET(new Request("http://localhost/api/og/report?id=report-1"));
 
+    expect(mocks.imageResponse).toHaveBeenCalledTimes(1);
     const [element] = mocks.imageResponse.mock.calls[0];
     const billNameElement = findBillNameElement(element, billName);
 

--- a/web/src/app/api/og/report/route.tsx
+++ b/web/src/app/api/og/report/route.tsx
@@ -9,6 +9,8 @@ import { truncateText } from "@/features/interview-report/shared/utils/truncate-
  */
 const OG_SUMMARY_MAX_LENGTH = 100;
 const OG_BILL_NAME_MAX_LENGTH = 40;
+const OG_BILL_NAME_WIDTH = 820;
+const OG_BILL_NAME_MAX_HEIGHT = 96;
 
 const FONT_FETCH_TIMEOUT_MS = 3000;
 
@@ -166,10 +168,14 @@ export async function GET(request: Request) {
           <div
             style={{
               display: "flex",
+              width: OG_BILL_NAME_WIDTH,
+              maxHeight: OG_BILL_NAME_MAX_HEIGHT,
               fontSize: 32,
               fontWeight: 800,
               color: "#0f8472",
               lineHeight: 1.5,
+              overflow: "hidden",
+              wordBreak: "break-all",
             }}
           >
             {truncatedBillName}


### PR DESCRIPTION
## Summary
- レポート OGP 画像の法案名テキストに固定幅と最大高さを設定
- 長い法案名が右下ロゴに重ならないよう折り返しと overflow 制御を追加
- OGP 生成ルートの法案名 style を検証する回帰テストを追加

## Validation
- `node --input-type=module` with `next/og.js` generated `/tmp/gikai340-after.png`
- `pnpm --filter web exec vitest run src/app/api/og/report/route.test.tsx`
- `codex review --base develop`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test`

## Notes
- 初回の `pnpm build` はローカル `.env` の旧 Supabase 変数名で失敗したため、既存値を新名のプロセス環境へマッピングして再実行し、通過を確認しました。
- `pr-screenshot` 用の R2 設定が無かったため、Linear の公開ファイルアップロードを代替アーティファクトストアとして使用しました。

## スクリーンショット

| OGP after |
|:---:|
| <img src="https://public.linear.app/3f421b9f-a58a-450b-a546-7e3a4c77ff35/208a9268-b94f-4f59-987b-1bb7bd5b34cd/82b0c6c0-f5da-4fad-8c7c-877c6946edc3" width="500" /> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * 請求書を共有する際のプレビュー画像で、請求書名の表示レイアウトに幅・高さの制約を追加し、文字の重なりやはみ出しを抑えて見栄えを改善しました。

* **テスト**
  * プレビュー生成APIのレンダリング結果を検証するテストを追加し、請求書名のレイアウト制約が期待どおり適用されることを確認します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->