### PR TITLE
インタビュー新規設定の設定名にログインユーザー名を自動入力

### DIFF
--- a/admin/src/app/(protected)/bills/[id]/interview/new/page.tsx
+++ b/admin/src/app/(protected)/bills/[id]/interview/new/page.tsx
@@ -6,6 +6,7 @@ import { notFound } from "next/navigation";
 import { getBillById } from "@/features/bills-edit/server/loaders/get-bill-by-id";
 import { getCurrentAdmin } from "@/features/auth/server/lib/auth-server";
 import { InterviewConfigEditClient } from "@/features/interview-config/client/components/interview-config-edit-client";
+import { generateDefaultConfigName } from "@/features/interview-config/shared/utils/default-config-name";
 import { routes } from "@/lib/routes";
 
 interface InterviewNewPageProps {
@@ -24,7 +25,10 @@ export default async function InterviewNewPage({
     notFound();
   }
 
-  const initialName = admin?.email?.split("@")[0] || null;
+  const username = admin?.email?.split("@")[0] || null;
+  const initialName = username
+    ? `${generateDefaultConfigName()} (${username})`
+    : null;
 
   return (
     <div>

--- a/admin/src/app/(protected)/bills/[id]/interview/new/page.tsx
+++ b/admin/src/app/(protected)/bills/[id]/interview/new/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import { getBillById } from "@/features/bills-edit/server/loaders/get-bill-by-id";
+import { getCurrentAdmin } from "@/features/auth/server/lib/auth-server";
 import { InterviewConfigEditClient } from "@/features/interview-config/client/components/interview-config-edit-client";
 import { routes } from "@/lib/routes";
 
@@ -17,11 +18,13 @@ export default async function InterviewNewPage({
   params,
 }: InterviewNewPageProps) {
   const { id } = await params;
-  const bill = await getBillById(id);
+  const [bill, admin] = await Promise.all([getBillById(id), getCurrentAdmin()]);
 
   if (!bill) {
     notFound();
   }
+
+  const initialName = admin?.email?.split("@")[0] || null;
 
   return (
     <div>
@@ -49,6 +52,7 @@ export default async function InterviewNewPage({
         config={null}
         questions={[]}
         completedReports={[]}
+        initialName={initialName}
       />
     </div>
   );

--- a/admin/src/features/interview-config/client/components/interview-config-edit-client.tsx
+++ b/admin/src/features/interview-config/client/components/interview-config-edit-client.tsx
@@ -31,6 +31,7 @@ interface InterviewConfigEditClientProps {
   completedReportsTruncated?: boolean;
   /** 切り詰め上限値 */
   completedReportsLimit?: number;
+  initialName?: string | null;
 }
 
 export function InterviewConfigEditClient({
@@ -40,6 +41,7 @@ export function InterviewConfigEditClient({
   completedReports,
   completedReportsTruncated = false,
   completedReportsLimit,
+  initialName,
 }: InterviewConfigEditClientProps) {
   const router = useRouter();
   const [configId, setConfigId] = useState<string | undefined>(
@@ -198,6 +200,7 @@ export function InterviewConfigEditClient({
               aiGeneratedThemes={aiGeneratedThemes}
               onAiThemesApplied={() => setAiGeneratedThemes(null)}
               getFormValuesRef={getFormValuesRef}
+              initialName={initialName}
             />
             {configId ? (
               <InterviewQuestionList

--- a/admin/src/features/interview-config/client/components/interview-config-form.tsx
+++ b/admin/src/features/interview-config/client/components/interview-config-form.tsx
@@ -65,6 +65,8 @@ interface InterviewConfigFormProps {
       })
     | null
   >;
+  /** 新規作成時の設定名初期値（ログインユーザー名） */
+  initialName?: string | null;
 }
 
 export function InterviewConfigForm({
@@ -74,6 +76,7 @@ export function InterviewConfigForm({
   onAiThemesApplied,
   onConfigCreated,
   getFormValuesRef,
+  initialName,
 }: InterviewConfigFormProps) {
   const router = useRouter();
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -82,7 +85,7 @@ export function InterviewConfigForm({
   const form = useForm<InterviewConfigInput>({
     resolver: zodResolver(interviewConfigSchema),
     defaultValues: {
-      name: config?.name || generateDefaultConfigName(),
+      name: config?.name || initialName || generateDefaultConfigName(),
       status: config?.status || "closed",
       mode: config?.mode || "loop",
       themes: config?.themes || [],


### PR DESCRIPTION
## 概要

インタビュー新規設定画面（`/bills/[id]/interview/new`）を開いたとき、設定名フィールドにログインユーザーのメールアドレス（`@`より前の部分）を自動で入力するようにした。

従来は `2026/05/13 作成` のような日付ベースのデフォルト名だったが、誰が作成した設定か一目でわかるようになる。

## 変更内容

- `page.tsx`: `getCurrentAdmin()` を `getBillById()` と並列で実行し、メールの`@`前をユーザー名として取得
- `InterviewConfigEditClient`: `initialName` prop を追加してフォームに中継
- `InterviewConfigForm`: `initialName` を `defaultValues.name` の優先度2番目に設定（`config.name` > `initialName` > 日付デフォルト）

## テスト

- `pnpm lint` ✅
- `pnpm typecheck` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能
* インタビュー設定の新規作成ページで、管理者のメールアドレスの前部(@の前の部分)が自動的に名前フィールドの初期値として使用されるようになりました。これによりフォーム入力時の手作業が削減されます。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/team-mirai/mirai-gikai/pull/816)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->