### PR TITLE
CI: Supabase CLIをv2.105.0に固定（integration-test復旧）

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -30,7 +30,10 @@ jobs:
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@b60b5899c73b63a2d2d651b1e90db8d4c9392f51 # v1.6.0
         with:
-          version: latest
+          # v2.106.0 で secret key ロールの table GRANT 挙動が変わり、global setup の
+          # `diet_sessions` select が permission denied で落ちるため、直前の安定版に固定する。
+          # latest に戻す場合は tests/supabase/setup.ts が通ることを確認すること。
+          version: 2.105.0
 
       - name: Start Supabase
         run: supabase start -x studio,imgproxy,logflare,vector,realtime,edge-runtime,supavisor,inbucket


### PR DESCRIPTION
## 概要
develop の integration-test が全PRで失敗している問題を修正する。

## 原因
- `.github/workflows/integration_test.yml` の `supabase/setup-cli` が `version: latest` で**未固定**。
- 2026-06-11 12:01 に **Supabase CLI v2.106.0**（安定版）がリリースされ、CIが翌日からこれを引くようになった。
- v2.106.0 で secret key に紐づく DB ロールの table GRANT 挙動が変わり、global setup（`tests/supabase/setup.ts`）の **secret key による `diet_sessions` select が `permission denied for table diet_sessions` で失敗** → 全テスト実行前に落ちる。
- マイグレーションや該当テーブルには変更がなく（diet_sessions は2025-10作成・RLS有効/ポリシーなしのまま）、リポジトリ差分ゼロで結果が変わったことから環境（CLI）起因と判断。

### タイムライン（develop の integration-test）
| commit | 時刻 | 結果 | latest stable CLI |
|---|---|---|---|
| 70fdd02 | 06-11 06:25 | ✅ success | v2.105.0 |
| 424b2bb/4b462ea | 06-12 | ❌ failure | v2.106.0 |

## 修正
`version: latest` → `version: 2.105.0`（70fdd02 が通っていた時点の latest stable）に固定。

## 補足
- v2.106.0 側の挙動変更に追従して `latest` に戻す場合は、`tests/supabase/setup.ts` の secret key 接続確認が通ることを確認すること（コメントにも記載）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)