### PR TITLE
deploy_worker: GCP値をsecrets参照に変更しガードをVariableフラグ化

### DIFF
--- a/.github/workflows/deploy_worker.yml
+++ b/.github/workflows/deploy_worker.yml
@@ -15,19 +15,20 @@ on:
 
 jobs:
   build-and-deploy:
-    # GCP 未プロビジョニング（GCP_PROJECT_ID 未設定）の間はジョブごとスキップする。
-    # 変数を設定した時点から自動でデプロイが走り始める（未設定中に赤を出さない）。
-    if: ${{ vars.GCP_PROJECT_ID != '' }}
+    # GCP デプロイを有効化した環境でのみ実行する。プロジェクトID等は OSS の公開
+    # Actions ログでマスクするため Secret に置く（if: では secrets を参照できないので）、
+    # ガードは非機密の Variable フラグで判定する。各 Environment に
+    # variables.GCP_DEPLOY_ENABLED=true を設定すると、その環境向けにデプロイが走る。
+    if: ${{ vars.GCP_DEPLOY_ENABLED == 'true' }}
     runs-on: ubuntu-latest
     environment: ${{ github.ref_name == 'main' && 'production' || 'staging' }}
     env:
-      # GCP プロジェクト ID は機密相当（OSS のため値はコミットしない）。
-      # GitHub Environment の variables.GCP_PROJECT_ID に設定する。
-      GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
-      # 以下はプロジェクト識別子ではない汎用のリソース名。variables で上書き可。
-      GCP_REGION: ${{ vars.GCP_REGION || 'asia-northeast1' }}
-      GCP_AR_REPO: ${{ vars.GCP_AR_REPO || 'topic-analysis' }}
-      GCP_TOPIC_ANALYSIS_JOB: ${{ vars.GCP_TOPIC_ANALYSIS_JOB || 'topic-analysis-worker' }}
+      # プロジェクト ID は機密相当。公開ログでマスクされるよう Secret から読む。
+      GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+      # リージョン等も Secret から（未設定なら汎用デフォルト）。
+      GCP_REGION: ${{ secrets.GCP_REGION || 'asia-northeast1' }}
+      GCP_AR_REPO: ${{ secrets.GCP_AR_REPO || 'topic-analysis' }}
+      GCP_TOPIC_ANALYSIS_JOB: ${{ secrets.GCP_TOPIC_ANALYSIS_JOB || 'topic-analysis-worker' }}
     steps:
       - uses: actions/checkout@v5
 
@@ -38,7 +39,7 @@ jobs:
           GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
         run: |
           if [ -z "$GCP_PROJECT_ID" ]; then
-            echo "::error::variables.GCP_PROJECT_ID is not set" && exit 1
+            echo "::error::secrets.GCP_PROJECT_ID is not set" && exit 1
           fi
           printf '%s' "$GCP_SA_KEY" > "${RUNNER_TEMP}/gcp-key.json"
           gcloud auth activate-service-account --key-file="${RUNNER_TEMP}/gcp-key.json"

--- a/docs/20260609_1230_トピック分析CloudRunプロビジョニング手順.md
+++ b/docs/20260609_1230_トピック分析CloudRunプロビジョニング手順.md
@@ -194,13 +194,28 @@ gcloud iam service-accounts keys create deployer-key.json \
   --iam-account="$DEPLOYER_SA"
 ```
 
-### GitHub（リポジトリ / Environment）設定
+### GitHub（Environment）設定
 
-- Secret: `GCP_SA_KEY` = `deployer-key.json` の中身
-- Variables（任意・デフォルトはワークフローに埋め込み済み）:
-  `GCP_PROJECT_ID` / `GCP_REGION` / `GCP_AR_REPO` / `GCP_TOPIC_ANALYSIS_JOB`
+`deploy_worker.yml` は `develop`→`staging` / `main`→`production` の Environment を使う。
+**公開リポジトリの Actions ログは誰でも閲覧可能**なので、プロジェクトID等の値は
+**Secret に置いてログでマスク**し、ジョブ実行可否は**非機密の Variable フラグ**で判定する。
 
-`develop` / `main` への push で `worker/` 等が変わると、CI がイメージを差し替える。
+各 Environment（`staging` / `production`）に以下を設定する:
+
+- **Variable**: `GCP_DEPLOY_ENABLED` = `true`（これが無い環境はジョブごとスキップ）
+- **Secret**:
+  - `GCP_SA_KEY` = その環境の `deployer-key.json` の中身
+  - `GCP_PROJECT_ID` = その環境の GCP プロジェクトID
+  - （任意）`GCP_REGION` / `GCP_AR_REPO` / `GCP_TOPIC_ANALYSIS_JOB` … 既定値
+    （`asia-northeast1` / `topic-analysis` / `topic-analysis-worker`）から変える場合のみ
+
+```bash
+gh variable set GCP_DEPLOY_ENABLED --env staging --body true
+gh secret   set GCP_PROJECT_ID     --env staging --body "<project-id>"
+gh secret   set GCP_SA_KEY         --env staging < deployer-key.json
+```
+
+`develop` / `main` への push で `worker/` 等が変わると、その環境向けに CI がイメージを差し替える。
 
 ## 8. 後片付け
 


### PR DESCRIPTION
## 背景
`deploy_worker.yml` のデプロイジョブが develop push のたびに **skipped** になっていた。原因はガード `if: vars.GCP_PROJECT_ID != ''` が **Variable** を見ているが、設定が **Secret** 側にあったため。

加えて OSS（**公開リポジトリの Actions ログは誰でも閲覧可**）では、`GCP_PROJECT_ID` を Variable にするとプロジェクトIDが**平文でログに露出**する。Secret なら**マスク**される。

## 変更
- 値（`GCP_PROJECT_ID` / `GCP_REGION` / `GCP_AR_REPO` / `GCP_TOPIC_ANALYSIS_JOB`）を **`secrets.*` 参照**に変更（公開ログでマスク）。
- `if:` では secrets を参照できないため、実行可否は**非機密の Variable `GCP_DEPLOY_ENABLED`** で判定。
- runbook（プロビジョニング手順）の GitHub 設定節を更新。

## 必要な GitHub Environment 設定（マージ後・各環境）
- Variable: `GCP_DEPLOY_ENABLED` = `true`
- Secret: `GCP_SA_KEY`（deployer 鍵）, `GCP_PROJECT_ID`（＋必要なら `GCP_REGION`/`GCP_TOPIC_ANALYSIS_JOB`）

## テスト
- YAML 構文チェック OK。
- アプリコード変更なし（ワークフロー YAML + docs のみ）。lint/typecheck/build への影響なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)