### PR TITLE
worker: core/shared/supabase を type:module 化（Node22のESM import解消）

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -2,6 +2,7 @@
   "name": "@mirai-gikai/shared",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "test": "vitest run",
     "test:watch": "vitest"

--- a/packages/supabase/package.json
+++ b/packages/supabase/package.json
@@ -2,6 +2,7 @@
   "name": "@mirai-gikai/supabase",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "exports": {

--- a/packages/topic-analysis-core/package.json
+++ b/packages/topic-analysis-core/package.json
@@ -2,6 +2,7 @@
   "name": "@mirai-gikai/topic-analysis-core",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "test": "vitest run",
     "test:watch": "vitest",


### PR DESCRIPTION
## 概要
Cloud Run（Node 22）上で topic-analysis worker が起動時に落ちる不具合を修正する。

```
SyntaxError: The requested module '@mirai-gikai/topic-analysis-core/analyze' does not provide an export named 'runAnalysis'
```

## 原因
- `worker` は `type: module`（ESM）だが、`@mirai-gikai/topic-analysis-core` / `shared` / `supabase` に `type` 指定が無く **CommonJS 扱い**になっていた。
- Node 22 は ESM↔CJS の named export 解決が厳格化しており、ESM の worker が CJS 扱いの `.ts` パッケージから `runAnalysis` 等の named export を取得できず起動失敗。ローカルの Node 20 では緩く通っていたため検知が遅れた（#828 で worker が develop に入って初めて顕在化）。

## 修正
- 3パッケージに `"type": "module"` を付与。これらの `.ts` は元から ESM 構文なので、実態に合わせて正しく宣言しただけ（挙動変更ではない）。

## 検証
- **docker（node:22-slim）でコンテナ実行**: 修正前は上記 SyntaxError で即死 → 修正後は import が解決し `requireEnv` まで到達（＝モジュール解決成功）することを確認。
- `pnpm typecheck`（全5プロジェクト）✅ / `pnpm lint` ✅
- ユニット（shared 68 / core 24 / admin 440）・統合テスト（8）すべて pass。

## 影響範囲
- `shared` / `supabase` は admin・web・seed・tests でも利用されるが、いずれも ESM 対応（Next.js バンドル / vitest）。typecheck・lint・テストで回帰なしを確認済み。Next ビルドは CI（code_check）で検証。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * パッケージのモジュール設定を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->