### PR TITLE
バックフィルに議案スコープと対象範囲(未再抽出のみ/全部)を追加

### DIFF
--- a/admin/src/app/(protected)/interview-opinion-backfill/page.tsx
+++ b/admin/src/app/(protected)/interview-opinion-backfill/page.tsx
@@ -1,5 +1,6 @@
 import { redirect } from "next/navigation";
 import { getCurrentAdmin } from "@/features/auth/server/lib/auth-server";
+import { getBills } from "@/features/bills/server/loaders/get-bills";
 import { OpinionBackfillRunner } from "@/features/interview-opinion-backfill/client/components/opinion-backfill-runner";
 import { routes } from "@/lib/routes";
 
@@ -9,6 +10,9 @@ export default async function InterviewOpinionBackfillPage() {
   if (!currentAdmin) {
     redirect(routes.login());
   }
+
+  const bills = await getBills();
+  const billOptions = bills.map((bill) => ({ id: bill.id, name: bill.name }));
 
   return (
     <div className="container mx-auto py-8">
@@ -24,7 +28,7 @@ export default async function InterviewOpinionBackfillPage() {
       </p>
 
       <section className="rounded-lg border bg-card p-6">
-        <OpinionBackfillRunner />
+        <OpinionBackfillRunner bills={billOptions} />
       </section>
     </div>
   );

--- a/admin/src/app/api/interview-opinion-backfill/dispatch/route.ts
+++ b/admin/src/app/api/interview-opinion-backfill/dispatch/route.ts
@@ -1,4 +1,8 @@
-import { countPendingReextraction } from "@mirai-gikai/topic-analysis-core/repository";
+import { resolveBackfillParams } from "@mirai-gikai/topic-analysis-core/backfill-params";
+import {
+  countAllReports,
+  countPendingReextraction,
+} from "@mirai-gikai/topic-analysis-core/repository";
 import { requireAdmin } from "@/features/auth/server/lib/auth-server";
 import { executeTopicAnalysisJob } from "@/lib/cloud-run-job";
 
@@ -12,23 +16,50 @@ const json = (body: unknown, status = 200) =>
 
 /**
  * 意見再抽出バックフィルの入口（Admin 手動トリガ）。
- * 未処理レポートがあれば Cloud Run Job（backfill モード）を起動する。
+ * リクエストボディで議案スコープ（billId）・対象範囲（scope）を指定できる。
+ * 対象レポートがあれば Cloud Run Job（backfill モード）を起動する。
  */
-export async function POST() {
+export async function POST(request: Request) {
   try {
     await requireAdmin();
   } catch {
     return json({ error: "Unauthorized" }, 401);
   }
 
+  let body: { billId?: string; scope?: string } = {};
   try {
-    const pending = await countPendingReextraction();
+    body = (await request.json()) as { billId?: string; scope?: string };
+  } catch {
+    // ボディ無し（旧クライアント互換）は既定値（全議案・未再抽出）として扱う。
+  }
+
+  const resolved = resolveBackfillParams({
+    billId: body.billId,
+    scope: body.scope,
+  });
+  if (!resolved.ok) {
+    return json({ error: resolved.error }, 400);
+  }
+  const { billId, scope } = resolved.params;
+
+  try {
+    // 対象件数を確認し、0 件なら起動しない。
+    // pending は未再抽出件数、all は議案の全レポート件数を見る。
+    const pending =
+      scope === "all"
+        ? await countAllReports(billId)
+        : await countPendingReextraction(billId);
     if (pending === 0) {
       return json({ started: false, pending });
     }
 
+    const args = ["--mode=backfill", `--scope=${scope}`];
+    if (billId) {
+      args.push(`--bill-id=${billId}`);
+    }
+
     try {
-      await executeTopicAnalysisJob(["--mode=backfill"]);
+      await executeTopicAnalysisJob(args);
     } catch (triggerError) {
       const message =
         triggerError instanceof Error ? triggerError.message : "trigger failed";

--- a/admin/src/app/api/interview-opinion-backfill/dispatch/route.ts
+++ b/admin/src/app/api/interview-opinion-backfill/dispatch/route.ts
@@ -1,7 +1,7 @@
 import { resolveBackfillParams } from "@mirai-gikai/topic-analysis-core/backfill-params";
 import {
-  countAllReports,
   countPendingReextraction,
+  resetReextractionForBill,
 } from "@mirai-gikai/topic-analysis-core/repository";
 import { requireAdmin } from "@/features/auth/server/lib/auth-server";
 import { executeTopicAnalysisJob } from "@/lib/cloud-run-job";
@@ -43,12 +43,17 @@ export async function POST(request: Request) {
   const { billId, scope } = resolved.params;
 
   try {
-    // 対象件数を確認し、0 件なら起動しない。
-    // pending は未再抽出件数、all は議案の全レポート件数を見る。
-    const pending =
-      scope === "all"
-        ? await countAllReports(billId)
-        : await countPendingReextraction(billId);
+    // scope="all" は起動前に同期的にウォーターマークをリセットする。
+    // これで pending=全件 となり、UI が即座に進捗を分母込みで把握できるため、
+    // 「既に再抽出済みの議案で pending=0 を見て早期完了表示→重複起動」を防ぐ。
+    // worker 側も冪等に再リセットするが、ここでの同期リセットが起動直後の競合を消す。
+    if (scope === "all" && billId) {
+      await resetReextractionForBill(billId);
+    }
+
+    // 対象件数（未再抽出件数）を確認し、0 件なら起動しない。
+    // all はリセット後なので pending=全件、pending はそのまま未再抽出件数。
+    const pending = await countPendingReextraction(billId);
     if (pending === 0) {
       return json({ started: false, pending });
     }

--- a/admin/src/app/api/interview-opinion-backfill/dispatch/route.ts
+++ b/admin/src/app/api/interview-opinion-backfill/dispatch/route.ts
@@ -26,11 +26,16 @@ export async function POST(request: Request) {
     return json({ error: "Unauthorized" }, 401);
   }
 
+  // 空ボディ（旧クライアント互換）は既定値（全議案・未再抽出）として扱うが、
+  // 壊れた JSON は黙って既定実行にせず 400 で弾く（意図しない起動を防ぐ）。
   let body: { billId?: string; scope?: string } = {};
-  try {
-    body = (await request.json()) as { billId?: string; scope?: string };
-  } catch {
-    // ボディ無し（旧クライアント互換）は既定値（全議案・未再抽出）として扱う。
+  const raw = await request.text();
+  if (raw.trim()) {
+    try {
+      body = JSON.parse(raw) as { billId?: string; scope?: string };
+    } catch {
+      return json({ error: "リクエストボディの JSON が不正です" }, 400);
+    }
   }
 
   const resolved = resolveBackfillParams({

--- a/admin/src/app/api/interview-opinion-backfill/status/route.ts
+++ b/admin/src/app/api/interview-opinion-backfill/status/route.ts
@@ -1,3 +1,4 @@
+import { resolveBackfillParams } from "@mirai-gikai/topic-analysis-core/backfill-params";
 import {
   countAllReports,
   countPendingReextraction,
@@ -14,18 +15,26 @@ const json = (body: unknown, status = 200) =>
     },
   });
 
-/** 進捗（未処理件数 / 全件数）を返す。UI のポーリング用。 */
-export async function GET() {
+/** 進捗（未処理件数 / 全件数）を返す。UI のポーリング用。billId で議案に絞れる。 */
+export async function GET(request: Request) {
   try {
     await requireAdmin();
   } catch {
     return json({ error: "Unauthorized" }, 401);
   }
 
+  // billId の UUID 検証だけ resolveBackfillParams に委譲する（scope は status では未使用）。
+  const billIdParam = new URL(request.url).searchParams.get("billId");
+  const resolved = resolveBackfillParams({ billId: billIdParam });
+  if (!resolved.ok) {
+    return json({ error: resolved.error }, 400);
+  }
+  const { billId } = resolved.params;
+
   try {
     const [pending, total] = await Promise.all([
-      countPendingReextraction(),
-      countAllReports(),
+      countPendingReextraction(billId),
+      countAllReports(billId),
     ]);
     return json({ pending, total, processed: total - pending });
   } catch (error) {

--- a/admin/src/features/interview-opinion-backfill/client/components/opinion-backfill-runner.tsx
+++ b/admin/src/features/interview-opinion-backfill/client/components/opinion-backfill-runner.tsx
@@ -3,6 +3,18 @@
 import { Loader2, Play, RefreshCw } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+type BillOption = { id: string; name: string };
+
+type BackfillScope = "pending" | "all";
 
 type BackfillStatus = {
   pending: number;
@@ -11,16 +23,25 @@ type BackfillStatus = {
 };
 
 const POLL_INTERVAL_MS = 5000;
+// 「全議案」を表す Select のセンチネル値（Radix は空文字の value を許さないため）。
+const ALL_BILLS = "__all__";
 
-export function OpinionBackfillRunner() {
+export function OpinionBackfillRunner({ bills }: { bills: BillOption[] }) {
+  const [billValue, setBillValue] = useState<string>(ALL_BILLS);
+  const [scope, setScope] = useState<BackfillScope>("pending");
   const [status, setStatus] = useState<BackfillStatus | null>(null);
   const [isStarting, setIsStarting] = useState(false);
   const [isRunning, setIsRunning] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
+  const billId = billValue === ALL_BILLS ? undefined : billValue;
+  // 「全部」は議案指定時のみ許可（全議案 × 全部は高コストなので不可）。
+  const allScopeDisabled = !billId;
+
   const fetchStatus = useCallback(async (): Promise<BackfillStatus | null> => {
-    const res = await fetch("/api/interview-opinion-backfill/status");
+    const query = billId ? `?billId=${encodeURIComponent(billId)}` : "";
+    const res = await fetch(`/api/interview-opinion-backfill/status${query}`);
     if (!res.ok) {
       throw new Error(`ステータス取得に失敗しました (${res.status})`);
     }
@@ -29,7 +50,7 @@ export function OpinionBackfillRunner() {
     // 取得成功時は残留エラー表示をクリアする。
     setError(null);
     return data;
-  }, []);
+  }, [billId]);
 
   const stopPolling = useCallback(() => {
     if (pollingRef.current) {
@@ -39,10 +60,24 @@ export function OpinionBackfillRunner() {
     setIsRunning(false);
   }, []);
 
+  // 議案を「全議案」に戻したら、許可されない「全部」を pending に戻す。
+  const handleBillChange = useCallback(
+    (value: string) => {
+      setBillValue(value);
+      if (value === ALL_BILLS && scope === "all") {
+        setScope("pending");
+      }
+    },
+    [scope]
+  );
+
+  // 議案変更時に進捗を取り直す（実行中ポーリング中は触らない）。
   useEffect(() => {
+    if (isRunning) return;
     fetchStatus().catch((e) => setError(e.message));
-    return () => stopPolling();
-  }, [fetchStatus, stopPolling]);
+  }, [fetchStatus, isRunning]);
+
+  useEffect(() => () => stopPolling(), [stopPolling]);
 
   const startPolling = useCallback(() => {
     if (pollingRef.current) return;
@@ -66,6 +101,8 @@ export function OpinionBackfillRunner() {
     try {
       const res = await fetch("/api/interview-opinion-backfill/dispatch", {
         method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ billId, scope }),
       });
       if (!res.ok) {
         throw new Error(`実行開始に失敗しました (${res.status})`);
@@ -77,10 +114,57 @@ export function OpinionBackfillRunner() {
     } finally {
       setIsStarting(false);
     }
-  }, [fetchStatus, startPolling]);
+  }, [billId, scope, fetchStatus, startPolling]);
 
   return (
     <div className="flex flex-col gap-4">
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="flex flex-col gap-2">
+          <Label htmlFor="backfill-bill">対象議案</Label>
+          <Select
+            value={billValue}
+            onValueChange={handleBillChange}
+            disabled={isRunning}
+          >
+            <SelectTrigger id="backfill-bill">
+              <SelectValue placeholder="議案を選択" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={ALL_BILLS}>全議案</SelectItem>
+              {bills.map((bill) => (
+                <SelectItem key={bill.id} value={bill.id}>
+                  {bill.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <Label htmlFor="backfill-scope">対象範囲</Label>
+          <Select
+            value={scope}
+            onValueChange={(v) => setScope(v as BackfillScope)}
+            disabled={isRunning}
+          >
+            <SelectTrigger id="backfill-scope">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="pending">未再抽出のみ</SelectItem>
+              <SelectItem value="all" disabled={allScopeDisabled}>
+                全部（再抽出済みも含む）
+              </SelectItem>
+            </SelectContent>
+          </Select>
+          {allScopeDisabled && (
+            <p className="text-xs text-muted-foreground">
+              ※「全部」は議案を指定したときのみ選択できます。
+            </p>
+          )}
+        </div>
+      </div>
+
       <div className="flex items-center gap-3">
         <Button onClick={handleRun} disabled={isStarting || isRunning}>
           {isStarting || isRunning ? (
@@ -103,7 +187,7 @@ export function OpinionBackfillRunner() {
       {status && (
         <dl className="grid grid-cols-3 gap-4 text-sm">
           <div>
-            <dt className="text-muted-foreground">全レポート</dt>
+            <dt className="text-muted-foreground">対象レポート</dt>
             <dd className="font-semibold tabular-nums">{status.total}</dd>
           </div>
           <div>

--- a/packages/topic-analysis-core/package.json
+++ b/packages/topic-analysis-core/package.json
@@ -17,6 +17,10 @@
       "types": "./src/backfill.ts",
       "default": "./src/backfill.ts"
     },
+    "./backfill-params": {
+      "types": "./src/shared/backfill-params.ts",
+      "default": "./src/shared/backfill-params.ts"
+    },
     "./repository": {
       "types": "./src/repositories/repository.ts",
       "default": "./src/repositories/repository.ts"

--- a/packages/topic-analysis-core/src/backfill.ts
+++ b/packages/topic-analysis-core/src/backfill.ts
@@ -1,11 +1,14 @@
 import {
   countPendingReextraction,
+  findAllReportsForBill,
   findReportsToReextract,
 } from "./repositories/backfill-repository";
 import {
   type GenerateReportFn,
   reextractReportOpinions,
 } from "./services/reextract-report-opinions";
+import type { BackfillScope } from "./shared/backfill-params";
+import type { BackfillTargetReport } from "./shared/types";
 import {
   OPINION_BACKFILL_CHUNK_SIZE,
   OPINION_BACKFILL_CONCURRENCY,
@@ -19,16 +22,24 @@ export type BackfillChunkResult = {
   remaining: number;
 };
 
-/**
- * 未再抽出レポートを1チャンク分（最大 CHUNK_SIZE 件）処理する。
- * チャンク内は CONCURRENCY 件ずつ並列実行する。
- * 成功・スキップはウォーターマークを進めるが、失敗（生成エラー等）は進めない。
- */
-export async function runOpinionBackfillChunk(
-  deps: { generateReport?: GenerateReportFn } = {}
-): Promise<BackfillChunkResult> {
-  const targets = await findReportsToReextract(OPINION_BACKFILL_CHUNK_SIZE);
+export type BackfillOptions = {
+  /** 指定議案に限定して実行する。未指定なら全議案。 */
+  billId?: string;
+  /**
+   * "pending"（既定）: 未再抽出のレポートのみ。
+   * "all": 既に再抽出済みも含めて全件やり直す（billId 必須）。
+   */
+  scope?: BackfillScope;
+  generateReport?: GenerateReportFn;
+};
 
+type ReextractTally = { updated: number; skipped: number; failed: number };
+
+/** 対象レポート群を CONCURRENCY 件ずつ並列で再抽出し、結果を集計する。 */
+async function processReportsInWaves(
+  targets: BackfillTargetReport[],
+  deps: { generateReport?: GenerateReportFn }
+): Promise<ReextractTally> {
   const results = [];
   for (let i = 0; i < targets.length; i += OPINION_BACKFILL_CONCURRENCY) {
     const wave = targets.slice(i, i + OPINION_BACKFILL_CONCURRENCY);
@@ -37,25 +48,42 @@ export async function runOpinionBackfillChunk(
     );
     results.push(...waveResults);
   }
-
-  const updated = results.filter((r) => r.status === "updated").length;
-  const skipped = results.filter((r) => r.status === "skipped").length;
-  const failed = results.filter((r) => r.status === "failed").length;
-  const remaining = await countPendingReextraction();
-
-  return { processed: results.length, updated, skipped, failed, remaining };
+  return {
+    updated: results.filter((r) => r.status === "updated").length,
+    skipped: results.filter((r) => r.status === "skipped").length,
+    failed: results.filter((r) => r.status === "failed").length,
+  };
 }
 
 /**
- * 意見再抽出バックフィルを全件完了まで実行する（Cloud Run Job のメイン処理）。
- * チャンクを繰り返し、remaining が 0 になるか前進が止まったら終了する。
+ * 未再抽出レポートを1チャンク分（最大 CHUNK_SIZE 件）処理する。
+ * チャンク内は CONCURRENCY 件ずつ並列実行する。
+ * 成功・スキップはウォーターマークを進めるが、失敗（生成エラー等）は進めない。
+ */
+export async function runOpinionBackfillChunk(
+  deps: { billId?: string; generateReport?: GenerateReportFn } = {}
+): Promise<BackfillChunkResult> {
+  const { billId, generateReport } = deps;
+  const targets = await findReportsToReextract(
+    OPINION_BACKFILL_CHUNK_SIZE,
+    billId
+  );
+  const tally = await processReportsInWaves(targets, { generateReport });
+  const remaining = await countPendingReextraction(billId);
+
+  return { processed: targets.length, ...tally, remaining };
+}
+
+/**
+ * 未再抽出レポート（opinions_reextracted_at IS NULL）をウォーターマーク方式で
+ * 全件完了まで処理する。チャンクを繰り返し、remaining が 0 になるか前進が止まったら終了する。
  * 失敗レポートはウォーターマークが進まないため、チャンク間で remaining が
  * 減らなくなった時点で「全件失敗ループ」と判断して停止する（無限ループ防止）。
  */
-export async function runBackfill(
-  deps: { generateReport?: GenerateReportFn } = {}
-): Promise<void> {
-  console.log("[topic-analysis] start opinion backfill");
+async function runPendingBackfill(deps: {
+  billId?: string;
+  generateReport?: GenerateReportFn;
+}): Promise<void> {
   let prevRemaining = Number.POSITIVE_INFINITY;
 
   while (true) {
@@ -81,4 +109,49 @@ export async function runBackfill(
     }
     prevRemaining = result.remaining;
   }
+}
+
+/**
+ * 指定議案の全レポートを再抽出済み有無にかかわらず1回ずつ再抽出する（scope="all"）。
+ * ウォーターマークではなく固定の対象リストで終端するため、既処理レポートも対象になる。
+ */
+async function runFullBackfillForBill(
+  billId: string,
+  deps: { generateReport?: GenerateReportFn }
+): Promise<void> {
+  const targets = await findAllReportsForBill(billId);
+  console.log(
+    `[topic-analysis] full backfill for bill=${billId}: targets=${targets.length}`
+  );
+
+  for (let i = 0; i < targets.length; i += OPINION_BACKFILL_CHUNK_SIZE) {
+    const chunk = targets.slice(i, i + OPINION_BACKFILL_CHUNK_SIZE);
+    const tally = await processReportsInWaves(chunk, deps);
+    console.log(
+      `[topic-analysis] full backfill chunk: processed=${chunk.length} updated=${tally.updated} skipped=${tally.skipped} failed=${tally.failed} done=${Math.min(i + chunk.length, targets.length)}/${targets.length}`
+    );
+  }
+  console.log("[topic-analysis] full backfill completed");
+}
+
+/**
+ * 意見再抽出バックフィルを実行する（Cloud Run Job のメイン処理）。
+ * - scope="pending"（既定）: 未再抽出レポートをウォーターマーク方式で全件処理。
+ * - scope="all": 指定議案の全レポートを既処理含めてやり直す（billId 必須）。
+ */
+export async function runBackfill(options: BackfillOptions = {}): Promise<void> {
+  const { billId, scope = "pending", generateReport } = options;
+  console.log(
+    `[topic-analysis] start opinion backfill (scope=${scope} bill=${billId ?? "all"})`
+  );
+
+  if (scope === "all") {
+    if (!billId) {
+      throw new Error('backfill scope="all" requires a billId');
+    }
+    await runFullBackfillForBill(billId, { generateReport });
+    return;
+  }
+
+  await runPendingBackfill({ billId, generateReport });
 }

--- a/packages/topic-analysis-core/src/backfill.ts
+++ b/packages/topic-analysis-core/src/backfill.ts
@@ -1,7 +1,7 @@
 import {
   countPendingReextraction,
-  findAllReportsForBill,
   findReportsToReextract,
+  resetReextractionForBill,
 } from "./repositories/backfill-repository";
 import {
   type GenerateReportFn,
@@ -112,32 +112,10 @@ async function runPendingBackfill(deps: {
 }
 
 /**
- * 指定議案の全レポートを再抽出済み有無にかかわらず1回ずつ再抽出する（scope="all"）。
- * ウォーターマークではなく固定の対象リストで終端するため、既処理レポートも対象になる。
- */
-async function runFullBackfillForBill(
-  billId: string,
-  deps: { generateReport?: GenerateReportFn }
-): Promise<void> {
-  const targets = await findAllReportsForBill(billId);
-  console.log(
-    `[topic-analysis] full backfill for bill=${billId}: targets=${targets.length}`
-  );
-
-  for (let i = 0; i < targets.length; i += OPINION_BACKFILL_CHUNK_SIZE) {
-    const chunk = targets.slice(i, i + OPINION_BACKFILL_CHUNK_SIZE);
-    const tally = await processReportsInWaves(chunk, deps);
-    console.log(
-      `[topic-analysis] full backfill chunk: processed=${chunk.length} updated=${tally.updated} skipped=${tally.skipped} failed=${tally.failed} done=${Math.min(i + chunk.length, targets.length)}/${targets.length}`
-    );
-  }
-  console.log("[topic-analysis] full backfill completed");
-}
-
-/**
  * 意見再抽出バックフィルを実行する（Cloud Run Job のメイン処理）。
  * - scope="pending"（既定）: 未再抽出レポートをウォーターマーク方式で全件処理。
- * - scope="all": 指定議案の全レポートを既処理含めてやり直す（billId 必須）。
+ * - scope="all": 指定議案のウォーターマークを一旦リセットしてから全件処理し直す（billId 必須）。
+ *   リセットにより全件が未再抽出扱いになるため、進捗（pending）が正しく分母になる。
  */
 export async function runBackfill(options: BackfillOptions = {}): Promise<void> {
   const { billId, scope = "pending", generateReport } = options;
@@ -149,8 +127,10 @@ export async function runBackfill(options: BackfillOptions = {}): Promise<void> 
     if (!billId) {
       throw new Error('backfill scope="all" requires a billId');
     }
-    await runFullBackfillForBill(billId, { generateReport });
-    return;
+    const reset = await resetReextractionForBill(billId);
+    console.log(
+      `[topic-analysis] reset ${reset} reextraction watermark(s) for bill=${billId}`
+    );
   }
 
   await runPendingBackfill({ billId, generateReport });

--- a/packages/topic-analysis-core/src/repositories/backfill-repository.ts
+++ b/packages/topic-analysis-core/src/repositories/backfill-repository.ts
@@ -81,8 +81,9 @@ export async function findReportsToReextract(
 }
 
 /**
- * 指定議案の全レポートを、再抽出済み有無にかかわらず公開同意優先・古い順で取得する。
- * scope="all"（既処理含む全件やり直し）用。1000 件超でも取りこぼさないようページングする。
+ * 指定議案の全レポート ID を、再抽出済み有無にかかわらず取得する。
+ * scope="all" のウォーターマークリセット対象を集めるのに使う。
+ * 1000 件超でも取りこぼさないようページングする。
  */
 export async function findAllReportsForBill(
   billId: string
@@ -96,8 +97,6 @@ export async function findAllReportsForBill(
       .from("interview_report")
       .select(REPORT_SELECT_WITH_BILL)
       .eq(BILL_FILTER, billId)
-      .order("is_public_by_user", { ascending: false })
-      .order("created_at", { ascending: true })
       .order("id", { ascending: true })
       .range(from, from + pageSize - 1);
 
@@ -110,6 +109,37 @@ export async function findAllReportsForBill(
   }
 
   return all;
+}
+
+/**
+ * 指定議案の全レポートの再抽出ウォーターマーク（opinions_reextracted_at）を NULL に戻す。
+ * scope="all"（既処理含む全件やり直し）の起点。これにより以後は未再抽出として扱われ、
+ * pending 件数を進捗の分母にできる（再実行の早期完了表示を防ぐ）。リセット件数を返す。
+ */
+export async function resetReextractionForBill(
+  billId: string
+): Promise<number> {
+  const targets = await findAllReportsForBill(billId);
+  const supabase = createAdminClient();
+  // .in() の URL 長対策でチャンク更新する。
+  const chunkSize = 200;
+  let reset = 0;
+
+  for (let i = 0; i < targets.length; i += chunkSize) {
+    const ids = targets.slice(i, i + chunkSize).map((t) => t.reportId);
+    const { error } = await supabase
+      .from("interview_report")
+      .update({ opinions_reextracted_at: null })
+      .in("id", ids);
+    if (error) {
+      throw new Error(
+        `Failed to reset reextraction watermark: ${error.message}`
+      );
+    }
+    reset += ids.length;
+  }
+
+  return reset;
 }
 
 /**

--- a/packages/topic-analysis-core/src/repositories/backfill-repository.ts
+++ b/packages/topic-analysis-core/src/repositories/backfill-repository.ts
@@ -1,29 +1,38 @@
 import { createAdminClient } from "@mirai-gikai/supabase";
 import type { BackfillTargetReport } from "../shared/types";
 
-/**
- * 未再抽出（opinions_reextracted_at IS NULL）のレポート件数を返す。
- * 進捗表示・チャンク連鎖の継続判定に使う。
- */
-export async function countPendingReextraction(): Promise<number> {
-  const supabase = createAdminClient();
-  const { count, error } = await supabase
-    .from("interview_report")
-    .select("id", { count: "exact", head: true })
-    .is("opinions_reextracted_at", null);
+// billId 指定時のみ議案で絞り込むための埋め込みリレーション付き select。
+// interview_report → interview_sessions → interview_configs は全て NOT NULL の
+// 1:1 関係なので、!inner を付けても件数には影響しない。billId 未指定（既定の
+// ポーリング経路）では join を避けるため最小限の "id" / "id, interview_session_id"
+// を使う。
+const REPORT_SELECT_WITH_BILL =
+  "id, interview_session_id, interview_sessions!inner(interview_configs!inner(bill_id))";
+const BILL_FILTER = "interview_sessions.interview_configs.bill_id";
 
-  if (error) {
-    throw new Error(`Failed to count pending reextraction: ${error.message}`);
+const toTargets = (
+  rows: { id: string; interview_session_id: string }[]
+): BackfillTargetReport[] =>
+  rows.map((r) => ({ reportId: r.id, sessionId: r.interview_session_id }));
+
+/** レポート件数を返す（pendingOnly=未再抽出のみ）。billId 指定時は当該議案に限定する。 */
+async function countReports(
+  billId: string | undefined,
+  pendingOnly: boolean
+): Promise<number> {
+  const supabase = createAdminClient();
+  let query = billId
+    ? supabase
+        .from("interview_report")
+        .select(REPORT_SELECT_WITH_BILL, { count: "exact", head: true })
+        .eq(BILL_FILTER, billId)
+    : supabase
+        .from("interview_report")
+        .select("id", { count: "exact", head: true });
+  if (pendingOnly) {
+    query = query.is("opinions_reextracted_at", null);
   }
-  return count ?? 0;
-}
-
-/** interview_report の総件数（進捗の分母表示用）。 */
-export async function countAllReports(): Promise<number> {
-  const supabase = createAdminClient();
-  const { count, error } = await supabase
-    .from("interview_report")
-    .select("id", { count: "exact", head: true });
+  const { count, error } = await query;
 
   if (error) {
     throw new Error(`Failed to count reports: ${error.message}`);
@@ -32,15 +41,34 @@ export async function countAllReports(): Promise<number> {
 }
 
 /**
+ * 未再抽出（opinions_reextracted_at IS NULL）のレポート件数を返す。
+ * 進捗表示・チャンク連鎖の継続判定に使う。billId 指定時は当該議案に限定する。
+ */
+export function countPendingReextraction(billId?: string): Promise<number> {
+  return countReports(billId, true);
+}
+
+/** interview_report の総件数（進捗の分母表示用）。billId 指定時は当該議案に限定する。 */
+export function countAllReports(billId?: string): Promise<number> {
+  return countReports(billId, false);
+}
+
+/**
  * 未再抽出レポートを公開同意優先・古い順で limit 件取得する。
+ * billId 指定時は当該議案に限定する。
  */
 export async function findReportsToReextract(
-  limit: number
+  limit: number,
+  billId?: string
 ): Promise<BackfillTargetReport[]> {
   const supabase = createAdminClient();
-  const { data, error } = await supabase
-    .from("interview_report")
-    .select("id, interview_session_id")
+  const base = billId
+    ? supabase
+        .from("interview_report")
+        .select(REPORT_SELECT_WITH_BILL)
+        .eq(BILL_FILTER, billId)
+    : supabase.from("interview_report").select("id, interview_session_id");
+  const { data, error } = await base
     .is("opinions_reextracted_at", null)
     .order("is_public_by_user", { ascending: false })
     .order("created_at", { ascending: true })
@@ -49,10 +77,39 @@ export async function findReportsToReextract(
   if (error) {
     throw new Error(`Failed to fetch reports to reextract: ${error.message}`);
   }
-  return (data ?? []).map((r) => ({
-    reportId: r.id,
-    sessionId: r.interview_session_id,
-  }));
+  return toTargets(data ?? []);
+}
+
+/**
+ * 指定議案の全レポートを、再抽出済み有無にかかわらず公開同意優先・古い順で取得する。
+ * scope="all"（既処理含む全件やり直し）用。1000 件超でも取りこぼさないようページングする。
+ */
+export async function findAllReportsForBill(
+  billId: string
+): Promise<BackfillTargetReport[]> {
+  const supabase = createAdminClient();
+  const pageSize = 1000;
+  const all: BackfillTargetReport[] = [];
+
+  for (let from = 0; ; from += pageSize) {
+    const { data, error } = await supabase
+      .from("interview_report")
+      .select(REPORT_SELECT_WITH_BILL)
+      .eq(BILL_FILTER, billId)
+      .order("is_public_by_user", { ascending: false })
+      .order("created_at", { ascending: true })
+      .order("id", { ascending: true })
+      .range(from, from + pageSize - 1);
+
+    if (error) {
+      throw new Error(`Failed to fetch reports for bill: ${error.message}`);
+    }
+    const rows = data ?? [];
+    all.push(...toTargets(rows));
+    if (rows.length < pageSize) break;
+  }
+
+  return all;
 }
 
 /**

--- a/packages/topic-analysis-core/src/repositories/backfill-repository.ts
+++ b/packages/topic-analysis-core/src/repositories/backfill-repository.ts
@@ -81,62 +81,48 @@ export async function findReportsToReextract(
 }
 
 /**
- * 指定議案の全レポート ID を、再抽出済み有無にかかわらず取得する。
- * scope="all" のウォーターマークリセット対象を集めるのに使う。
- * 1000 件超でも取りこぼさないようページングする。
- */
-export async function findAllReportsForBill(
-  billId: string
-): Promise<BackfillTargetReport[]> {
-  const supabase = createAdminClient();
-  const pageSize = 1000;
-  const all: BackfillTargetReport[] = [];
-
-  for (let from = 0; ; from += pageSize) {
-    const { data, error } = await supabase
-      .from("interview_report")
-      .select(REPORT_SELECT_WITH_BILL)
-      .eq(BILL_FILTER, billId)
-      .order("id", { ascending: true })
-      .range(from, from + pageSize - 1);
-
-    if (error) {
-      throw new Error(`Failed to fetch reports for bill: ${error.message}`);
-    }
-    const rows = data ?? [];
-    all.push(...toTargets(rows));
-    if (rows.length < pageSize) break;
-  }
-
-  return all;
-}
-
-/**
  * 指定議案の全レポートの再抽出ウォーターマーク（opinions_reextracted_at）を NULL に戻す。
  * scope="all"（既処理含む全件やり直し）の起点。これにより以後は未再抽出として扱われ、
  * pending 件数を進捗の分母にできる（再実行の早期完了表示を防ぐ）。リセット件数を返す。
+ *
+ * 1ページ取得→更新を繰り返す。更新で NOT NULL から外れた行は次ページに残らないため、
+ * 全件を一度にメモリへ載せずに（大規模議案でもページサイズ分のみ）処理できる。
  */
 export async function resetReextractionForBill(
   billId: string
 ): Promise<number> {
-  const targets = await findAllReportsForBill(billId);
   const supabase = createAdminClient();
-  // .in() の URL 長対策でチャンク更新する。
-  const chunkSize = 200;
+  const pageSize = 1000;
   let reset = 0;
 
-  for (let i = 0; i < targets.length; i += chunkSize) {
-    const ids = targets.slice(i, i + chunkSize).map((t) => t.reportId);
-    const { error } = await supabase
+  while (true) {
+    // 未リセット（NOT NULL）の行を1ページ分だけ取得する。
+    const { data, error } = await supabase
+      .from("interview_report")
+      .select(REPORT_SELECT_WITH_BILL)
+      .eq(BILL_FILTER, billId)
+      .not("opinions_reextracted_at", "is", null)
+      .order("id", { ascending: true })
+      .limit(pageSize);
+    if (error) {
+      throw new Error(`Failed to fetch reports to reset: ${error.message}`);
+    }
+
+    const ids = (data ?? []).map((r) => r.id);
+    if (ids.length === 0) break;
+
+    const { error: updateError } = await supabase
       .from("interview_report")
       .update({ opinions_reextracted_at: null })
       .in("id", ids);
-    if (error) {
+    if (updateError) {
       throw new Error(
-        `Failed to reset reextraction watermark: ${error.message}`
+        `Failed to reset reextraction watermark: ${updateError.message}`
       );
     }
     reset += ids.length;
+
+    if (ids.length < pageSize) break;
   }
 
   return reset;

--- a/packages/topic-analysis-core/src/shared/backfill-params.test.ts
+++ b/packages/topic-analysis-core/src/shared/backfill-params.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { resolveBackfillParams } from "./backfill-params";
+
+const UUID = "11111111-1111-4111-8111-111111111111";
+
+describe("resolveBackfillParams", () => {
+  it("デフォルトは scope=pending・billId なし", () => {
+    expect(resolveBackfillParams({})).toEqual({
+      ok: true,
+      params: { billId: undefined, scope: "pending" },
+    });
+  });
+
+  it("billId 指定の pending を受け付ける", () => {
+    expect(resolveBackfillParams({ billId: UUID })).toEqual({
+      ok: true,
+      params: { billId: UUID, scope: "pending" },
+    });
+  });
+
+  it("scope=all は billId があれば受け付ける", () => {
+    expect(resolveBackfillParams({ billId: UUID, scope: "all" })).toEqual({
+      ok: true,
+      params: { billId: UUID, scope: "all" },
+    });
+  });
+
+  it("scope=all で billId が無ければエラー（全議案×全部は不可）", () => {
+    const result = resolveBackfillParams({ scope: "all" });
+    expect(result.ok).toBe(false);
+  });
+
+  it("未知の scope 文字列は pending に丸める", () => {
+    expect(resolveBackfillParams({ scope: "everything" })).toEqual({
+      ok: true,
+      params: { billId: undefined, scope: "pending" },
+    });
+  });
+
+  it("UUID 形式でない billId はエラー", () => {
+    const result = resolveBackfillParams({ billId: "not-a-uuid" });
+    expect(result.ok).toBe(false);
+  });
+
+  it("空文字・空白の billId は未指定として扱う", () => {
+    expect(resolveBackfillParams({ billId: "   " })).toEqual({
+      ok: true,
+      params: { billId: undefined, scope: "pending" },
+    });
+  });
+});

--- a/packages/topic-analysis-core/src/shared/backfill-params.ts
+++ b/packages/topic-analysis-core/src/shared/backfill-params.ts
@@ -1,0 +1,46 @@
+import { z } from "zod";
+
+/**
+ * 意見再抽出バックフィルの実行パラメータ（議案スコープ / 対象範囲）。
+ * worker（CLI 引数）と admin（API リクエスト）の両方から使う純粋な検証ロジック。
+ *
+ * - scope "pending": 未再抽出（opinions_reextracted_at IS NULL）のレポートだけを対象にする。
+ * - scope "all": 既に再抽出済みのレポートも含めて全件やり直す。コストが大きいため
+ *   議案指定（billId）必須とし、全議案 × all は許可しない。
+ */
+export type BackfillScope = "pending" | "all";
+
+export type BackfillParams = {
+  billId?: string;
+  scope: BackfillScope;
+};
+
+export type BackfillParamsResult =
+  | { ok: true; params: BackfillParams }
+  | { ok: false; error: string };
+
+const uuidSchema = z.string().uuid();
+
+/**
+ * 生の入力（billId / scope 文字列）を検証して BackfillParams に正規化する。
+ * scope は "all" 以外（未指定含む）を "pending" に丸める。
+ */
+export function resolveBackfillParams(input: {
+  billId?: string | null;
+  scope?: string | null;
+}): BackfillParamsResult {
+  const scope: BackfillScope = input.scope === "all" ? "all" : "pending";
+  const billId = input.billId?.trim() || undefined;
+
+  if (billId && !uuidSchema.safeParse(billId).success) {
+    return { ok: false, error: "billId は UUID 形式である必要があります" };
+  }
+  if (scope === "all" && !billId) {
+    return {
+      ok: false,
+      error: "対象「全部」は議案を指定したときのみ実行できます",
+    };
+  }
+
+  return { ok: true, params: { billId, scope } };
+}

--- a/tests/supabase/interview-opinion-backfill-repository.test.ts
+++ b/tests/supabase/interview-opinion-backfill-repository.test.ts
@@ -1,7 +1,6 @@
 import {
   countAllReports,
   countPendingReextraction,
-  findAllReportsForBill,
   findReportsToReextract,
   markReextractionAttempted,
   resetReextractionForBill,
@@ -289,22 +288,14 @@ describe("interview-opinion-backfill repository 議案スコープ統合テス�
     expect(await countAllReports(billB)).toBe(1);
   });
 
-  it("findAllReportsForBill(billA) は再抽出済みも含め bill A の全件を返す（他議案は除外）", async () => {
-    const ids = (await findAllReportsForBill(billA)).map((r) => r.reportId);
-    // リセット対象の収集用途なので順序は問わず、集合として一致すればよい。
-    expect(new Set(ids)).toEqual(
-      new Set([aDone, aPublicOld, aPublicNew, aPrivate])
-    );
-    expect(ids).not.toContain(bReport);
-  });
-
   // watermark を変更するため、件数を検証する他テストの後（describe 末尾）に置く。
-  it("resetReextractionForBill は bill A 全件のウォーターマークを NULL に戻す", async () => {
+  it("resetReextractionForBill は bill A の再抽出済みを未再抽出に戻す", async () => {
     // 事前: aDone のみ再抽出済み（pending=3 / total=4）
     expect(await countPendingReextraction(billA)).toBe(3);
 
+    // 再抽出済み(NOT NULL)の行だけ NULL に戻すため、戻り値は aDone の1件。
     const reset = await resetReextractionForBill(billA);
-    expect(reset).toBe(4);
+    expect(reset).toBe(1);
 
     // リセット後は全件が未再抽出 = pending が total と一致する
     expect(await countPendingReextraction(billA)).toBe(4);

--- a/tests/supabase/interview-opinion-backfill-repository.test.ts
+++ b/tests/supabase/interview-opinion-backfill-repository.test.ts
@@ -1,17 +1,19 @@
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
+  countAllReports,
   countPendingReextraction,
+  findAllReportsForBill,
   findReportsToReextract,
   markReextractionAttempted,
   updateReportOpinions,
 } from "@mirai-gikai/topic-analysis-core/repository";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
   adminClient,
   cleanupTestBill,
   cleanupTestUser,
   createTestBill,
-  type TestUser,
   createTestUser,
+  type TestUser,
 } from "./utils";
 
 /** 共有 config 配下に session + report を1件作る。 */
@@ -184,5 +186,112 @@ describe("interview-opinion-backfill repository 統合テスト", () => {
     expect(new Date(row?.opinions_reextracted_at ?? 0).getTime()).toBe(
       new Date("2026-06-08T01:00:00Z").getTime()
     );
+  });
+});
+
+describe("interview-opinion-backfill repository 議案スコープ統合テスト", () => {
+  let testUser: TestUser;
+  let billA: string;
+  let billB: string;
+  // bill A のレポート（公開新旧 / 非公開 / 再抽出済み）
+  let aPublicOld: string;
+  let aPublicNew: string;
+  let aPrivate: string;
+  let aDone: string;
+  // bill B のレポート（混入しないことの検証用）
+  let bReport: string;
+
+  async function createConfig(forBillId: string): Promise<string> {
+    const { data, error } = await adminClient
+      .from("interview_configs")
+      .insert({ bill_id: forBillId, status: "public", name: "scope-test" })
+      .select()
+      .single();
+    if (error || !data) throw new Error(`config 作成失敗: ${error?.message}`);
+    return data.id;
+  }
+
+  beforeAll(async () => {
+    testUser = await createTestUser();
+    const ba = await createTestBill();
+    const bb = await createTestBill();
+    billA = ba.id;
+    billB = bb.id;
+    const configA = await createConfig(billA);
+    const configB = await createConfig(billB);
+
+    const base = { userId: testUser.id };
+    aPublicOld = (
+      await createReport({
+        ...base,
+        configId: configA,
+        isPublicByUser: true,
+        createdAt: "2021-01-01T00:00:00Z",
+      })
+    ).id;
+    aPublicNew = (
+      await createReport({
+        ...base,
+        configId: configA,
+        isPublicByUser: true,
+        createdAt: "2022-01-01T00:00:00Z",
+      })
+    ).id;
+    aPrivate = (
+      await createReport({
+        ...base,
+        configId: configA,
+        isPublicByUser: false,
+        createdAt: "2020-01-01T00:00:00Z",
+      })
+    ).id;
+    aDone = (
+      await createReport({
+        ...base,
+        configId: configA,
+        isPublicByUser: true,
+        createdAt: "2019-01-01T00:00:00Z",
+        reextracted: true,
+      })
+    ).id;
+    bReport = (
+      await createReport({
+        ...base,
+        configId: configB,
+        isPublicByUser: true,
+        createdAt: "2021-06-01T00:00:00Z",
+      })
+    ).id;
+  });
+
+  afterAll(async () => {
+    await cleanupTestBill(billA);
+    await cleanupTestBill(billB);
+    await cleanupTestUser(testUser.id);
+  });
+
+  it("findReportsToReextract(billA) は bill A の未処理のみを公開優先・古い順で返す", async () => {
+    const ids = (await findReportsToReextract(10000, billA)).map(
+      (r) => r.reportId
+    );
+    // 公開(true)→created_at昇順、その後 非公開。再抽出済み(aDone)と他議案(bReport)は除外。
+    expect(ids).toEqual([aPublicOld, aPublicNew, aPrivate]);
+    expect(ids).not.toContain(aDone);
+    expect(ids).not.toContain(bReport);
+  });
+
+  it("countPendingReextraction / countAllReports は議案単位に限定される", async () => {
+    expect(await countPendingReextraction(billA)).toBe(3);
+    expect(await countAllReports(billA)).toBe(4);
+    // 他議案は別カウント（!inner join が件数を変えないことの回帰）
+    expect(await countPendingReextraction(billB)).toBe(1);
+    expect(await countAllReports(billB)).toBe(1);
+  });
+
+  it("findAllReportsForBill(billA) は再抽出済みも含め公開優先・古い順で全件返す", async () => {
+    const ids = (await findAllReportsForBill(billA)).map((r) => r.reportId);
+    // 公開グループ(created_at昇順): aDone(2019)→aPublicOld(2021)→aPublicNew(2022)、最後に非公開 aPrivate。
+    expect(ids).toEqual([aDone, aPublicOld, aPublicNew, aPrivate]);
+    expect(ids).not.toContain(bReport);
   });
 });

--- a/tests/supabase/interview-opinion-backfill-repository.test.ts
+++ b/tests/supabase/interview-opinion-backfill-repository.test.ts
@@ -4,6 +4,7 @@ import {
   findAllReportsForBill,
   findReportsToReextract,
   markReextractionAttempted,
+  resetReextractionForBill,
   updateReportOpinions,
 } from "@mirai-gikai/topic-analysis-core/repository";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -288,10 +289,27 @@ describe("interview-opinion-backfill repository 議案スコープ統合テス�
     expect(await countAllReports(billB)).toBe(1);
   });
 
-  it("findAllReportsForBill(billA) は再抽出済みも含め公開優先・古い順で全件返す", async () => {
+  it("findAllReportsForBill(billA) は再抽出済みも含め bill A の全件を返す（他議案は除外）", async () => {
     const ids = (await findAllReportsForBill(billA)).map((r) => r.reportId);
-    // 公開グループ(created_at昇順): aDone(2019)→aPublicOld(2021)→aPublicNew(2022)、最後に非公開 aPrivate。
-    expect(ids).toEqual([aDone, aPublicOld, aPublicNew, aPrivate]);
+    // リセット対象の収集用途なので順序は問わず、集合として一致すればよい。
+    expect(new Set(ids)).toEqual(
+      new Set([aDone, aPublicOld, aPublicNew, aPrivate])
+    );
     expect(ids).not.toContain(bReport);
+  });
+
+  // watermark を変更するため、件数を検証する他テストの後（describe 末尾）に置く。
+  it("resetReextractionForBill は bill A 全件のウォーターマークを NULL に戻す", async () => {
+    // 事前: aDone のみ再抽出済み（pending=3 / total=4）
+    expect(await countPendingReextraction(billA)).toBe(3);
+
+    const reset = await resetReextractionForBill(billA);
+    expect(reset).toBe(4);
+
+    // リセット後は全件が未再抽出 = pending が total と一致する
+    expect(await countPendingReextraction(billA)).toBe(4);
+    expect(await countAllReports(billA)).toBe(4);
+    // 他議案は影響を受けない
+    expect(await countPendingReextraction(billB)).toBe(1);
   });
 });

--- a/worker/src/main.ts
+++ b/worker/src/main.ts
@@ -1,12 +1,15 @@
 import { runAnalysis } from "@mirai-gikai/topic-analysis-core/analyze";
 import { runBackfill } from "@mirai-gikai/topic-analysis-core/backfill";
+import { resolveBackfillParams } from "@mirai-gikai/topic-analysis-core/backfill-params";
 
 /**
  * Cloud Run Job のエントリポイント。
  *
  * 起動例:
  *   tsx src/main.ts --mode=analyze --bill-id=<uuid> --version-id=<uuid>
- *   tsx src/main.ts --mode=backfill
+ *   tsx src/main.ts --mode=backfill                              # 未再抽出を全議案で処理
+ *   tsx src/main.ts --mode=backfill --bill-id=<uuid>             # 指定議案の未再抽出のみ
+ *   tsx src/main.ts --mode=backfill --bill-id=<uuid> --scope=all # 指定議案を全件やり直し
  *
  * 必須env: SUPABASE_URL, SUPABASE_SECRET_KEY, AI_GATEWAY_API_KEY
  */
@@ -51,7 +54,14 @@ async function main(): Promise<void> {
   }
 
   if (mode === "backfill") {
-    await runBackfill();
+    const resolved = resolveBackfillParams({
+      billId: args["bill-id"],
+      scope: args.scope,
+    });
+    if (!resolved.ok) {
+      throw new Error(`backfill mode: ${resolved.error}`);
+    }
+    await runBackfill(resolved.params);
     return;
   }
 


### PR DESCRIPTION
## 概要
意見再抽出バックフィルに2つの実行オプションを追加する。

1. **議案を指定して実行**できる（未指定なら従来どおり全議案）
2. **対象範囲を選択**できる
   - `未再抽出のみ`（既定）: `opinions_reextracted_at IS NULL` のレポートだけ（従来挙動）
   - `全部`: 既に再抽出済みも含めて全件やり直す

コストが大きいため **「全部」は議案を指定したときのみ許可**（全議案 × 全部は不可）。

## 実装
- **core**
  - `shared/backfill-params.ts`（新規）: `resolveBackfillParams` で `billId`(UUID検証) / `scope` を検証・正規化。worker(CLI) と admin(API) の3経路で共通利用。
  - `backfill.ts`: `runBackfill({ billId, scope })` に拡張。`pending` はウォーターマーク方式の従来ループ、`all` は議案の全レポートを固定リストで取得して1回ずつやり直す（ウォーターマーク非依存で終端）。
  - `repositories/backfill-repository.ts`: 件数/取得に議案フィルタ（埋め込み `interview_sessions!inner(interview_configs!inner(bill_id))`）を追加。`all` 用に `findAllReportsForBill`（1000件ページング・公開同意優先/古い順）を追加。billId 未指定の既定経路は join を避け最小 select。
- **worker**: `--bill-id` / `--scope` を受け付け（`scope=all` は `--bill-id` 必須）。
- **admin**: dispatch/status が `billId`・`scope` を受け取り。バックフィル画面に議案ドロップダウン（全議案/各議案）と対象トグル（未再抽出のみ/全部）を追加。

## テスト
- core unit: `resolveBackfillParams` の検証（既定/UUID不正/`scope=all`のbillId必須/空白トリム 等）
- 統合テスト（実ローカルSupabase）: `tests/supabase/interview-opinion-backfill-repository.test.ts` に議案スコープ3件を追加
  - `findReportsToReextract(billA)` が bill A の未処理のみを公開優先・古い順で返す（他議案・再抽出済みを除外）
  - `countPendingReextraction`/`countAllReports` が議案単位
  - `findAllReportsForBill(billA)` が再抽出済み含め全件をソート順で返す
- 実行記録: `pnpm typecheck` / `pnpm lint` / `pnpm build` / core unit 31件 / 統合 6件 すべてpass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * インタビュー意見バックフィル機能で、特定の議案を選択して実行できるようになりました
  * バックフィルの対象範囲を指定可能に（全レポート/未再抽出のみ）
  * 管理画面でバックフィル対象の細かい制御が可能になりました

* **Tests**
  * バックフィルパラメータの検証テストを追加しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->