### PR TITLE
deploy_worker: 環境のGCP設定有無をステップ判定に（job-level if廃止）

### DIFF
--- a/.github/workflows/deploy_worker.yml
+++ b/.github/workflows/deploy_worker.yml
@@ -15,38 +15,45 @@ on:
 
 jobs:
   build-and-deploy:
-    # GCP デプロイを有効化した環境でのみ実行する。プロジェクトID等は OSS の公開
-    # Actions ログでマスクするため Secret に置く（if: では secrets を参照できないので）、
-    # ガードは非機密の Variable フラグで判定する。各 Environment に
-    # variables.GCP_DEPLOY_ENABLED=true を設定すると、その環境向けにデプロイが走る。
-    if: ${{ vars.GCP_DEPLOY_ENABLED == 'true' }}
     runs-on: ubuntu-latest
+    # develop→staging / main→production。接続先は環境ごとの Secret で切り替える。
     environment: ${{ github.ref_name == 'main' && 'production' || 'staging' }}
     env:
-      # プロジェクト ID は機密相当。公開ログでマスクされるよう Secret から読む。
+      # 値は Secret から読む（OSS の公開 Actions ログでマスクされる）。
       GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
-      # リージョン等も Secret から（未設定なら汎用デフォルト）。
       GCP_REGION: ${{ secrets.GCP_REGION || 'asia-northeast1' }}
       GCP_AR_REPO: ${{ secrets.GCP_AR_REPO || 'topic-analysis' }}
       GCP_TOPIC_ANALYSIS_JOB: ${{ secrets.GCP_TOPIC_ANALYSIS_JOB || 'topic-analysis-worker' }}
     steps:
-      - uses: actions/checkout@v5
+      # Environment の Secret は job 開始後のステップでしか参照できない
+      # （job-level if からは Environment スコープの vars/secrets が見えない）。
+      # この環境に GCP 設定が無ければ以降を skip し、green で終わる（赤を出さない）。
+      - name: Check GCP configuration
+        id: cfg
+        run: |
+          if [ -z "$GCP_PROJECT_ID" ]; then
+            echo "GCP_PROJECT_ID secret is not set for this environment — skipping deploy."
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          fi
 
-      # gcloud / docker は ubuntu-latest にプリインストール済み。
-      # 追加のサードパーティ Action を使わず、SAキーで直接認証する。
+      - uses: actions/checkout@v5
+        if: steps.cfg.outputs.configured == 'true'
+
+      # gcloud / docker は ubuntu-latest にプリインストール済み。SAキーで直接認証する。
       - name: Authenticate gcloud
+        if: steps.cfg.outputs.configured == 'true'
         env:
           GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
         run: |
-          if [ -z "$GCP_PROJECT_ID" ]; then
-            echo "::error::secrets.GCP_PROJECT_ID is not set" && exit 1
-          fi
           printf '%s' "$GCP_SA_KEY" > "${RUNNER_TEMP}/gcp-key.json"
           gcloud auth activate-service-account --key-file="${RUNNER_TEMP}/gcp-key.json"
           gcloud config set project "$GCP_PROJECT_ID"
           gcloud auth configure-docker "${GCP_REGION}-docker.pkg.dev" --quiet
 
       - name: Build and push image
+        if: steps.cfg.outputs.configured == 'true'
         run: |
           IMAGE="${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_AR_REPO}/topic-analysis-worker:${GITHUB_SHA}"
           docker build -f worker/Dockerfile -t "$IMAGE" .
@@ -56,6 +63,7 @@ jobs:
       # Job 自体（env/secret/リソース）の初期作成は docs の手順書で行う。
       # CI はイメージの差し替えのみを担当する（設定の上書きを避ける）。
       - name: Update Cloud Run Job image
+        if: steps.cfg.outputs.configured == 'true'
         run: |
           gcloud run jobs update "$GCP_TOPIC_ANALYSIS_JOB" \
             --image "$IMAGE" \

--- a/docs/20260609_1230_トピック分析CloudRunプロビジョニング手順.md
+++ b/docs/20260609_1230_トピック分析CloudRunプロビジョニング手順.md
@@ -198,21 +198,21 @@ gcloud iam service-accounts keys create deployer-key.json \
 
 `deploy_worker.yml` は `develop`→`staging` / `main`→`production` の Environment を使う。
 **公開リポジトリの Actions ログは誰でも閲覧可能**なので、プロジェクトID等の値は
-**Secret に置いてログでマスク**し、ジョブ実行可否は**非機密の Variable フラグ**で判定する。
+**Secret に置いてログでマスク**する。デプロイ実行可否は**その環境に `GCP_PROJECT_ID`
+Secret があるかどうか**で自動判定する（未設定の環境はステップを skip して green 終了。
+Environment スコープの Secret は job 開始後のステップでしか参照できないため、判定も
+ステップ側で行う）。
 
-各 Environment（`staging` / `production`）に以下を設定する:
+各 Environment（`staging` / `production`）に以下の **Secret** を設定する:
 
-- **Variable**: `GCP_DEPLOY_ENABLED` = `true`（これが無い環境はジョブごとスキップ）
-- **Secret**:
-  - `GCP_SA_KEY` = その環境の `deployer-key.json` の中身
-  - `GCP_PROJECT_ID` = その環境の GCP プロジェクトID
-  - （任意）`GCP_REGION` / `GCP_AR_REPO` / `GCP_TOPIC_ANALYSIS_JOB` … 既定値
-    （`asia-northeast1` / `topic-analysis` / `topic-analysis-worker`）から変える場合のみ
+- `GCP_SA_KEY` = その環境の `deployer-key.json` の中身
+- `GCP_PROJECT_ID` = その環境の GCP プロジェクトID（これが設定されるとデプロイが有効化）
+- （任意）`GCP_REGION` / `GCP_AR_REPO` / `GCP_TOPIC_ANALYSIS_JOB` … 既定値
+  （`asia-northeast1` / `topic-analysis` / `topic-analysis-worker`）から変える場合のみ
 
 ```bash
-gh variable set GCP_DEPLOY_ENABLED --env staging --body true
-gh secret   set GCP_PROJECT_ID     --env staging --body "<project-id>"
-gh secret   set GCP_SA_KEY         --env staging < deployer-key.json
+gh secret set GCP_PROJECT_ID --env staging --body "<project-id>"
+gh secret set GCP_SA_KEY     --env staging < deployer-key.json
 ```
 
 `develop` / `main` への push で `worker/` 等が変わると、その環境向けに CI がイメージを差し替える。


### PR DESCRIPTION
## 背景
`GCP_DEPLOY_ENABLED=true` を staging Environment に設定しても deploy_worker が **skip され続けた**。

原因は GitHub の仕様で、**ジョブレベルの `if:` は Environment スコープの Variable/Secret を参照できない**（`if:` は environment 適用前に評価される）こと。`GCP_DEPLOY_ENABLED` を Environment に置いたため `if` から見えず常に false 扱いだった。

## 変更
- **job-level `if:` を撤去**し、判定を**ジョブ開始後のステップ**に移動。
- 先頭の `Check GCP configuration` ステップで、その環境の `GCP_PROJECT_ID`（Secret）が空かどうかを見て `configured` を出力。
- `checkout` / `Authenticate` / `Build and push` / `Update Cloud Run Job` を `if: steps.cfg.outputs.configured == 'true'` で gate。未設定環境は **green で skip**（赤を出さない）。
- これにより **`GCP_DEPLOY_ENABLED` 変数は不要**（`GCP_PROJECT_ID` secret の有無で自動有効化）。runbook も更新。

## 有効化（マージ後）
staging には既に `GCP_PROJECT_ID` / `GCP_SA_KEY` 等の Secret 設定済みなので、**追加設定は不要**。`GCP_DEPLOY_ENABLED` 変数は削除して構いません。

## テスト
- YAML 構文チェック OK。アプリコード変更なし（ワークフロー YAML + docs のみ）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)