### PR TITLE
インタビューのchat→summary自動遷移でAnthropic系モデルの400を回避

### DIFF
--- a/web/src/features/interview-session/server/services/handle-interview-chat-request.integration.test.ts
+++ b/web/src/features/interview-session/server/services/handle-interview-chat-request.integration.test.ts
@@ -1,17 +1,58 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import {
   adminClient,
-  createTestUser,
+  cleanupTestBill,
   cleanupTestUser,
   createTestInterviewData,
-  cleanupTestBill,
+  createTestUser,
   type TestUser,
 } from "@test-utils/utils";
-import { createStreamMock } from "@/test-utils/mock-language-model";
+import { convertArrayToReadableStream, MockLanguageModelV3 } from "ai/test";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { InterviewConfig } from "@/features/interview-config/server/loaders/get-interview-config-admin";
+import { createStreamMock } from "@/test-utils/mock-language-model";
+import type { InterviewSession } from "../../shared/types";
 import { findInterviewMessagesBySessionId } from "../repositories/interview-session-repository";
 import { handleInterviewChatRequest } from "./handle-interview-chat-request";
-import type { InterviewSession } from "../../shared/types";
+
+type CapturedPrompt = Array<{ role: string }>;
+
+/**
+ * モデルが受け取った prompt（変換後のメッセージ列）を記録する streamText 用モック。
+ * 末尾が user メッセージで終わっているか検証するために使う。
+ */
+function createCapturingStreamMock(text: string): {
+  model: MockLanguageModelV3;
+  prompts: CapturedPrompt[];
+} {
+  const prompts: CapturedPrompt[] = [];
+  const model = new MockLanguageModelV3({
+    doStream: async (options) => {
+      prompts.push(options.prompt as CapturedPrompt);
+      return {
+        stream: convertArrayToReadableStream([
+          { type: "stream-start" as const, warnings: [] as [] },
+          { type: "text-start" as const, id: "text-1" },
+          { type: "text-delta" as const, id: "text-1", delta: text },
+          { type: "text-end" as const, id: "text-1" },
+          {
+            type: "finish" as const,
+            usage: {
+              inputTokens: {
+                total: 0,
+                noCache: 0,
+                cacheRead: 0,
+                cacheWrite: 0,
+              },
+              outputTokens: { total: 0, text: 0, reasoning: 0 },
+            },
+            finishReason: { unified: "stop" as const, raw: undefined },
+          },
+        ]),
+      };
+    },
+  });
+  return { model, prompts };
+}
 
 /**
  * Response のボディストリームを全て読み込む。
@@ -220,6 +261,44 @@ describe("handleInterviewChatRequest 統合テスト", () => {
       expect(messages[0].content).toBe("まとめてください");
       expect(messages[1].role).toBe("assistant");
       expect(messages[1].content).toBe(validSummaryResponse);
+    });
+
+    it("chat→summary 自動遷移（末尾が assistant）でもモデルへは user メッセージで終わる列を渡す", async () => {
+      // クライアントの自動サマリーリクエストを再現：新しい user メッセージなしで
+      // 末尾が assistant のメッセージ列を送る。Anthropic 系は user で終わる必要がある。
+      const { model, prompts } =
+        createCapturingStreamMock(validSummaryResponse);
+
+      const response = await handleInterviewChatRequest({
+        messages: [
+          { role: "user", content: "賛成です" },
+          { role: "assistant", content: "最後の質問です。他にありますか？" },
+        ],
+        billId,
+        currentStage: "summary",
+        userId: testUser.id,
+        deps: {
+          summaryModel: model,
+          getBill: async () => null,
+          getInterviewConfig: async () => config,
+          getSession: async () => session,
+          getMessages: async () => [],
+        },
+      });
+
+      expect(response.status).toBe(200);
+      await consumeResponseStream(response);
+      await new Promise((resolve) => setTimeout(resolve, 300));
+
+      // モデルに渡された prompt の末尾が user メッセージであること
+      expect(prompts).toHaveLength(1);
+      expect(prompts[0].at(-1)?.role).toBe("user");
+
+      // 補った user メッセージは DB に保存されない（assistant の出力のみ保存）
+      const messages = await findInterviewMessagesBySessionId(sessionId);
+      expect(messages).toHaveLength(1);
+      expect(messages[0].role).toBe("assistant");
+      expect(messages[0].content).toBe(validSummaryResponse);
     });
 
     it("summaryフェーズではsummaryModelが使用される（chatModelは無視される）", async () => {

--- a/web/src/features/interview-session/server/services/handle-interview-chat-request.ts
+++ b/web/src/features/interview-session/server/services/handle-interview-chat-request.ts
@@ -8,11 +8,13 @@ import {
   streamText,
 } from "ai";
 import { getBillByIdAdmin } from "@/features/bills/server/loaders/get-bill-by-id-admin";
+import type { BillWithContent } from "@/features/bills/shared/types";
 import {
   isWithinDailyCostLimit,
   recordChatUsage,
 } from "@/features/chat/server/services/cost-tracker";
 import { ChatError, ChatErrorCode } from "@/features/chat/shared/types/errors";
+import type { InterviewConfig } from "@/features/interview-config/server/loaders/get-interview-config-admin";
 import { getInterviewConfigAdmin } from "@/features/interview-config/server/loaders/get-interview-config-admin";
 import { getInterviewQuestions } from "@/features/interview-config/server/loaders/get-interview-questions";
 import { createInterviewSession } from "@/features/interview-session/server/actions/create-interview-session";
@@ -22,8 +24,6 @@ import {
   interviewChatTextSchema,
   interviewChatWithReportSchema,
 } from "@/features/interview-session/shared/schemas";
-import type { BillWithContent } from "@/features/bills/shared/types";
-import type { InterviewConfig } from "@/features/interview-config/server/loaders/get-interview-config-admin";
 import type {
   InterviewChatRequestParams,
   InterviewMessage,
@@ -32,6 +32,7 @@ import type {
 import { DEFAULT_INTERVIEW_CHAT_MODEL } from "@/lib/ai/models";
 import { env } from "@/lib/env";
 import { logger } from "@/lib/logger";
+import { ensureTrailingUserMessage } from "../../shared/utils/ensure-trailing-user-message";
 import { mergeMessagesWithIds } from "../../shared/utils/merge-messages-with-ids";
 import {
   buildInterviewSystemPrompt,
@@ -295,7 +296,12 @@ async function generateStreamingResponse({
     }
   };
 
-  const uiMessages = messages.map((message) => ({
+  // Anthropic 系などは会話が user メッセージで終わる必要がある。
+  // chat→summary の自動遷移ではメッセージ末尾が assistant になるため、
+  // 続行を促す user メッセージを補う（DB には保存しない）。
+  const modelMessages = ensureTrailingUserMessage(messages, isSummaryPhase);
+
+  const uiMessages = modelMessages.map((message) => ({
     role: message.role as "user" | "assistant",
     parts: [{ type: "text" as const, text: message.content }],
   }));

--- a/web/src/features/interview-session/shared/utils/ensure-trailing-user-message.test.ts
+++ b/web/src/features/interview-session/shared/utils/ensure-trailing-user-message.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { ensureTrailingUserMessage } from "./ensure-trailing-user-message";
+
+describe("ensureTrailingUserMessage", () => {
+  it("末尾が user のときはそのまま返す", () => {
+    const messages = [
+      { role: "assistant", content: "質問です" },
+      { role: "user", content: "回答です" },
+    ];
+    expect(ensureTrailingUserMessage(messages, false)).toEqual(messages);
+  });
+
+  it("末尾が assistant かつ summary フェーズならレポート生成依頼の user を補う", () => {
+    const messages = [
+      { role: "user", content: "回答です" },
+      { role: "assistant", content: "最後の質問です" },
+    ];
+    const result = ensureTrailingUserMessage(messages, true);
+    expect(result).toHaveLength(3);
+    expect(result.at(-1)?.role).toBe("user");
+    expect(result.at(-1)?.content).toContain("レポート");
+    // 元の配列は破壊しない
+    expect(messages).toHaveLength(2);
+  });
+
+  it("末尾が assistant かつ非 summary なら続行を促す user を補う", () => {
+    const messages = [{ role: "assistant", content: "こんにちは" }];
+    const result = ensureTrailingUserMessage(messages, false);
+    expect(result).toHaveLength(2);
+    expect(result.at(-1)).toEqual({
+      role: "user",
+      content: "続けてください。",
+    });
+  });
+
+  it("空配列はそのまま返す", () => {
+    expect(ensureTrailingUserMessage([], true)).toEqual([]);
+  });
+});

--- a/web/src/features/interview-session/shared/utils/ensure-trailing-user-message.ts
+++ b/web/src/features/interview-session/shared/utils/ensure-trailing-user-message.ts
@@ -1,0 +1,32 @@
+type ChatMessage = { role: string; content: string };
+
+// chat→summary の自動遷移では、新しい user メッセージなしでレポート生成を依頼するため
+// メッセージ末尾が assistant になる。GPT 系は許容するが Anthropic 系などは
+// 「会話は user メッセージで終わる必要がある」として 400 を返すため、続行を促す
+// user メッセージを補ってモデル呼び出しを provider 非依存にする。
+const SUMMARY_TRIGGER_MESSAGE =
+  "ここまでの会話内容をもとに、インタビューのレポートを作成してください。";
+const CONTINUE_TRIGGER_MESSAGE = "続けてください。";
+
+/**
+ * モデルへ渡すメッセージ列の末尾が assistant の場合に、続行を促す user メッセージを補う。
+ * 補った user メッセージは LLM 呼び出し専用で、トランスクリプト（DB）には保存しない。
+ * 末尾が user（通常のチャットターン）の場合はそのまま返す。
+ */
+export function ensureTrailingUserMessage(
+  messages: ChatMessage[],
+  isSummaryPhase: boolean
+): ChatMessage[] {
+  if (messages.at(-1)?.role !== "assistant") {
+    return messages;
+  }
+  return [
+    ...messages,
+    {
+      role: "user",
+      content: isSummaryPhase
+        ? SUMMARY_TRIGGER_MESSAGE
+        : CONTINUE_TRIGGER_MESSAGE,
+    },
+  ];
+}


### PR DESCRIPTION
## 概要
インタビュー設定の `chat_model` が Anthropic 系（例: `anthropic/claude-sonnet-4.6`）のとき、インタビューの **chat→summary 自動遷移**で 500 エラーになる不具合を修正する。

## 原因
chat→summary 遷移時、クライアント（`use-interview-chat.ts`）が **新しい user メッセージなし**でサマリーリクエストを自動送信するため、モデルへ渡る messages 配列の**末尾が assistant** になる。AI Gateway 経由の Anthropic 系モデルはこれを拒否し、以下の 400 を返していた:

```
This model does not support assistant message prefill. The conversation must end with a user message.
（originalModelId: anthropic/claude-sonnet-4.6）
```

デフォルトの GPT-5 系では許容されるため、設定モデル次第で顕在化していた。通常のチャットターンは末尾が user で終わるため影響なし、サマリー自動遷移だけが該当する。

## 修正
サーバ側 `generateStreamingResponse` で、モデルへ渡す messages の末尾が assistant の場合に、続行（summary フェーズではレポート生成）を促す user メッセージを補う **provider 非依存**の対応にした。

- 補った user メッセージは **LLM 呼び出し専用**で、トランスクリプト（DB）には保存しない（保存は `handleInterviewChatRequest` 側で実 user メッセージのみ対象）。
- 正規化ロジックは純粋関数 `ensureTrailingUserMessage` に切り出し。

### 変更ファイル
- `web/src/features/interview-session/shared/utils/ensure-trailing-user-message.ts`（新規・純粋関数）
- 同 `*.test.ts`（新規・ユニットテスト）
- `web/src/features/interview-session/server/services/handle-interview-chat-request.ts`（配線）
- 同 `*.integration.test.ts`（回帰テスト追加：末尾 assistant → モデルへは user 終端で渡す／補完 user は永続化しない）

## テスト
- `ensure-trailing-user-message.test.ts` 4件 ✓
- `handle-interview-chat-request.integration.test.ts` 6件（新規1件含む）✓
- `pnpm typecheck` ✓ / `pnpm lint` ✓ / `pnpm --filter web build` ✓（env 注入）/ `pnpm --filter web test` 668件 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * インタビューセッションのチャット機能で、メッセージ列がモデルに正しく渡されるよう処理を最適化しました。

* **テスト**
  * メッセージハンドリングのロジックを検証する統合テストと単体テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->