### PR TITLE
インタビュー統計に総所要時間（途中離脱含む）を追加

### DIFF
--- a/admin/src/features/interview-reports/server/components/interview-statistics.tsx
+++ b/admin/src/features/interview-reports/server/components/interview-statistics.tsx
@@ -5,6 +5,7 @@ import {
   Clock,
   DollarSign,
   Eye,
+  Hourglass,
   MessageSquare,
   Star,
   Target,
@@ -13,7 +14,10 @@ import {
 
 import { Card, CardContent } from "@/components/ui/card";
 import type { InterviewStatistics as InterviewStatisticsType } from "../../shared/types";
-import { formatDurationSeconds } from "../../shared/utils/format-average-duration";
+import {
+  formatDurationSeconds,
+  formatTotalDurationSeconds,
+} from "../../shared/utils/format-average-duration";
 
 interface InterviewStatisticsProps {
   statistics: InterviewStatisticsType;
@@ -246,7 +250,7 @@ export function InterviewStatistics({
         />
       </div>
 
-      <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+      <div className="grid grid-cols-2 gap-4 md:grid-cols-5">
         <StatCard
           icon={<MessageSquare className="h-5 w-5" />}
           label="平均メッセージ数"
@@ -261,6 +265,12 @@ export function InterviewStatistics({
           icon={<Clock className="h-5 w-5" />}
           label="所要時間（中央値）"
           value={formatDurationSeconds(stats.medianDurationSeconds)}
+        />
+        <StatCard
+          icon={<Hourglass className="h-5 w-5" />}
+          label="総所要時間"
+          value={formatTotalDurationSeconds(stats.totalDurationSeconds)}
+          sub="途中離脱を含む"
         />
         <StatCard
           icon={<Eye className="h-5 w-5" />}

--- a/admin/src/features/interview-reports/shared/types/index.ts
+++ b/admin/src/features/interview-reports/shared/types/index.ts
@@ -110,6 +110,7 @@ export type InterviewStatistics = {
   roleGeneralCitizen: number;
   avgMessageCount: number | null;
   medianDurationSeconds: number | null;
+  totalDurationSeconds: number;
   publicByUserCount: number;
   publicRate: number;
   feedbackIrrelevantQuestions: number;

--- a/admin/src/features/interview-reports/shared/utils/format-average-duration.test.ts
+++ b/admin/src/features/interview-reports/shared/utils/format-average-duration.test.ts
@@ -73,7 +73,7 @@ describe("formatTotalDurationSeconds", () => {
     );
   });
 
-  it("returns dash for sub-minute total", () => {
+  it("returns 0分 for sub-minute total", () => {
     expect(formatTotalDurationSeconds(30)).toBe("0分");
   });
 });

--- a/admin/src/features/interview-reports/shared/utils/format-average-duration.test.ts
+++ b/admin/src/features/interview-reports/shared/utils/format-average-duration.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { formatDurationSeconds } from "./format-average-duration";
+import {
+  formatDurationSeconds,
+  formatTotalDurationSeconds,
+} from "./format-average-duration";
 
 describe("formatDurationSeconds", () => {
   it("returns dash for null", () => {
@@ -32,5 +35,45 @@ describe("formatDurationSeconds", () => {
 
   it("rounds tiny positive value to 1 second", () => {
     expect(formatDurationSeconds(0.3)).toBe("1秒");
+  });
+});
+
+describe("formatTotalDurationSeconds", () => {
+  it("returns dash for null", () => {
+    expect(formatTotalDurationSeconds(null)).toBe("-");
+  });
+
+  it("returns dash for zero", () => {
+    expect(formatTotalDurationSeconds(0)).toBe("-");
+  });
+
+  it("returns dash for negative", () => {
+    expect(formatTotalDurationSeconds(-1)).toBe("-");
+  });
+
+  it("formats minutes only when under one hour", () => {
+    expect(formatTotalDurationSeconds(45 * 60)).toBe("45分");
+  });
+
+  it("drops seconds (floor to minute)", () => {
+    expect(formatTotalDurationSeconds(45 * 60 + 59)).toBe("45分");
+  });
+
+  it("formats hours only when no remaining minutes", () => {
+    expect(formatTotalDurationSeconds(2 * 60 * 60)).toBe("2時間");
+  });
+
+  it("formats hours and minutes", () => {
+    expect(formatTotalDurationSeconds(3 * 60 * 60 + 25 * 60)).toBe("3時間25分");
+  });
+
+  it("rounds large totals to floor minute", () => {
+    expect(formatTotalDurationSeconds(36 * 60 * 60 + 7 * 60 + 30)).toBe(
+      "36時間7分"
+    );
+  });
+
+  it("returns dash for sub-minute total", () => {
+    expect(formatTotalDurationSeconds(30)).toBe("0分");
   });
 });

--- a/admin/src/features/interview-reports/shared/utils/format-average-duration.ts
+++ b/admin/src/features/interview-reports/shared/utils/format-average-duration.ts
@@ -17,3 +17,25 @@ export function formatDurationSeconds(durationSeconds: number | null): string {
 
   return `${minutes}分${seconds}秒`;
 }
+
+export function formatTotalDurationSeconds(
+  durationSeconds: number | null
+): string {
+  if (durationSeconds == null || durationSeconds <= 0) {
+    return "-";
+  }
+
+  const totalMinutes = Math.floor(durationSeconds / 60);
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+
+  if (hours === 0) {
+    return `${minutes}分`;
+  }
+
+  if (minutes === 0) {
+    return `${hours}時間`;
+  }
+
+  return `${hours}時間${minutes}分`;
+}

--- a/admin/src/features/interview-reports/shared/utils/map-interview-statistics.test.ts
+++ b/admin/src/features/interview-reports/shared/utils/map-interview-statistics.test.ts
@@ -16,6 +16,7 @@ describe("mapInterviewStatistics", () => {
     role_general_citizen_count: 35,
     avg_message_count: 12.3,
     median_duration_seconds: 345,
+    total_duration_seconds: 27600,
     public_by_user_count: 60,
     feedback_irrelevant_questions: 5,
     feedback_not_aligned: 3,
@@ -43,6 +44,7 @@ describe("mapInterviewStatistics", () => {
     expect(result.roleGeneralCitizen).toBe(35);
     expect(result.avgMessageCount).toBe(12.3);
     expect(result.medianDurationSeconds).toBe(345);
+    expect(result.totalDurationSeconds).toBe(27600);
     expect(result.publicByUserCount).toBe(60);
     expect(result.publicRate).toBe(75);
     expect(result.feedbackIrrelevantQuestions).toBe(5);
@@ -96,5 +98,14 @@ describe("mapInterviewStatistics", () => {
     expect(result.avgTotalContentRichness).toBeNull();
     expect(result.avgMessageCount).toBeNull();
     expect(result.medianDurationSeconds).toBeNull();
+  });
+
+  it("falls back to 0 when total_duration_seconds is null", () => {
+    const result = mapInterviewStatistics({
+      ...baseRaw,
+      total_duration_seconds: null,
+    });
+
+    expect(result.totalDurationSeconds).toBe(0);
   });
 });

--- a/admin/src/features/interview-reports/shared/utils/map-interview-statistics.ts
+++ b/admin/src/features/interview-reports/shared/utils/map-interview-statistics.ts
@@ -14,6 +14,7 @@ type RawStatistics = {
   role_general_citizen_count: number;
   avg_message_count: number | null;
   median_duration_seconds: number | null;
+  total_duration_seconds: number | null;
   public_by_user_count: number;
   feedback_irrelevant_questions: number;
   feedback_not_aligned: number;
@@ -43,6 +44,7 @@ export function mapInterviewStatistics(
     roleGeneralCitizen: raw.role_general_citizen_count,
     avgMessageCount: raw.avg_message_count,
     medianDurationSeconds: raw.median_duration_seconds,
+    totalDurationSeconds: raw.total_duration_seconds ?? 0,
     publicByUserCount: raw.public_by_user_count,
     publicRate:
       raw.completed_sessions > 0

--- a/packages/supabase/types/supabase.types.ts
+++ b/packages/supabase/types/supabase.types.ts
@@ -1044,6 +1044,7 @@ export type Database = {
           stance_for_count: number
           stance_neutral_count: number
           total_cost_usd: number
+          total_duration_seconds: number
           total_sessions: number
         }[]
       }

--- a/supabase/migrations/20260520100000_add_total_duration_to_interview_statistics.sql
+++ b/supabase/migrations/20260520100000_add_total_duration_to_interview_statistics.sql
@@ -1,0 +1,117 @@
+-- get_interview_statistics に総所要時間（途中離脱含む）を追加
+-- 完了セッション: completed_at - started_at
+-- 途中離脱セッション: 最後のメッセージ created_at - started_at（メッセージが無いセッションは集計から除外）
+drop function if exists get_interview_statistics(uuid);
+
+create function get_interview_statistics(p_config_id uuid)
+returns table (
+  total_sessions bigint,
+  completed_sessions bigint,
+  avg_rating numeric,
+  stance_for_count bigint,
+  stance_against_count bigint,
+  stance_neutral_count bigint,
+  avg_total_content_richness numeric,
+  role_subject_expert_count bigint,
+  role_work_related_count bigint,
+  role_daily_life_affected_count bigint,
+  role_general_citizen_count bigint,
+  avg_message_count numeric,
+  median_duration_seconds numeric,
+  total_duration_seconds numeric,
+  public_by_user_count bigint,
+  feedback_irrelevant_questions bigint,
+  feedback_not_aligned bigint,
+  feedback_misunderstood bigint,
+  feedback_too_many_questions bigint,
+  feedback_other bigint,
+  total_cost_usd numeric,
+  avg_cost_usd numeric
+) as $$
+begin
+  return query
+  select
+    count(s.id) as total_sessions,
+    count(s.completed_at) as completed_sessions,
+    round(avg(s.rating)::numeric, 2) as avg_rating,
+    count(case when r.stance = 'for' then 1 end) as stance_for_count,
+    count(case when r.stance = 'against' then 1 end) as stance_against_count,
+    count(case when r.stance = 'neutral' then 1 end) as stance_neutral_count,
+    round(avg(r.total_content_richness)::numeric, 1) as avg_total_content_richness,
+    count(case when r.role = 'subject_expert' then 1 end) as role_subject_expert_count,
+    count(case when r.role = 'work_related' then 1 end) as role_work_related_count,
+    count(case when r.role = 'daily_life_affected' then 1 end) as role_daily_life_affected_count,
+    count(case when r.role = 'general_citizen' then 1 end) as role_general_citizen_count,
+    round(avg(coalesce(mc.message_count, 0))::numeric, 1) as avg_message_count,
+    round(
+      (select percentile_cont(0.5) within group (
+        order by extract(epoch from (sub.completed_at - sub.started_at))
+      )
+      from interview_sessions sub
+      where sub.interview_config_id = p_config_id
+        and sub.completed_at is not null
+      )::numeric, 0
+    ) as median_duration_seconds,
+    -- 総所要時間: 完了セッションは completed_at、途中離脱は最終メッセージ時刻を終了時刻として集計
+    -- メッセージが無い未完了セッションは duration を算出できないため除外
+    coalesce(
+      (select sum(extract(epoch from (
+        coalesce(sub.completed_at, lm.last_message_at) - sub.started_at
+      )))
+      from interview_sessions sub
+      left join (
+        select im.interview_session_id, max(im.created_at) as last_message_at
+        from interview_messages im
+        group by im.interview_session_id
+      ) lm on lm.interview_session_id = sub.id
+      where sub.interview_config_id = p_config_id
+        and coalesce(sub.completed_at, lm.last_message_at) is not null
+      ),
+      0
+    )::numeric as total_duration_seconds,
+    count(case when r.is_public_by_user = true then 1 end) as public_by_user_count,
+    -- フィードバックタグ集計
+    coalesce(max(fc.feedback_irrelevant_questions), 0) as feedback_irrelevant_questions,
+    coalesce(max(fc.feedback_not_aligned), 0) as feedback_not_aligned,
+    coalesce(max(fc.feedback_misunderstood), 0) as feedback_misunderstood,
+    coalesce(max(fc.feedback_too_many_questions), 0) as feedback_too_many_questions,
+    coalesce(max(fc.feedback_other), 0) as feedback_other,
+    -- コスト集計
+    coalesce(max(cc.total_cost), 0)::numeric as total_cost_usd,
+    case
+      when count(s.id) > 0 then round(coalesce(max(cc.total_cost), 0)::numeric / count(s.id), 6)
+      else 0::numeric
+    end as avg_cost_usd
+  from interview_sessions s
+  left join interview_report r on r.interview_session_id = s.id
+  left join (
+    select im.interview_session_id, count(*) as message_count
+    from interview_messages im
+    group by im.interview_session_id
+  ) mc on mc.interview_session_id = s.id
+  left join (
+    select
+      count(*) filter (where f.tag = 'irrelevant_questions') as feedback_irrelevant_questions,
+      count(*) filter (where f.tag = 'not_aligned') as feedback_not_aligned,
+      count(*) filter (where f.tag = 'misunderstood') as feedback_misunderstood,
+      count(*) filter (where f.tag = 'too_many_questions') as feedback_too_many_questions,
+      count(*) filter (where f.tag = 'other') as feedback_other
+    from interview_rating_feedbacks f
+    join interview_sessions fs on fs.id = f.interview_session_id
+    where fs.interview_config_id = p_config_id
+  ) fc on true
+  left join (
+    select sum(c.cost_usd) as total_cost
+    from chat_usage_events c
+    join interview_sessions cs on cs.id::text = c.session_id
+    where cs.interview_config_id = p_config_id
+  ) cc on true
+  where s.interview_config_id = p_config_id;
+end;
+$$ language plpgsql stable;
+
+-- function を drop すると権限もリセットされるため、admin-only 権限を再付与
+revoke execute on function public.get_interview_statistics(uuid) from public;
+revoke execute on function public.get_interview_statistics(uuid) from anon;
+revoke execute on function public.get_interview_statistics(uuid) from authenticated;
+grant execute on function public.get_interview_statistics(uuid) to service_role;

--- a/tests/supabase/db-function/get-interview-statistics.test.ts
+++ b/tests/supabase/db-function/get-interview-statistics.test.ts
@@ -27,6 +27,7 @@ async function createTestSession(
   configId: string,
   userId: string,
   overrides: Partial<{
+    started_at: string;
     completed_at: string;
     rating: number;
   }> = {}
@@ -43,6 +44,20 @@ async function createTestSession(
     .single();
   if (error) throw new Error(`interview_session 作成失敗: ${error.message}`);
   return data;
+}
+
+async function insertInterviewMessage(
+  sessionId: string,
+  createdAt: string,
+  role: "assistant" | "user" = "user"
+) {
+  const { error } = await adminClient.from("interview_messages").insert({
+    interview_session_id: sessionId,
+    role,
+    content: `dropout test ${createdAt}`,
+    created_at: createdAt,
+  });
+  if (error) throw new Error(`interview_messages 作成失敗: ${error.message}`);
 }
 
 async function createTestReport(
@@ -423,6 +438,58 @@ describe("get_interview_statistics() 関数", () => {
     expect(Number(data?.[0].avg_cost_usd)).toBeCloseTo(0.05, 4);
   });
 
+  it("総所要時間を完了セッションと途中離脱セッションの両方で集計する", async () => {
+    const bill = await createTestBill();
+    billIds.push(bill.id);
+    const config = await createTestInterviewConfig(bill.id);
+
+    const base = new Date("2026-05-20T00:00:00.000Z").getTime();
+    const iso = (offsetSec: number) =>
+      new Date(base + offsetSec * 1000).toISOString();
+
+    // 完了セッション: 300秒
+    await createTestSession(config.id, testUser.id, {
+      started_at: iso(0),
+      completed_at: iso(300),
+    });
+    // 完了セッション: 120秒
+    await createTestSession(config.id, testUser.id, {
+      started_at: iso(0),
+      completed_at: iso(120),
+    });
+    // 途中離脱（未完了）: 最終メッセージ 180秒
+    const dropout = await createTestSession(config.id, testUser.id, {
+      started_at: iso(0),
+    });
+    await insertInterviewMessage(dropout.id, iso(60));
+    await insertInterviewMessage(dropout.id, iso(180));
+    // 途中離脱（メッセージなし）: 計算対象外
+    await createTestSession(config.id, testUser.id, {
+      started_at: iso(0),
+    });
+
+    const { data, error } = await adminClient.rpc("get_interview_statistics", {
+      p_config_id: config.id,
+    });
+
+    expect(error).toBeNull();
+    // 300 + 120 + 180 = 600
+    expect(Number(data?.[0].total_duration_seconds)).toBeCloseTo(600, 0);
+  });
+
+  it("該当セッションが無い場合 total_duration_seconds は 0", async () => {
+    const bill = await createTestBill();
+    billIds.push(bill.id);
+    const config = await createTestInterviewConfig(bill.id);
+
+    const { data, error } = await adminClient.rpc("get_interview_statistics", {
+      p_config_id: config.id,
+    });
+
+    expect(error).toBeNull();
+    expect(Number(data?.[0].total_duration_seconds)).toBe(0);
+  });
+
   it("存在しないconfig_idではすべてゼロ/NULLの行を返す", async () => {
     const { data, error } = await adminClient.rpc("get_interview_statistics", {
       p_config_id: "00000000-0000-0000-0000-000000000000",
@@ -434,5 +501,6 @@ describe("get_interview_statistics() 関数", () => {
     expect(data?.[0].completed_sessions).toBe(0);
     expect(data?.[0].avg_rating).toBeNull();
     expect(data?.[0].stance_for_count).toBe(0);
+    expect(Number(data?.[0].total_duration_seconds)).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

- インタビュー統計に「総所要時間」のStatCardを追加
- 完了セッションは `completed_at - started_at`、途中離脱は最終メッセージ時刻を実質的な終了時刻として集計
- メッセージのない未完了セッションは集計対象外（duration を算出できないため）

## 背景

Slack スレッド（[link](https://team-mirai-staff.slack.com/archives/C0AFPQKSKS7/p1779253887854569?thread_ts=1779251329.614829&cid=C0AFPQKSKS7)）で岩瀬さんから「インタビューに費やされた総時間数を出す方法」が要望として上がっており、村井さんから「途中離脱まで含めたい」とコメントがあったため実装。

## 変更内容（9ファイル / +278 / -3）

- `supabase/migrations/20260520100000_add_total_duration_to_interview_statistics.sql`（新規）
  - `get_interview_statistics(p_config_id uuid)` を drop & recreate し `total_duration_seconds numeric` を追加
  - 完了セッション: `EXTRACT(EPOCH FROM (completed_at - started_at))`
  - 途中離脱セッション: `EXTRACT(EPOCH FROM (MAX(interview_messages.created_at) - started_at))`
  - メッセージのない未完了セッションは duration を算出できないため除外
  - admin-only 権限を再付与（drop で権限がリセットされるため）
- `packages/supabase/types/supabase.types.ts` に `total_duration_seconds` を追加
- `admin/src/features/interview-reports/shared/types/index.ts` の `InterviewStatistics` に `totalDurationSeconds` 追加
- `map-interview-statistics.ts` で raw `total_duration_seconds` を `?? 0` でマッピング
- `format-average-duration.ts` に `formatTotalDurationSeconds`（○時間○分表記）を追加
- `interview-statistics.tsx` を `md:grid-cols-4` → `md:grid-cols-5` に拡張し、Hourglass アイコンの StatCard を追加
- vitest 単体テスト & supabase 統合テストに新フィールドのケースを追加

## 仕様メモ

- 集計対象セッション:
  - 完了: `completed_at - started_at`
  - 途中離脱: `MAX(interview_messages.created_at) - started_at`
  - メッセージなし未完了: 除外（duration 不明）
- `formatTotalDurationSeconds` は秒を切り捨てて「○時間○分」表記（合計値前提）
- 該当セッション 0 件のときは `total_duration_seconds = 0` を返す

## Test plan

- [x] `pnpm lint`（exit 0、既存の warning のみ）
- [x] `pnpm typecheck`
- [x] `pnpm --filter admin test`（425 tests passed）
- [ ] CI 上で `pnpm test`（DB function 統合テスト含む）が通過することを確認
- [ ] ローカル `pnpm dev` で Admin UI の bills/[id]/interview-reports ページに「総所要時間」が表示されることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * インタビュー統計に「総所要時間」を集計・表示する指標を追加。ダッシュボードに新しい統計カードを表示します。
* **Backend**
  * 統計集計に総所要時間および中央値の算出を追加し、完了・途中離脱セッションを考慮して集計します。
* **Tests**
  * 総所要時間の整形・マッピングに関するテストを追加・拡張しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/team-mirai/mirai-gikai/pull/821?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->