### PR TITLE
インタビューチャットのTTFB改善: DBアクセス並列化とsummary履歴の二重送信解消

### DIFF
--- a/web/src/features/interview-session/server/services/handle-interview-chat-request.integration.test.ts
+++ b/web/src/features/interview-session/server/services/handle-interview-chat-request.integration.test.ts
@@ -14,11 +14,11 @@ import type { InterviewSession } from "../../shared/types";
 import { findInterviewMessagesBySessionId } from "../repositories/interview-session-repository";
 import { handleInterviewChatRequest } from "./handle-interview-chat-request";
 
-type CapturedPrompt = Array<{ role: string }>;
+type CapturedPrompt = Array<{ role: string; content?: unknown }>;
 
 /**
  * モデルが受け取った prompt（変換後のメッセージ列）を記録する streamText 用モック。
- * 末尾が user メッセージで終わっているか検証するために使う。
+ * 末尾が user メッセージで終わっているか・履歴が二重送信されていないかの検証に使う。
  */
 function createCapturingStreamMock(text: string): {
   model: MockLanguageModelV3;
@@ -294,11 +294,66 @@ describe("handleInterviewChatRequest 統合テスト", () => {
       expect(prompts).toHaveLength(1);
       expect(prompts[0].at(-1)?.role).toBe("user");
 
+      // 会話履歴はシステムプロンプトに含まれるため、メッセージ列には
+      // 合成 user メッセージ1件のみを渡す（履歴の二重送信を防ぐ）
+      const nonSystemMessages = prompts[0].filter((m) => m.role !== "system");
+      expect(nonSystemMessages).toHaveLength(1);
+
       // 補った user メッセージは DB に保存されない（assistant の出力のみ保存）
       const messages = await findInterviewMessagesBySessionId(sessionId);
       expect(messages).toHaveLength(1);
       expect(messages[0].role).toBe("assistant");
       expect(messages[0].content).toBe(validSummaryResponse);
+    });
+
+    it("レポート修正依頼（末尾が user）では末尾の user メッセージのみをモデルへ渡す", async () => {
+      const { model, prompts } =
+        createCapturingStreamMock(validSummaryResponse);
+
+      const response = await handleInterviewChatRequest({
+        messages: [
+          { role: "user", content: "賛成です" },
+          { role: "assistant", content: "レポート案です" },
+          { role: "user", content: "もっと簡潔にしてください" },
+        ],
+        billId,
+        currentStage: "summary",
+        userId: testUser.id,
+        deps: {
+          summaryModel: model,
+          getBill: async () => null,
+          getInterviewConfig: async () => config,
+          getSession: async () => session,
+          getMessages: async () => [],
+        },
+      });
+
+      expect(response.status).toBe(200);
+      await consumeResponseStream(response);
+      await new Promise((resolve) => setTimeout(resolve, 300));
+
+      // 履歴はシステムプロンプト側にあるため、メッセージ列は末尾の user 1件のみ
+      expect(prompts).toHaveLength(1);
+      const nonSystemMessages = prompts[0].filter((m) => m.role !== "system");
+      expect(nonSystemMessages).toHaveLength(1);
+      expect(nonSystemMessages[0].role).toBe("user");
+      expect(JSON.stringify(nonSystemMessages[0].content)).toContain(
+        "もっと簡潔にしてください"
+      );
+
+      // 会話履歴（修正依頼を含む）はシステムプロンプトに含まれること
+      const systemMessage = prompts[0].find((m) => m.role === "system");
+      expect(JSON.stringify(systemMessage?.content)).toContain("賛成です");
+      expect(JSON.stringify(systemMessage?.content)).toContain(
+        "もっと簡潔にしてください"
+      );
+
+      // 修正依頼の user メッセージと assistant の出力が DB に保存されること
+      const messages = await findInterviewMessagesBySessionId(sessionId);
+      expect(messages).toHaveLength(2);
+      expect(messages[0].role).toBe("user");
+      expect(messages[0].content).toBe("もっと簡潔にしてください");
+      expect(messages[1].role).toBe("assistant");
     });
 
     it("summaryフェーズではsummaryModelが使用される（chatModelは無視される）", async () => {

--- a/web/src/features/interview-session/server/services/handle-interview-chat-request.ts
+++ b/web/src/features/interview-session/server/services/handle-interview-chat-request.ts
@@ -32,6 +32,7 @@ import type {
 import { DEFAULT_INTERVIEW_CHAT_MODEL } from "@/lib/ai/models";
 import { env } from "@/lib/env";
 import { logger } from "@/lib/logger";
+import { buildSummaryModelMessages } from "../../shared/utils/build-summary-model-messages";
 import { ensureTrailingUserMessage } from "../../shared/utils/ensure-trailing-user-message";
 import { mergeMessagesWithIds } from "../../shared/utils/merge-messages-with-ids";
 import {
@@ -82,64 +83,63 @@ export async function handleInterviewChatRequest({
   userId: string;
   deps?: InterviewChatDeps;
 }) {
-  // 日次コスト制限チェック（fail-closed: エラー時もリクエストをブロック）
-  const isWithinLimit = await isWithinDailyCostLimit(
-    userId,
-    env.chat.dailyUserCostLimitUsd
-  );
-  if (!isWithinLimit) {
-    throw new ChatError(ChatErrorCode.DAILY_COST_LIMIT_REACHED);
-  }
-
   // リクエスト単位のトレースID（同一リクエスト内のLLM呼び出しをまとめる）
   const traceId = crypto.randomUUID();
 
-  // インタビュー設定と法案情報を取得（テスト時はdeps経由でNext.js依存をバイパス）
+  // TTFB短縮のため、互いに依存しないDBアクセスは並列実行する。
+  // 日次コスト制限チェック（fail-closed: エラー時もリクエストをブロック）と
+  // インタビュー設定・法案情報の取得（テスト時はdeps経由でNext.js依存をバイパス）
   const getInterviewConfigFn =
     deps?.getInterviewConfig ?? getInterviewConfigAdmin;
   const getBillFn = deps?.getBill ?? getBillByIdAdmin;
-  const [interviewConfig, bill] = await Promise.all([
+  const [isWithinLimit, interviewConfig, bill] = await Promise.all([
+    isWithinDailyCostLimit(userId, env.chat.dailyUserCostLimitUsd),
     getInterviewConfigFn(billId),
     getBillFn(billId),
   ]);
+  if (!isWithinLimit) {
+    throw new ChatError(ChatErrorCode.DAILY_COST_LIMIT_REACHED);
+  }
 
   if (!interviewConfig) {
     throw new Error("Interview config not found");
   }
 
-  // セッション取得または作成（テスト時はdeps経由で認証をバイパス）
-  const getSessionFn = deps?.getSession ?? getInterviewSession;
-  const session =
-    (await getSessionFn(interviewConfig.id)) ??
-    (await createInterviewSession({ interviewConfigId: interviewConfig.id }));
-
   // 最新のメッセージを取得
   const lastMessage = messages[messages.length - 1];
 
-  // ユーザーメッセージを保存
-  if (lastMessage?.role === "user") {
-    const userMessageText = lastMessage.content;
+  // 「セッション取得→ユーザーメッセージ保存→全メッセージ取得」は順序依存があるため
+  // チェーンとして実行する（テスト時はdeps経由で認証をバイパス）
+  const loadSessionAndMessages = async () => {
+    const getSessionFn = deps?.getSession ?? getInterviewSession;
+    const getMessagesFn = deps?.getMessages ?? getInterviewMessages;
+    const session =
+      (await getSessionFn(interviewConfig.id)) ??
+      (await createInterviewSession({ interviewConfigId: interviewConfig.id }));
 
-    if (userMessageText.trim()) {
+    // ユーザーメッセージを保存（保存後に取得することで dbMessages に最新を含める）
+    if (lastMessage?.role === "user" && lastMessage.content.trim()) {
       await saveInterviewMessage({
         sessionId: session.id,
         role: "user",
-        content: userMessageText,
+        content: lastMessage.content,
         isRetry,
       });
     }
-  }
 
-  // 事前定義質問を取得
-  const questions = await getInterviewQuestions(interviewConfig.id);
+    const dbMessages = await getMessagesFn(session.id);
+    return { session, dbMessages };
+  };
+
+  // 独立した事前定義質問の取得とセッション系チェーンを並列実行
+  const [questions, { session, dbMessages }] = await Promise.all([
+    getInterviewQuestions(interviewConfig.id),
+    loadSessionAndMessages(),
+  ]);
 
   // モードに応じたロジックを取得（DBの設定を使用）
   const mode = interviewConfig.mode;
   const logic = modeLogicMap[mode] ?? bulkModeLogic;
-
-  // DBから最新を含む全メッセージを取得（テスト時はdeps経由で認証をバイパス）
-  const getMessagesFn = deps?.getMessages ?? getInterviewMessages;
-  const dbMessages = await getMessagesFn(session.id);
 
   // 既に聞いた質問IDを収集
   const askedQuestionIds = collectAskedQuestionIds(dbMessages);
@@ -297,9 +297,14 @@ async function generateStreamingResponse({
   };
 
   // Anthropic 系などは会話が user メッセージで終わる必要がある。
-  // chat→summary の自動遷移ではメッセージ末尾が assistant になるため、
-  // 続行を促す user メッセージを補う（DB には保存しない）。
-  const modelMessages = ensureTrailingUserMessage(messages, isSummaryPhase);
+  // summary フェーズは会話履歴全文をシステムプロンプトに埋め込んでいるため、
+  // 入力トークンの二重送信を避けて末尾の user メッセージ1件のみをモデルへ渡す
+  // （末尾が assistant の場合はレポート作成を促す合成 user メッセージを補う）。
+  // chat フェーズで末尾が assistant の場合は続行を促す user メッセージを補う。
+  // いずれの合成メッセージも DB には保存しない。
+  const modelMessages = isSummaryPhase
+    ? buildSummaryModelMessages(messages)
+    : ensureTrailingUserMessage(messages);
 
   const uiMessages = modelMessages.map((message) => ({
     role: message.role as "user" | "assistant",

--- a/web/src/features/interview-session/shared/utils/build-summary-model-messages.test.ts
+++ b/web/src/features/interview-session/shared/utils/build-summary-model-messages.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { buildSummaryModelMessages } from "./build-summary-model-messages";
+
+describe("buildSummaryModelMessages", () => {
+  it("末尾が user のときは末尾の user メッセージ1件のみを返す（履歴の二重送信を防ぐ）", () => {
+    const messages = [
+      { role: "user", content: "賛成です" },
+      { role: "assistant", content: "レポート案です" },
+      { role: "user", content: "もっと簡潔にしてください" },
+    ];
+    expect(buildSummaryModelMessages(messages)).toEqual([
+      { role: "user", content: "もっと簡潔にしてください" },
+    ]);
+    // 元の配列は破壊しない
+    expect(messages).toHaveLength(3);
+  });
+
+  it("末尾が assistant のとき（chat→summary 自動遷移）はレポート作成を促す合成 user メッセージを返す", () => {
+    const messages = [
+      { role: "user", content: "賛成です" },
+      { role: "assistant", content: "最後の質問です" },
+    ];
+    const result = buildSummaryModelMessages(messages);
+    expect(result).toHaveLength(1);
+    expect(result[0].role).toBe("user");
+    expect(result[0].content).toContain("レポート");
+  });
+
+  it("空配列でも合成 user メッセージを返す（user で終わる列を保証する）", () => {
+    const result = buildSummaryModelMessages([]);
+    expect(result).toHaveLength(1);
+    expect(result[0].role).toBe("user");
+  });
+});

--- a/web/src/features/interview-session/shared/utils/build-summary-model-messages.ts
+++ b/web/src/features/interview-session/shared/utils/build-summary-model-messages.ts
@@ -1,0 +1,27 @@
+type ChatMessage = { role: string; content: string };
+
+// chat→summary の自動遷移では、新しい user メッセージなしでレポート生成を依頼するため
+// 末尾の user メッセージが存在しない。Anthropic 系は「会話は user メッセージで
+// 終わる必要がある」として 400 を返すため、レポート作成を促す合成メッセージで補う。
+const SUMMARY_TRIGGER_MESSAGE =
+  "ここまでの会話内容をもとに、インタビューのレポートを作成してください。";
+
+/**
+ * summary フェーズでモデルへ渡すメッセージ列を構築する。
+ *
+ * summary フェーズは会話履歴全文（msg_id 付き）をシステムプロンプトに埋め込むため、
+ * messages にも全履歴を渡すと入力トークンが二重になる。末尾の user メッセージ
+ * （レポート修正依頼など）のみを渡し、末尾が user でない場合はレポート作成を促す
+ * 合成 user メッセージを渡す。合成メッセージは LLM 呼び出し専用で DB には保存しない。
+ * なお末尾の user メッセージ1件のみ、システムプロンプト内の会話履歴とモデル入力の
+ * 両方に現れるが、これは意図した挙動。
+ */
+export function buildSummaryModelMessages(
+  messages: ChatMessage[]
+): ChatMessage[] {
+  const lastMessage = messages.at(-1);
+  if (lastMessage?.role === "user") {
+    return [lastMessage];
+  }
+  return [{ role: "user", content: SUMMARY_TRIGGER_MESSAGE }];
+}

--- a/web/src/features/interview-session/shared/utils/ensure-trailing-user-message.test.ts
+++ b/web/src/features/interview-session/shared/utils/ensure-trailing-user-message.test.ts
@@ -7,33 +7,25 @@ describe("ensureTrailingUserMessage", () => {
       { role: "assistant", content: "質問です" },
       { role: "user", content: "回答です" },
     ];
-    expect(ensureTrailingUserMessage(messages, false)).toEqual(messages);
+    expect(ensureTrailingUserMessage(messages)).toEqual(messages);
   });
 
-  it("末尾が assistant かつ summary フェーズならレポート生成依頼の user を補う", () => {
+  it("末尾が assistant なら続行を促す user を補う", () => {
     const messages = [
       { role: "user", content: "回答です" },
       { role: "assistant", content: "最後の質問です" },
     ];
-    const result = ensureTrailingUserMessage(messages, true);
+    const result = ensureTrailingUserMessage(messages);
     expect(result).toHaveLength(3);
-    expect(result.at(-1)?.role).toBe("user");
-    expect(result.at(-1)?.content).toContain("レポート");
-    // 元の配列は破壊しない
-    expect(messages).toHaveLength(2);
-  });
-
-  it("末尾が assistant かつ非 summary なら続行を促す user を補う", () => {
-    const messages = [{ role: "assistant", content: "こんにちは" }];
-    const result = ensureTrailingUserMessage(messages, false);
-    expect(result).toHaveLength(2);
     expect(result.at(-1)).toEqual({
       role: "user",
       content: "続けてください。",
     });
+    // 元の配列は破壊しない
+    expect(messages).toHaveLength(2);
   });
 
   it("空配列はそのまま返す", () => {
-    expect(ensureTrailingUserMessage([], true)).toEqual([]);
+    expect(ensureTrailingUserMessage([])).toEqual([]);
   });
 });

--- a/web/src/features/interview-session/shared/utils/ensure-trailing-user-message.ts
+++ b/web/src/features/interview-session/shared/utils/ensure-trailing-user-message.ts
@@ -1,11 +1,10 @@
 type ChatMessage = { role: string; content: string };
 
-// chat→summary の自動遷移では、新しい user メッセージなしでレポート生成を依頼するため
+// summary→chat の再開直後など、新しい user メッセージなしで会話を続ける場合に
 // メッセージ末尾が assistant になる。GPT 系は許容するが Anthropic 系などは
 // 「会話は user メッセージで終わる必要がある」として 400 を返すため、続行を促す
 // user メッセージを補ってモデル呼び出しを provider 非依存にする。
-const SUMMARY_TRIGGER_MESSAGE =
-  "ここまでの会話内容をもとに、インタビューのレポートを作成してください。";
+// summary フェーズ用は build-summary-model-messages.ts を参照。
 const CONTINUE_TRIGGER_MESSAGE = "続けてください。";
 
 /**
@@ -14,19 +13,10 @@ const CONTINUE_TRIGGER_MESSAGE = "続けてください。";
  * 末尾が user（通常のチャットターン）の場合はそのまま返す。
  */
 export function ensureTrailingUserMessage(
-  messages: ChatMessage[],
-  isSummaryPhase: boolean
+  messages: ChatMessage[]
 ): ChatMessage[] {
   if (messages.at(-1)?.role !== "assistant") {
     return messages;
   }
-  return [
-    ...messages,
-    {
-      role: "user",
-      content: isSummaryPhase
-        ? SUMMARY_TRIGGER_MESSAGE
-        : CONTINUE_TRIGGER_MESSAGE,
-    },
-  ];
+  return [...messages, { role: "user", content: CONTINUE_TRIGGER_MESSAGE }];
 }


### PR DESCRIPTION
## 概要

AIインタビューの質問生成が遅い問題のうち、サーバー側で対処できる2点を改善する。

### 1. LLM呼び出し前のDBアクセス並列化（TTFB短縮）

`handleInterviewChatRequest` はLLM呼び出し開始前に最大6回のSupabaseラウンドトリップを直列実行していた。依存関係を整理して2段階の並列実行に再構成（6段→3段）。

- **並列グループ1**: 日次コスト制限チェック ∥ インタビュー設定取得 ∥ 法案取得
- **並列グループ2**: 事前定義質問取得 ∥ （セッション取得 → ユーザーメッセージ保存 → 全メッセージ取得）

「セッション取得→保存→取得」のチェーンは順序依存（summaryフェーズの `mergeMessagesWithIds` が保存済みメッセージのDB IDを必要とする）があるため直列を維持。コスト制限チェックのfail-closedセマンティクスも維持（`Promise.all` のreject伝播でブロック）。

### 2. summaryフェーズの会話履歴二重送信の解消（入力トークン約半減）

summaryフェーズでは会話履歴全文（msg_id付き）をシステムプロンプトに埋め込んでいるにもかかわらず、同じ履歴を `messages` としても送信しており、入力トークンがほぼ2倍になっていた。長いインタビューほどレポート生成が遅くなる要因。

新設の純粋関数 `buildSummaryModelMessages` で、summaryフェーズのモデル入力を**末尾のuserメッセージ1件のみ**（レポート修正依頼など。末尾がassistantの場合はレポート作成を促す合成userメッセージ）に変更。

- LLMが見る情報は変わらない（履歴はシステムプロンプト側に完全に含まれる。assistantメッセージのレポートJSONは従来からmessagesに含まれていない）
- Anthropic系の「userメッセージで終わる必要がある」制約（#835）も引き続き満たす
- これに伴い `ensureTrailingUserMessage` はchatフェーズ専用に簡素化（`isSummaryPhase` 引数を削除）

## 実行テスト記録

- `pnpm --filter web exec vitest run --config vitest.integration.config.mts src/features/interview-session` → 11 files / 48 tests passed（新規テスト含む）
- `pnpm lint` / `pnpm typecheck` / `pnpm build` → 通過
- `pnpm test` → 683 tests passed。※ web で15ファイルのcollectエラー（html-encoding-sniffer の ERR_REQUIRE_ESM）が出るが、develop ブランチでも同様に発生するローカル環境起因の既存事象で本PRとは無関係

## テスト

- `build-summary-model-messages.test.ts`（新規）: 末尾user/末尾assistant/空配列の3分岐＋非破壊性
- `handle-interview-chat-request.integration.test.ts`: summaryフェーズでモデルに渡るメッセージ列が1件のみであること、履歴がシステムプロンプト側に含まれること、DB保存状態を検証するテストを追加

## 補足

残りの改善候補（モデル変更/reasoning effort制御、Anthropic系のprompt caching）は別対応。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **テスト**
  * 統合テストを拡張し、要約フェーズと「レポート修正依頼（末尾が user）」のシーケンスを検証するケースを追加しました。

* **改良**
  * DB読み取りや設定取得を並列化して処理パフォーマンスを改善しました。
  * ユーザーメッセージ保存ルールを厳密化し、空メッセージを保存しない挙動を明確化しました。
  * 要約生成とチャット継続で末尾メッセージの扱いを整理し、要約時と通常チャットで適切な末尾メッセージが決定されるようにしました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->