### PR TITLE
AIインタビューの全対話をTSVでクリップボードにコピー

### DIFF
--- a/admin/src/app/(protected)/bills/[id]/interview/[configId]/reports/page.tsx
+++ b/admin/src/app/(protected)/bills/[id]/interview/[configId]/reports/page.tsx
@@ -6,6 +6,7 @@ import { notFound } from "next/navigation";
 import { getBillById } from "@/features/bills-edit/server/loaders/get-bill-by-id";
 import { BatchModerationButton } from "@/features/interview-reports/client/components/batch-moderation-button";
 import { BatchPublishButton } from "@/features/interview-reports/client/components/batch-publish-button";
+import { CopyTsvButton } from "@/features/interview-reports/client/components/copy-tsv-button";
 import { InterviewStatistics } from "@/features/interview-reports/server/components/interview-statistics";
 import { SessionList } from "@/features/interview-reports/server/components/session-list";
 import {
@@ -82,6 +83,7 @@ export default async function ReportsPage({
           <p className="text-gray-600 mt-1">議案「{bill.name}」のレポート</p>
         </div>
         <div className="flex items-center gap-2">
+          <CopyTsvButton billId={id} configId={configId} />
           <BatchPublishButton billId={id} configId={configId} />
           <BatchModerationButton />
         </div>

--- a/admin/src/features/interview-reports/client/components/copy-tsv-button.tsx
+++ b/admin/src/features/interview-reports/client/components/copy-tsv-button.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { ClipboardCopy } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { exportInterviewTsvAction } from "../../server/actions/export-interview-tsv-action";
+
+interface CopyTsvButtonProps {
+  billId: string;
+  configId: string;
+}
+
+export function CopyTsvButton({ billId, configId }: CopyTsvButtonProps) {
+  const [isRunning, setIsRunning] = useState(false);
+
+  const handleClick = async () => {
+    if (isRunning) return;
+    setIsRunning(true);
+
+    try {
+      const result = await exportInterviewTsvAction({ billId, configId });
+      if (!result.success || result.tsv === undefined) {
+        toast.error(result.error || "TSVの出力に失敗しました");
+        return;
+      }
+
+      await navigator.clipboard.writeText(result.tsv);
+      toast.success(
+        `${result.sessionCount ?? 0}件のセッションをTSVとしてコピーしました`
+      );
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? `クリップボードへのコピーに失敗しました: ${error.message}`
+          : "クリップボードへのコピーに失敗しました"
+      );
+    } finally {
+      setIsRunning(false);
+    }
+  };
+
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      onClick={handleClick}
+      disabled={isRunning}
+      className="gap-2"
+    >
+      <ClipboardCopy className="h-4 w-4" />
+      {isRunning ? "コピー中..." : "全対話をTSVでコピー"}
+    </Button>
+  );
+}

--- a/admin/src/features/interview-reports/server/actions/bulk-publish-reports-action.ts
+++ b/admin/src/features/interview-reports/server/actions/bulk-publish-reports-action.ts
@@ -3,6 +3,7 @@
 import { createAdminClient } from "@mirai-gikai/supabase";
 import { revalidateTag } from "next/cache";
 import { requireAdmin } from "@/features/auth/server/lib/auth-server";
+import { verifyConfigBelongsToBill } from "../services/verify-config-belongs-to-bill";
 
 interface BulkPublishParams {
   configId: string;
@@ -15,23 +16,6 @@ interface BulkPublishResult {
   success: boolean;
   updatedCount?: number;
   error?: string;
-}
-
-async function verifyConfigBelongsToBill(
-  configId: string,
-  billId: string
-): Promise<void> {
-  const supabase = createAdminClient();
-  const { data, error } = await supabase
-    .from("interview_configs")
-    .select("id")
-    .eq("id", configId)
-    .eq("bill_id", billId)
-    .single();
-
-  if (error || !data) {
-    throw new Error("指定されたインタビュー設定はこの議案に属していません");
-  }
 }
 
 export async function bulkPublishReportsAction(

--- a/admin/src/features/interview-reports/server/actions/export-interview-tsv-action.ts
+++ b/admin/src/features/interview-reports/server/actions/export-interview-tsv-action.ts
@@ -1,0 +1,36 @@
+"use server";
+
+import { requireAdmin } from "@/features/auth/server/lib/auth-server";
+import { buildInterviewTsv } from "../../shared/utils/build-interview-tsv";
+import { getInterviewSessionsForTsv } from "../loaders/get-interview-sessions-for-tsv";
+import { verifyConfigBelongsToBill } from "../services/verify-config-belongs-to-bill";
+
+interface ExportInterviewTsvParams {
+  configId: string;
+  billId: string;
+}
+
+interface ExportInterviewTsvResult {
+  success: boolean;
+  tsv?: string;
+  sessionCount?: number;
+  error?: string;
+}
+
+export async function exportInterviewTsvAction(
+  params: ExportInterviewTsvParams
+): Promise<ExportInterviewTsvResult> {
+  await requireAdmin();
+
+  try {
+    await verifyConfigBelongsToBill(params.configId, params.billId);
+    const sessions = await getInterviewSessionsForTsv(params.configId);
+    const tsv = buildInterviewTsv(sessions);
+    return { success: true, tsv, sessionCount: sessions.length };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "TSVの出力に失敗しました",
+    };
+  }
+}

--- a/admin/src/features/interview-reports/server/loaders/get-interview-sessions-for-tsv.ts
+++ b/admin/src/features/interview-reports/server/loaders/get-interview-sessions-for-tsv.ts
@@ -1,35 +1,92 @@
 import "server-only";
 
 import { createAdminClient } from "@mirai-gikai/supabase";
+import type {
+  InterviewMessage,
+  InterviewReport,
+  InterviewSession,
+} from "../../shared/types";
 import type { InterviewSessionForTsv } from "../../shared/utils/build-interview-tsv";
+
+const PAGE_SIZE = 1000;
+
+async function fetchAllPaginated<T>(
+  fetchPage: (from: number, to: number) => Promise<T[]>
+): Promise<T[]> {
+  const all: T[] = [];
+  let offset = 0;
+  while (true) {
+    const page = await fetchPage(offset, offset + PAGE_SIZE - 1);
+    all.push(...page);
+    if (page.length < PAGE_SIZE) break;
+    offset += PAGE_SIZE;
+  }
+  return all;
+}
+
+type SessionWithReport = InterviewSession & {
+  interview_report: InterviewReport | InterviewReport[] | null;
+};
+
+async function fetchAllSessions(
+  configId: string
+): Promise<SessionWithReport[]> {
+  const supabase = createAdminClient();
+  return fetchAllPaginated(async (from, to) => {
+    const { data, error } = await supabase
+      .from("interview_sessions")
+      .select("*, interview_report(*)")
+      .eq("interview_config_id", configId)
+      .order("started_at", { ascending: true })
+      .range(from, to);
+    if (error) {
+      throw new Error(
+        `Failed to fetch interview sessions for TSV: ${error.message}`
+      );
+    }
+    return (data ?? []) as SessionWithReport[];
+  });
+}
+
+async function fetchAllMessages(
+  sessionIds: string[]
+): Promise<InterviewMessage[]> {
+  if (sessionIds.length === 0) return [];
+  const supabase = createAdminClient();
+  return fetchAllPaginated(async (from, to) => {
+    const { data, error } = await supabase
+      .from("interview_messages")
+      .select("*")
+      .in("interview_session_id", sessionIds)
+      .order("interview_session_id", { ascending: true })
+      .order("created_at", { ascending: true })
+      .range(from, to);
+    if (error) {
+      throw new Error(
+        `Failed to fetch interview messages for TSV: ${error.message}`
+      );
+    }
+    return data ?? [];
+  });
+}
 
 export async function getInterviewSessionsForTsv(
   configId: string
 ): Promise<InterviewSessionForTsv[]> {
-  const supabase = createAdminClient();
-  const { data, error } = await supabase
-    .from("interview_sessions")
-    .select(
-      `
-      *,
-      interview_report(*),
-      interview_messages(*)
-      `
-    )
-    .eq("interview_config_id", configId)
-    .order("started_at", { ascending: true })
-    .order("created_at", {
-      referencedTable: "interview_messages",
-      ascending: true,
-    });
+  const sessions = await fetchAllSessions(configId);
+  const messages = await fetchAllMessages(sessions.map((s) => s.id));
 
-  if (error) {
-    throw new Error(
-      `Failed to fetch interview sessions for TSV: ${error.message}`
-    );
+  const messagesBySessionId = new Map<string, InterviewMessage[]>();
+  for (const message of messages) {
+    const list = messagesBySessionId.get(message.interview_session_id);
+    if (list) {
+      list.push(message);
+    } else {
+      messagesBySessionId.set(message.interview_session_id, [message]);
+    }
   }
 
-  return (data ?? []).map((session) => {
+  return sessions.map((session) => {
     // 1:1 リレーションでも Supabase の生成型では配列で返るケースがあるため正規化
     const reportRelation = session.interview_report;
     const report = Array.isArray(reportRelation)
@@ -38,7 +95,7 @@ export async function getInterviewSessionsForTsv(
     return {
       ...session,
       interview_report: report,
-      interview_messages: session.interview_messages ?? [],
+      interview_messages: messagesBySessionId.get(session.id) ?? [],
     };
   });
 }

--- a/admin/src/features/interview-reports/server/loaders/get-interview-sessions-for-tsv.ts
+++ b/admin/src/features/interview-reports/server/loaders/get-interview-sessions-for-tsv.ts
@@ -1,0 +1,44 @@
+import "server-only";
+
+import { createAdminClient } from "@mirai-gikai/supabase";
+import type { InterviewSessionForTsv } from "../../shared/utils/build-interview-tsv";
+
+export async function getInterviewSessionsForTsv(
+  configId: string
+): Promise<InterviewSessionForTsv[]> {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("interview_sessions")
+    .select(
+      `
+      *,
+      interview_report(*),
+      interview_messages(*)
+      `
+    )
+    .eq("interview_config_id", configId)
+    .order("started_at", { ascending: true })
+    .order("created_at", {
+      referencedTable: "interview_messages",
+      ascending: true,
+    });
+
+  if (error) {
+    throw new Error(
+      `Failed to fetch interview sessions for TSV: ${error.message}`
+    );
+  }
+
+  return (data ?? []).map((session) => {
+    // 1:1 リレーションでも Supabase の生成型では配列で返るケースがあるため正規化
+    const reportRelation = session.interview_report;
+    const report = Array.isArray(reportRelation)
+      ? (reportRelation[0] ?? null)
+      : reportRelation;
+    return {
+      ...session,
+      interview_report: report,
+      interview_messages: session.interview_messages ?? [],
+    };
+  });
+}

--- a/admin/src/features/interview-reports/server/services/verify-config-belongs-to-bill.ts
+++ b/admin/src/features/interview-reports/server/services/verify-config-belongs-to-bill.ts
@@ -1,0 +1,20 @@
+import "server-only";
+
+import { createAdminClient } from "@mirai-gikai/supabase";
+
+export async function verifyConfigBelongsToBill(
+  configId: string,
+  billId: string
+): Promise<void> {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("interview_configs")
+    .select("id")
+    .eq("id", configId)
+    .eq("bill_id", billId)
+    .single();
+
+  if (error || !data) {
+    throw new Error("指定されたインタビュー設定はこの議案に属していません");
+  }
+}

--- a/admin/src/features/interview-reports/shared/utils/build-interview-tsv.test.ts
+++ b/admin/src/features/interview-reports/shared/utils/build-interview-tsv.test.ts
@@ -183,4 +183,66 @@ describe("buildInterviewTsv", () => {
     expect(cells[5]).toBe("");
     expect(cells[13]).toBe("");
   });
+
+  it("先頭が = + - @ の値は ' を前置して数式評価を防ぐ", () => {
+    const tsv = buildInterviewTsv([
+      buildSession({
+        interview_report: {
+          id: "r1",
+          interview_session_id: "session-1",
+          stance: null,
+          role: null,
+          role_title: null,
+          role_description: null,
+          moderation_score: null,
+          moderation_status: null,
+          moderation_reasoning: null,
+          content_richness: null,
+          total_content_richness: null,
+          opinions: null,
+          summary: "=SUM(A1:A2)",
+          is_public_by_user: false,
+          is_public_by_admin: false,
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:10:00Z",
+        },
+        interview_messages: [
+          {
+            id: "m1",
+            interview_session_id: "session-1",
+            role: "user",
+            content: "=1+1",
+            created_at: "2026-01-01T00:01:00Z",
+          },
+          {
+            id: "m2",
+            interview_session_id: "session-1",
+            role: "user",
+            content: "@cmd",
+            created_at: "2026-01-01T00:02:00Z",
+          },
+          {
+            id: "m3",
+            interview_session_id: "session-1",
+            role: "user",
+            content: "-1",
+            created_at: "2026-01-01T00:03:00Z",
+          },
+          {
+            id: "m4",
+            interview_session_id: "session-1",
+            role: "user",
+            content: "+SUM",
+            created_at: "2026-01-01T00:04:00Z",
+          },
+        ],
+      }),
+    ]);
+    const rows = tsv.split("\n");
+    expect(rows[1].split("\t")[13]).toBe("'=SUM(A1:A2)");
+    expect(rows[1].split("\t")[16]).toBe("'=1+1");
+    expect(rows[2].split("\t")[16]).toBe("'@cmd");
+    expect(rows[3].split("\t")[16]).toBe("'-1");
+    expect(rows[4].split("\t")[16]).toBe("'+SUM");
+  });
 });

--- a/admin/src/features/interview-reports/shared/utils/build-interview-tsv.test.ts
+++ b/admin/src/features/interview-reports/shared/utils/build-interview-tsv.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildInterviewTsv,
+  type InterviewSessionForTsv,
+} from "./build-interview-tsv";
+
+function buildSession(
+  overrides: Partial<InterviewSessionForTsv> = {}
+): InterviewSessionForTsv {
+  return {
+    id: "session-1",
+    interview_config_id: "config-1",
+    user_id: "user-1",
+    started_at: "2026-01-01T00:00:00Z",
+    completed_at: "2026-01-01T00:10:00Z",
+    archived_at: null,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:10:00Z",
+    langfuse_session_id: null,
+    rating: null,
+    interview_report: null,
+    interview_messages: [],
+    ...overrides,
+  };
+}
+
+describe("buildInterviewTsv", () => {
+  it("ヘッダー行を含み、全カラムをタブ区切りで出力する", () => {
+    const tsv = buildInterviewTsv([]);
+    expect(tsv.split("\n")[0]).toBe(
+      [
+        "session_id",
+        "user_id",
+        "started_at",
+        "completed_at",
+        "archived_at",
+        "stance",
+        "role",
+        "role_title",
+        "moderation_score",
+        "moderation_status",
+        "total_content_richness",
+        "is_public_by_user",
+        "is_public_by_admin",
+        "summary",
+        "message_order",
+        "message_role",
+        "message_content",
+        "message_created_at",
+      ].join("\t")
+    );
+  });
+
+  it("1セッション = N行(メッセージ数ぶん)に展開され、セッション情報が冗長コピーされる", () => {
+    const tsv = buildInterviewTsv([
+      buildSession({
+        interview_messages: [
+          {
+            id: "m1",
+            interview_session_id: "session-1",
+            role: "assistant",
+            content: "質問1",
+            created_at: "2026-01-01T00:01:00Z",
+          },
+          {
+            id: "m2",
+            interview_session_id: "session-1",
+            role: "user",
+            content: "回答1",
+            created_at: "2026-01-01T00:02:00Z",
+          },
+        ],
+      }),
+    ]);
+    const rows = tsv.split("\n");
+    expect(rows).toHaveLength(3);
+    const cellsRow1 = rows[1].split("\t");
+    const cellsRow2 = rows[2].split("\t");
+    expect(cellsRow1[0]).toBe("session-1");
+    expect(cellsRow2[0]).toBe("session-1");
+    expect(cellsRow1[14]).toBe("1");
+    expect(cellsRow1[15]).toBe("assistant");
+    expect(cellsRow1[16]).toBe("質問1");
+    expect(cellsRow2[14]).toBe("2");
+    expect(cellsRow2[15]).toBe("user");
+    expect(cellsRow2[16]).toBe("回答1");
+  });
+
+  it("セッション情報(stance/score/summary 等)が各行に重複コピーされる", () => {
+    const tsv = buildInterviewTsv([
+      buildSession({
+        interview_report: {
+          id: "r1",
+          interview_session_id: "session-1",
+          stance: "for",
+          role: "subject_expert",
+          role_title: "教育研究者",
+          role_description: null,
+          moderation_score: 12,
+          moderation_status: "ok",
+          moderation_reasoning: null,
+          content_richness: null,
+          total_content_richness: 75,
+          opinions: null,
+          summary: "賛成意見",
+          is_public_by_user: true,
+          is_public_by_admin: false,
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:10:00Z",
+        },
+        interview_messages: [
+          {
+            id: "m1",
+            interview_session_id: "session-1",
+            role: "user",
+            content: "意見",
+            created_at: "2026-01-01T00:01:00Z",
+          },
+        ],
+      }),
+    ]);
+    const cells = tsv.split("\n")[1].split("\t");
+    expect(cells[5]).toBe("for");
+    expect(cells[6]).toBe("subject_expert");
+    expect(cells[7]).toBe("教育研究者");
+    expect(cells[8]).toBe("12");
+    expect(cells[9]).toBe("ok");
+    expect(cells[10]).toBe("75");
+    expect(cells[11]).toBe("true");
+    expect(cells[12]).toBe("false");
+    expect(cells[13]).toBe("賛成意見");
+  });
+
+  it("改行・タブを半角スペースに置換してTSVの区切りを壊さない", () => {
+    const tsv = buildInterviewTsv([
+      buildSession({
+        interview_messages: [
+          {
+            id: "m1",
+            interview_session_id: "session-1",
+            role: "user",
+            content: "改行\nあり\tタブも",
+            created_at: "2026-01-01T00:01:00Z",
+          },
+        ],
+      }),
+    ]);
+    const cells = tsv.split("\n")[1].split("\t");
+    expect(cells).toHaveLength(18);
+    expect(cells[16]).toBe("改行 あり タブも");
+  });
+
+  it("メッセージが0件のセッションも1行として出力される", () => {
+    const tsv = buildInterviewTsv([buildSession({ interview_messages: [] })]);
+    const rows = tsv.split("\n");
+    expect(rows).toHaveLength(2);
+    const cells = rows[1].split("\t");
+    expect(cells[0]).toBe("session-1");
+    expect(cells[14]).toBe("");
+    expect(cells[15]).toBe("");
+    expect(cells[16]).toBe("");
+    expect(cells[17]).toBe("");
+  });
+
+  it("null/undefined のセッション情報は空文字として出力される", () => {
+    const tsv = buildInterviewTsv([
+      buildSession({
+        completed_at: null,
+        interview_report: null,
+        interview_messages: [
+          {
+            id: "m1",
+            interview_session_id: "session-1",
+            role: "user",
+            content: "x",
+            created_at: "2026-01-01T00:01:00Z",
+          },
+        ],
+      }),
+    ]);
+    const cells = tsv.split("\n")[1].split("\t");
+    expect(cells[3]).toBe("");
+    expect(cells[5]).toBe("");
+    expect(cells[13]).toBe("");
+  });
+});

--- a/admin/src/features/interview-reports/shared/utils/build-interview-tsv.ts
+++ b/admin/src/features/interview-reports/shared/utils/build-interview-tsv.ts
@@ -1,0 +1,83 @@
+import type {
+  InterviewMessage,
+  InterviewReport,
+  InterviewSession,
+} from "../types";
+
+export type InterviewSessionForTsv = InterviewSession & {
+  interview_report: InterviewReport | null;
+  interview_messages: InterviewMessage[];
+};
+
+const COLUMNS = [
+  "session_id",
+  "user_id",
+  "started_at",
+  "completed_at",
+  "archived_at",
+  "stance",
+  "role",
+  "role_title",
+  "moderation_score",
+  "moderation_status",
+  "total_content_richness",
+  "is_public_by_user",
+  "is_public_by_admin",
+  "summary",
+  "message_order",
+  "message_role",
+  "message_content",
+  "message_created_at",
+] as const;
+
+function escapeTsvCell(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  const str = typeof value === "string" ? value : String(value);
+  return str.replace(/[\t\r\n]+/g, " ");
+}
+
+export function buildInterviewTsv(sessions: InterviewSessionForTsv[]): string {
+  const lines: string[] = [COLUMNS.join("\t")];
+
+  for (const session of sessions) {
+    const report = session.interview_report;
+    const sessionPrefix = [
+      session.id,
+      session.user_id,
+      session.started_at,
+      session.completed_at,
+      session.archived_at,
+      report?.stance ?? null,
+      report?.role ?? null,
+      report?.role_title ?? null,
+      report?.moderation_score ?? null,
+      report?.moderation_status ?? null,
+      report?.total_content_richness ?? null,
+      report?.is_public_by_user ?? null,
+      report?.is_public_by_admin ?? null,
+      report?.summary ?? null,
+    ]
+      .map(escapeTsvCell)
+      .join("\t");
+
+    const messages = session.interview_messages;
+    if (messages.length === 0) {
+      lines.push(`${sessionPrefix}\t\t\t\t`);
+      continue;
+    }
+
+    messages.forEach((message, index) => {
+      const messageSuffix = [
+        index + 1,
+        message.role,
+        message.content,
+        message.created_at,
+      ]
+        .map(escapeTsvCell)
+        .join("\t");
+      lines.push(`${sessionPrefix}\t${messageSuffix}`);
+    });
+  }
+
+  return lines.join("\n");
+}

--- a/admin/src/features/interview-reports/shared/utils/build-interview-tsv.ts
+++ b/admin/src/features/interview-reports/shared/utils/build-interview-tsv.ts
@@ -33,7 +33,9 @@ const COLUMNS = [
 function escapeTsvCell(value: unknown): string {
   if (value === null || value === undefined) return "";
   const str = typeof value === "string" ? value : String(value);
-  return str.replace(/[\t\r\n]+/g, " ");
+  const normalized = str.replace(/[\t\r\n]+/g, " ");
+  // Google Sheets 等の数式インジェクション対策: 先頭が = + - @ なら ' を前置
+  return /^[=+\-@]/.test(normalized) ? `'${normalized}` : normalized;
 }
 
 export function buildInterviewTsv(sessions: InterviewSessionForTsv[]): string {


### PR DESCRIPTION
## Summary
- 法案ごとのインタビューレポート一覧ページに「全対話をTSVでコピー」ボタンを追加
- 1セッションの対話を flatten（1行 = 1メッセージ）し、セッション情報を各行に冗長コピーした TSV を生成
- Google Sheets に貼り付けて role でフィルタしたり session_id でグループ化できる構成

## 列構成
左がセッション情報、右がメッセージ情報。

```
session_id  user_id  started_at  completed_at  archived_at
stance  role  role_title  moderation_score  moderation_status
total_content_richness  is_public_by_user  is_public_by_admin  summary
message_order  message_role  message_content  message_created_at
```

- 改行・タブは半角スペースに置換して TSV の区切りを壊さない
- メッセージ0件のセッションも1行として出力

## 実装メモ
- `buildInterviewTsv` を `shared/utils/` の純粋関数として実装し、同階層に Vitest テスト（6ケース）を配置
- `verifyConfigBelongsToBill` は `bulk-publish-reports-action.ts` にも同等の関数があったため `server/services/` に切り出して共有化
- メッセージのソートは Supabase 側で `referencedTable` 指定により実施

## Test plan
- [ ] `pnpm --filter admin test -- build-interview-tsv` で純粋関数テスト通過
- [ ] admin の `/bills/[id]/interview/[configId]/reports` 画面でボタンをクリックし、クリップボードに TSV が入ることを確認
- [ ] Google Sheets に貼り付けてフィルタ／ピボットが効くことを確認
- [ ] CodeRabbit / CI チェック

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * レポート一覧ヘッダーに「TSVをコピー」ボタンを追加。クリックでインタビュー一覧をTSV取得→クリップボードへコピーし、完了時に成功／失敗の通知を表示。

* **Tests**
  * TSV生成ロジックの包括的なテストを追加（ヘッダー、メッセージ展開、改行/タブ処理、数式評価防止など）。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/team-mirai/mirai-gikai/pull/820?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->