### PR TITLE
opinion backfill の使用モデルを選択可能にする

### DIFF
--- a/admin/src/app/api/interview-opinion-backfill/dispatch/route.ts
+++ b/admin/src/app/api/interview-opinion-backfill/dispatch/route.ts
@@ -16,7 +16,7 @@ const json = (body: unknown, status = 200) =>
 
 /**
  * 意見再抽出バックフィルの入口（Admin 手動トリガ）。
- * リクエストボディで議案スコープ（billId）・対象範囲（scope）を指定できる。
+ * リクエストボディで議案スコープ（billId）・対象範囲（scope）・使用モデル（model）を指定できる。
  * 対象レポートがあれば Cloud Run Job（backfill モード）を起動する。
  */
 export async function POST(request: Request) {
@@ -28,11 +28,15 @@ export async function POST(request: Request) {
 
   // 空ボディ（旧クライアント互換）は既定値（全議案・未再抽出）として扱うが、
   // 壊れた JSON は黙って既定実行にせず 400 で弾く（意図しない起動を防ぐ）。
-  let body: { billId?: string; scope?: string } = {};
+  let body: { billId?: string; scope?: string; model?: string } = {};
   const raw = await request.text();
   if (raw.trim()) {
     try {
-      body = JSON.parse(raw) as { billId?: string; scope?: string };
+      body = JSON.parse(raw) as {
+        billId?: string;
+        scope?: string;
+        model?: string;
+      };
     } catch {
       return json({ error: "リクエストボディの JSON が不正です" }, 400);
     }
@@ -41,11 +45,12 @@ export async function POST(request: Request) {
   const resolved = resolveBackfillParams({
     billId: body.billId,
     scope: body.scope,
+    model: body.model,
   });
   if (!resolved.ok) {
     return json({ error: resolved.error }, 400);
   }
-  const { billId, scope } = resolved.params;
+  const { billId, scope, model } = resolved.params;
 
   try {
     // scope="all" は起動前に同期的にウォーターマークをリセットする。
@@ -66,6 +71,9 @@ export async function POST(request: Request) {
     const args = ["--mode=backfill", `--scope=${scope}`];
     if (billId) {
       args.push(`--bill-id=${billId}`);
+    }
+    if (model) {
+      args.push(`--model=${model}`);
     }
 
     try {

--- a/admin/src/app/api/interview-opinion-backfill/dispatch/route.ts
+++ b/admin/src/app/api/interview-opinion-backfill/dispatch/route.ts
@@ -27,19 +27,28 @@ export async function POST(request: Request) {
   }
 
   // 空ボディ（旧クライアント互換）は既定値（全議案・未再抽出）として扱うが、
-  // 壊れた JSON は黙って既定実行にせず 400 で弾く（意図しない起動を防ぐ）。
-  let body: { billId?: string; scope?: string; model?: string } = {};
+  // 壊れた JSON や非オブジェクト（null / 配列 / プリミティブ）は黙って既定実行に
+  // せず 400 で弾く（意図しない起動・プロパティアクセスでの 500 を防ぐ）。
+  let body: { billId?: unknown; scope?: unknown; model?: unknown } = {};
   const raw = await request.text();
   if (raw.trim()) {
+    let parsed: unknown;
     try {
-      body = JSON.parse(raw) as {
-        billId?: string;
-        scope?: string;
-        model?: string;
-      };
+      parsed = JSON.parse(raw);
     } catch {
       return json({ error: "リクエストボディの JSON が不正です" }, 400);
     }
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      Array.isArray(parsed)
+    ) {
+      return json(
+        { error: "リクエストボディはオブジェクトである必要があります" },
+        400
+      );
+    }
+    body = parsed as { billId?: unknown; scope?: unknown; model?: unknown };
   }
 
   const resolved = resolveBackfillParams({

--- a/admin/src/features/interview-config/shared/utils/chat-model-options.test.ts
+++ b/admin/src/features/interview-config/shared/utils/chat-model-options.test.ts
@@ -1,3 +1,4 @@
+import { isKnownModel } from "@mirai-gikai/shared/ai/models";
 import { describe, expect, it } from "vitest";
 import {
   CHAT_MODEL_GROUPS,
@@ -9,6 +10,15 @@ describe("CHAT_MODEL_OPTIONS", () => {
   it("全てのオプションがprovider/model形式のvalueを持つ", () => {
     for (const option of CHAT_MODEL_OPTIONS) {
       expect(option.value).toMatch(/^(openai|google|anthropic)\//);
+    }
+  });
+
+  // UI で選べるモデルは必ず AI_MODELS（isKnownModel）のサブセットであること。
+  // ここが崩れると、UI で選べるのに backfill dispatch が「未知のモデルID」で
+  // 400 を返す乖離が起きる。
+  it("全てのオプションが AI_MODELS に登録済み（isKnownModel=true）", () => {
+    for (const option of CHAT_MODEL_OPTIONS) {
+      expect(isKnownModel(option.value)).toBe(true);
     }
   });
 

--- a/admin/src/features/interview-opinion-backfill/client/components/opinion-backfill-runner.tsx
+++ b/admin/src/features/interview-opinion-backfill/client/components/opinion-backfill-runner.tsx
@@ -7,10 +7,16 @@ import { Label } from "@/components/ui/label";
 import {
   Select,
   SelectContent,
+  SelectGroup,
   SelectItem,
+  SelectLabel,
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import {
+  CHAT_MODEL_GROUPS,
+  DEFAULT_MODEL_LABEL,
+} from "@/features/interview-config/shared/utils/chat-model-options";
 
 type BillOption = { id: string; name: string };
 
@@ -25,10 +31,13 @@ type BackfillStatus = {
 const POLL_INTERVAL_MS = 5000;
 // 「全議案」を表す Select のセンチネル値（Radix は空文字の value を許さないため）。
 const ALL_BILLS = "__all__";
+// 「既定モデル（OPINION_BACKFILL_MODEL）」を表すセンチネル値。
+const DEFAULT_MODEL = "__default__";
 
 export function OpinionBackfillRunner({ bills }: { bills: BillOption[] }) {
   const [billValue, setBillValue] = useState<string>(ALL_BILLS);
   const [scope, setScope] = useState<BackfillScope>("pending");
+  const [modelValue, setModelValue] = useState<string>(DEFAULT_MODEL);
   const [status, setStatus] = useState<BackfillStatus | null>(null);
   const [isStarting, setIsStarting] = useState(false);
   const [isRunning, setIsRunning] = useState(false);
@@ -36,6 +45,7 @@ export function OpinionBackfillRunner({ bills }: { bills: BillOption[] }) {
   const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const billId = billValue === ALL_BILLS ? undefined : billValue;
+  const model = modelValue === DEFAULT_MODEL ? undefined : modelValue;
   // 「全部」は議案指定時のみ許可（全議案 × 全部は高コストなので不可）。
   const allScopeDisabled = !billId;
 
@@ -102,7 +112,7 @@ export function OpinionBackfillRunner({ bills }: { bills: BillOption[] }) {
       const res = await fetch("/api/interview-opinion-backfill/dispatch", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ billId, scope }),
+        body: JSON.stringify({ billId, scope, model }),
       });
       if (!res.ok) {
         throw new Error(`実行開始に失敗しました (${res.status})`);
@@ -114,7 +124,7 @@ export function OpinionBackfillRunner({ bills }: { bills: BillOption[] }) {
     } finally {
       setIsStarting(false);
     }
-  }, [billId, scope, fetchStatus, startPolling]);
+  }, [billId, scope, model, fetchStatus, startPolling]);
 
   return (
     <div className="flex flex-col gap-4">
@@ -163,6 +173,43 @@ export function OpinionBackfillRunner({ bills }: { bills: BillOption[] }) {
             </p>
           )}
         </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="backfill-model">再抽出モデル</Label>
+        <Select
+          value={modelValue}
+          onValueChange={setModelValue}
+          disabled={isRunning}
+        >
+          <SelectTrigger id="backfill-model" className="sm:max-w-sm">
+            <SelectValue placeholder="モデルを選択" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={DEFAULT_MODEL}>
+              デフォルト（{DEFAULT_MODEL_LABEL}）
+            </SelectItem>
+            {CHAT_MODEL_GROUPS.map((group) => (
+              <SelectGroup key={group.provider}>
+                <SelectLabel>{group.provider}</SelectLabel>
+                {group.options.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                    {option.estimatedCost && (
+                      <span className="ml-2 text-muted-foreground">
+                        {option.estimatedCost}/回
+                      </span>
+                    )}
+                  </SelectItem>
+                ))}
+              </SelectGroup>
+            ))}
+          </SelectContent>
+        </Select>
+        <p className="text-xs text-muted-foreground">
+          再抽出に使用するモデル。未指定はデフォルト（GPT-5.2）。
+          コスト表記はインタビュー1回あたりの目安で、再抽出1件の実コストとは異なります。
+        </p>
       </div>
 
       <div className="flex items-center gap-3">

--- a/admin/src/features/interview-opinion-backfill/client/components/opinion-backfill-runner.tsx
+++ b/admin/src/features/interview-opinion-backfill/client/components/opinion-backfill-runner.tsx
@@ -207,7 +207,7 @@ export function OpinionBackfillRunner({ bills }: { bills: BillOption[] }) {
           </SelectContent>
         </Select>
         <p className="text-xs text-muted-foreground">
-          再抽出に使用するモデル。未指定はデフォルト（GPT-5.2）。
+          再抽出に使用するモデル。「デフォルト」は上の選択肢に表示されたモデルを使います。
           コスト表記はインタビュー1回あたりの目安で、再抽出1件の実コストとは異なります。
         </p>
       </div>

--- a/packages/shared/src/ai/models.test.ts
+++ b/packages/shared/src/ai/models.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { AI_MODELS, isKnownModel } from "./models";
+
+describe("isKnownModel", () => {
+  it("AI_MODELS に登録済みのIDは true", () => {
+    expect(isKnownModel(AI_MODELS.gpt5_2)).toBe(true);
+    expect(isKnownModel("anthropic/claude-sonnet-4.6")).toBe(true);
+  });
+
+  it("未登録のIDは false", () => {
+    expect(isKnownModel("openai/gpt-3.5-turbo")).toBe(false);
+    expect(isKnownModel("")).toBe(false);
+    expect(isKnownModel("not-a-model")).toBe(false);
+  });
+});

--- a/packages/shared/src/ai/models.ts
+++ b/packages/shared/src/ai/models.ts
@@ -30,5 +30,12 @@ export const AI_MODELS = {
 
 export type AiModel = (typeof AI_MODELS)[keyof typeof AI_MODELS];
 
+const KNOWN_MODELS: ReadonlySet<string> = new Set(Object.values(AI_MODELS));
+
+/** 文字列が AI_MODELS に登録済みのモデルIDかどうかを判定する。 */
+export function isKnownModel(model: string): model is AiModel {
+  return KNOWN_MODELS.has(model);
+}
+
 /** インタビューチャットのデフォルトモデル */
 export const DEFAULT_INTERVIEW_CHAT_MODEL = AI_MODELS.gpt5_2;

--- a/packages/topic-analysis-core/src/backfill.ts
+++ b/packages/topic-analysis-core/src/backfill.ts
@@ -22,7 +22,10 @@ export type BackfillChunkResult = {
   remaining: number;
 };
 
-export type BackfillOptions = {
+/** 再抽出1件あたりの依存（生成関数の差し替え・使用モデル）。 */
+type ReextractDeps = { generateReport?: GenerateReportFn; model?: string };
+
+export type BackfillOptions = ReextractDeps & {
   /** 指定議案に限定して実行する。未指定なら全議案。 */
   billId?: string;
   /**
@@ -30,7 +33,6 @@ export type BackfillOptions = {
    * "all": 既に再抽出済みも含めて全件やり直す（billId 必須）。
    */
   scope?: BackfillScope;
-  generateReport?: GenerateReportFn;
 };
 
 type ReextractTally = { updated: number; skipped: number; failed: number };
@@ -38,7 +40,7 @@ type ReextractTally = { updated: number; skipped: number; failed: number };
 /** 対象レポート群を CONCURRENCY 件ずつ並列で再抽出し、結果を集計する。 */
 async function processReportsInWaves(
   targets: BackfillTargetReport[],
-  deps: { generateReport?: GenerateReportFn }
+  deps: ReextractDeps
 ): Promise<ReextractTally> {
   const results = [];
   for (let i = 0; i < targets.length; i += OPINION_BACKFILL_CONCURRENCY) {
@@ -61,14 +63,14 @@ async function processReportsInWaves(
  * 成功・スキップはウォーターマークを進めるが、失敗（生成エラー等）は進めない。
  */
 export async function runOpinionBackfillChunk(
-  deps: { billId?: string; generateReport?: GenerateReportFn } = {}
+  deps: { billId?: string } & ReextractDeps = {}
 ): Promise<BackfillChunkResult> {
-  const { billId, generateReport } = deps;
+  const { billId, generateReport, model } = deps;
   const targets = await findReportsToReextract(
     OPINION_BACKFILL_CHUNK_SIZE,
     billId
   );
-  const tally = await processReportsInWaves(targets, { generateReport });
+  const tally = await processReportsInWaves(targets, { generateReport, model });
   const remaining = await countPendingReextraction(billId);
 
   return { processed: targets.length, ...tally, remaining };
@@ -80,10 +82,9 @@ export async function runOpinionBackfillChunk(
  * 失敗レポートはウォーターマークが進まないため、チャンク間で remaining が
  * 減らなくなった時点で「全件失敗ループ」と判断して停止する（無限ループ防止）。
  */
-async function runPendingBackfill(deps: {
-  billId?: string;
-  generateReport?: GenerateReportFn;
-}): Promise<void> {
+async function runPendingBackfill(
+  deps: { billId?: string } & ReextractDeps
+): Promise<void> {
   let prevRemaining = Number.POSITIVE_INFINITY;
 
   while (true) {
@@ -116,11 +117,12 @@ async function runPendingBackfill(deps: {
  * - scope="pending"（既定）: 未再抽出レポートをウォーターマーク方式で全件処理。
  * - scope="all": 指定議案のウォーターマークを一旦リセットしてから全件処理し直す（billId 必須）。
  *   リセットにより全件が未再抽出扱いになるため、進捗（pending）が正しく分母になる。
+ * - model: 再抽出に使う AI モデル（未指定なら OPINION_BACKFILL_MODEL）。
  */
 export async function runBackfill(options: BackfillOptions = {}): Promise<void> {
-  const { billId, scope = "pending", generateReport } = options;
+  const { billId, scope = "pending", generateReport, model } = options;
   console.log(
-    `[topic-analysis] start opinion backfill (scope=${scope} bill=${billId ?? "all"})`
+    `[topic-analysis] start opinion backfill (scope=${scope} bill=${billId ?? "all"} model=${model ?? "default"})`
   );
 
   if (scope === "all") {
@@ -133,5 +135,5 @@ export async function runBackfill(options: BackfillOptions = {}): Promise<void> 
     );
   }
 
-  await runPendingBackfill({ billId, generateReport });
+  await runPendingBackfill({ billId, generateReport, model });
 }

--- a/packages/topic-analysis-core/src/services/reextract-report-opinions.ts
+++ b/packages/topic-analysis-core/src/services/reextract-report-opinions.ts
@@ -27,18 +27,21 @@ export type GenerateReportFn = (params: {
   systemPrompt: string;
 }) => Promise<InterviewReportData>;
 
-const defaultGenerateReport: GenerateReportFn = async ({ systemPrompt }) => {
-  const { object } = await generateObject({
-    model: OPINION_BACKFILL_MODEL,
-    schema: interviewReportSchema,
-    prompt: systemPrompt,
-    experimental_telemetry: {
-      isEnabled: true,
-      functionId: "interview-opinion-backfill-reextract",
-    },
-  });
-  return object;
-};
+/** 指定モデルで再抽出する既定の生成関数を作る。 */
+function createDefaultGenerateReport(model: string): GenerateReportFn {
+  return async ({ systemPrompt }) => {
+    const { object } = await generateObject({
+      model,
+      schema: interviewReportSchema,
+      prompt: systemPrompt,
+      experimental_telemetry: {
+        isEnabled: true,
+        functionId: "interview-opinion-backfill-reextract",
+      },
+    });
+    return object;
+  };
+}
 
 /**
  * 1レポートの意見を新プロンプトで再抽出し、opinions だけを更新する。
@@ -49,10 +52,12 @@ const defaultGenerateReport: GenerateReportFn = async ({ systemPrompt }) => {
  */
 export async function reextractReportOpinions(
   target: BackfillTargetReport,
-  deps: { generateReport?: GenerateReportFn } = {}
+  deps: { generateReport?: GenerateReportFn; model?: string } = {}
 ): Promise<ReextractResult> {
   const { reportId, sessionId } = target;
-  const generateReport = deps.generateReport ?? defaultGenerateReport;
+  const generateReport =
+    deps.generateReport ??
+    createDefaultGenerateReport(deps.model ?? OPINION_BACKFILL_MODEL);
   const nowIso = new Date().toISOString();
 
   try {

--- a/packages/topic-analysis-core/src/shared/backfill-params.test.ts
+++ b/packages/topic-analysis-core/src/shared/backfill-params.test.ts
@@ -48,4 +48,29 @@ describe("resolveBackfillParams", () => {
       params: { billId: undefined, scope: "pending" },
     });
   });
+
+  it("登録済みモデルIDを受け付ける", () => {
+    const result = resolveBackfillParams({ model: "anthropic/claude-sonnet-4.6" });
+    expect(result).toEqual({
+      ok: true,
+      params: {
+        billId: undefined,
+        scope: "pending",
+        model: "anthropic/claude-sonnet-4.6",
+      },
+    });
+  });
+
+  it("未知のモデルIDはエラー", () => {
+    const result = resolveBackfillParams({ model: "openai/gpt-3.5-turbo" });
+    expect(result.ok).toBe(false);
+  });
+
+  it("空文字・空白の model は未指定として扱う", () => {
+    const result = resolveBackfillParams({ model: "  " });
+    expect(result).toEqual({
+      ok: true,
+      params: { billId: undefined, scope: "pending", model: undefined },
+    });
+  });
 });

--- a/packages/topic-analysis-core/src/shared/backfill-params.test.ts
+++ b/packages/topic-analysis-core/src/shared/backfill-params.test.ts
@@ -73,4 +73,14 @@ describe("resolveBackfillParams", () => {
       params: { billId: undefined, scope: "pending", model: undefined },
     });
   });
+
+  it("非文字列の model は throw せず検証エラーになる", () => {
+    const result = resolveBackfillParams({ model: 123 });
+    expect(result.ok).toBe(false);
+  });
+
+  it("非文字列の billId は throw せず検証エラーになる", () => {
+    const result = resolveBackfillParams({ billId: { id: 1 } });
+    expect(result.ok).toBe(false);
+  });
 });

--- a/packages/topic-analysis-core/src/shared/backfill-params.ts
+++ b/packages/topic-analysis-core/src/shared/backfill-params.ts
@@ -1,18 +1,21 @@
+import { isKnownModel } from "@mirai-gikai/shared/ai/models";
 import { z } from "zod";
 
 /**
- * 意見再抽出バックフィルの実行パラメータ（議案スコープ / 対象範囲）。
+ * 意見再抽出バックフィルの実行パラメータ（議案スコープ / 対象範囲 / モデル）。
  * worker（CLI 引数）と admin（API リクエスト）の両方から使う純粋な検証ロジック。
  *
  * - scope "pending": 未再抽出（opinions_reextracted_at IS NULL）のレポートだけを対象にする。
  * - scope "all": 既に再抽出済みのレポートも含めて全件やり直す。コストが大きいため
  *   議案指定（billId）必須とし、全議案 × all は許可しない。
+ * - model: 再抽出に使う AI モデル（未指定なら呼び出し側の既定モデル）。
  */
 export type BackfillScope = "pending" | "all";
 
 export type BackfillParams = {
   billId?: string;
   scope: BackfillScope;
+  model?: string;
 };
 
 export type BackfillParamsResult =
@@ -22,15 +25,18 @@ export type BackfillParamsResult =
 const uuidSchema = z.string().uuid();
 
 /**
- * 生の入力（billId / scope 文字列）を検証して BackfillParams に正規化する。
+ * 生の入力（billId / scope / model 文字列）を検証して BackfillParams に正規化する。
  * scope は "all" 以外（未指定含む）を "pending" に丸める。
+ * model は未指定なら undefined（呼び出し側で既定モデルを適用）。
  */
 export function resolveBackfillParams(input: {
   billId?: string | null;
   scope?: string | null;
+  model?: string | null;
 }): BackfillParamsResult {
   const scope: BackfillScope = input.scope === "all" ? "all" : "pending";
   const billId = input.billId?.trim() || undefined;
+  const model = input.model?.trim() || undefined;
 
   if (billId && !uuidSchema.safeParse(billId).success) {
     return { ok: false, error: "billId は UUID 形式である必要があります" };
@@ -41,6 +47,9 @@ export function resolveBackfillParams(input: {
       error: "対象「全部」は議案を指定したときのみ実行できます",
     };
   }
+  if (model && !isKnownModel(model)) {
+    return { ok: false, error: "未知のモデルIDです" };
+  }
 
-  return { ok: true, params: { billId, scope } };
+  return { ok: true, params: { billId, scope, model } };
 }

--- a/packages/topic-analysis-core/src/shared/backfill-params.ts
+++ b/packages/topic-analysis-core/src/shared/backfill-params.ts
@@ -25,18 +25,42 @@ export type BackfillParamsResult =
 const uuidSchema = z.string().uuid();
 
 /**
- * 生の入力（billId / scope / model 文字列）を検証して BackfillParams に正規化する。
+ * 任意文字列フィールドを trim して返す。未指定（undefined/null/空）は undefined。
+ * JSON 由来で非文字列が来ても throw せず検証エラーにするため typeof を見る。
+ */
+function trimOptionalString(
+  value: unknown,
+  field: string
+): { ok: true; value: string | undefined } | { ok: false; error: string } {
+  if (value === undefined || value === null) {
+    return { ok: true, value: undefined };
+  }
+  if (typeof value !== "string") {
+    return { ok: false, error: `${field} は文字列で指定してください` };
+  }
+  return { ok: true, value: value.trim() || undefined };
+}
+
+/**
+ * 生の入力（billId / scope / model）を検証して BackfillParams に正規化する。
+ * 入力は JSON 由来で任意型のため非文字列も throw せず検証エラーで返す。
  * scope は "all" 以外（未指定含む）を "pending" に丸める。
  * model は未指定なら undefined（呼び出し側で既定モデルを適用）。
  */
 export function resolveBackfillParams(input: {
-  billId?: string | null;
-  scope?: string | null;
-  model?: string | null;
+  billId?: unknown;
+  scope?: unknown;
+  model?: unknown;
 }): BackfillParamsResult {
   const scope: BackfillScope = input.scope === "all" ? "all" : "pending";
-  const billId = input.billId?.trim() || undefined;
-  const model = input.model?.trim() || undefined;
+
+  const billIdResult = trimOptionalString(input.billId, "billId");
+  if (!billIdResult.ok) return billIdResult;
+  const billId = billIdResult.value;
+
+  const modelResult = trimOptionalString(input.model, "model");
+  if (!modelResult.ok) return modelResult;
+  const model = modelResult.value;
 
   if (billId && !uuidSchema.safeParse(billId).success) {
     return { ok: false, error: "billId は UUID 形式である必要があります" };
@@ -48,7 +72,7 @@ export function resolveBackfillParams(input: {
     };
   }
   if (model && !isKnownModel(model)) {
-    return { ok: false, error: "未知のモデルIDです" };
+    return { ok: false, error: `未知のモデルIDです: ${model}` };
   }
 
   return { ok: true, params: { billId, scope, model } };

--- a/worker/src/main.ts
+++ b/worker/src/main.ts
@@ -10,6 +10,7 @@ import { resolveBackfillParams } from "@mirai-gikai/topic-analysis-core/backfill
  *   tsx src/main.ts --mode=backfill                              # 未再抽出を全議案で処理
  *   tsx src/main.ts --mode=backfill --bill-id=<uuid>             # 指定議案の未再抽出のみ
  *   tsx src/main.ts --mode=backfill --bill-id=<uuid> --scope=all # 指定議案を全件やり直し
+ *   tsx src/main.ts --mode=backfill --model=openai/gpt-5.2       # 使用モデルを指定（省略時は既定）
  *
  * 必須env: SUPABASE_URL, SUPABASE_SECRET_KEY, AI_GATEWAY_API_KEY
  */
@@ -57,6 +58,7 @@ async function main(): Promise<void> {
     const resolved = resolveBackfillParams({
       billId: args["bill-id"],
       scope: args.scope,
+      model: args.model,
     });
     if (!resolved.ok) {
       throw new Error(`backfill mode: ${resolved.error}`);


### PR DESCRIPTION
## 概要
意見再抽出バックフィルで、**実行ごとに使用する AI モデルを選択**できるようにする。
現状は `OPINION_BACKFILL_MODEL`（= GPT-5.2）固定。

## 実装
- **shared**: `isKnownModel`（`AI_MODELS` 登録済みID判定の型ガード）を追加。
- **core**:
  - `resolveBackfillParams` が `model` を検証（`isKnownModel`、未知なら 400）。非文字列入力でも throw せず検証エラーにする。
  - `runBackfill` → `runPendingBackfill` → `processReportsInWaves` → `reextractReportOpinions` まで `model` を伝播。`reextract` は `createDefaultGenerateReport(model ?? OPINION_BACKFILL_MODEL)` で生成（未指定時は従来どおり既定モデル）。
- **worker**: `--model=<id>` を受け付け。
- **admin**: dispatch が `model` を受け取り `--model` で worker へ。バックフィル画面に「再抽出モデル」ドロップダウン（既定 = GPT-5.2、`CHAT_MODEL_GROUPS` 流用）を追加。

## 設計メモ
- モデル選択は**実行ごとの上書き**（バッチ全体で1モデル）。議案ごとの `chat_model` には依存しない。
- 検証は core（`isKnownModel` = 全 `AI_MODELS`）、UI は curated な `CHAT_MODEL_OPTIONS` を提示。両者の乖離（UIで選べるのに dispatch が弾く）を防ぐため、`CHAT_MODEL_OPTIONS ⊆ AI_MODELS` をテストで固定。

## テスト
- `isKnownModel`（shared）/ `resolveBackfillParams` の model 検証（登録済み/未知/空白/非文字列）のユニットテスト
- `CHAT_MODEL_OPTIONS` が全て `isKnownModel=true` であることの不変条件テスト
- 実行記録: `pnpm typecheck` / `pnpm lint` / `pnpm build` / shared・core unit すべて pass

## セルフレビュー
- `/simplify`: クリーン（指摘なし）
- `/review`: Codex P2（非文字列 model で 500 になる）を修正。CodeRabbit 指摘は届き次第対応。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 意見バックフィル実行時にAIモデルの選択を追加し、選択値を実行リクエストに反映するようにしました。
  * モデルグループ別ラベル、説明、推定コストを選択画面に表示。

* **バグ修正 / 改良**
  * 実行APIとバックフィル処理でモデル指定を受け渡すよう対応。
  * リクエスト本文の入力検証を強化し、不正なJSONや型を400で返すようにしました。

* **テスト**
  * モデル選択・検証ロジックをカバーするテストを追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->