### PR TITLE
トピック分析の対象を管理者公開済みの意見に限定

### DIFF
--- a/packages/topic-analysis-core/src/repositories/analysis-repository.ts
+++ b/packages/topic-analysis-core/src/repositories/analysis-repository.ts
@@ -10,8 +10,10 @@ type VersionStatus = "pending" | "running" | "completed" | "failed";
 
 /**
  * §8 フィルタ後の分析対象意見を取得する。
- * interview_opinion → interview_report(is_public_by_user=true, moderation_status='ok')
+ * interview_opinion
+ * → interview_report(is_public_by_admin=true, is_public_by_user=true, moderation_status='ok')
  * → interview_sessions → interview_configs(bill_id) を辿る。
+ * 管理者公開・ユーザー公開の両方に同意済みで、かつモデレーションOKの意見のみ分析対象とする。
  */
 export async function fetchTargetOpinions(
   billId: string
@@ -22,12 +24,13 @@ export async function fetchTargetOpinions(
     .select(
       `id, opinion_index, title, content, contextual_quote, bill_sentiment, interview_report_id,
        interview_report!inner(
-         is_public_by_user, moderation_status, role,
+         is_public_by_admin, is_public_by_user, moderation_status, role,
          interview_sessions!inner(
            interview_configs!inner(bill_id)
          )
        )`
     )
+    .eq("interview_report.is_public_by_admin", true)
     .eq("interview_report.is_public_by_user", true)
     .eq("interview_report.moderation_status", "ok")
     .eq("interview_report.interview_sessions.interview_configs.bill_id", billId)

--- a/tests/supabase/user-topic-analysis-repository.test.ts
+++ b/tests/supabase/user-topic-analysis-repository.test.ts
@@ -26,6 +26,7 @@ async function createReportWithOpinions(opts: {
   configId: string;
   userId: string;
   isPublicByUser: boolean;
+  isPublicByAdmin?: boolean; // 既定 true（管理者公開済み）
   moderationScore: number; // <30=ok, 30-69=warning, >=70=ng（generated column）
   opinions: Array<{ title: string; content: string }>;
 }): Promise<{ reportId: string; opinionIds: string[] }> {
@@ -46,6 +47,7 @@ async function createReportWithOpinions(opts: {
     .insert({
       interview_session_id: session.id,
       is_public_by_user: opts.isPublicByUser,
+      is_public_by_admin: opts.isPublicByAdmin ?? true,
       moderation_score: opts.moderationScore,
       role: "general_citizen",
       summary: "s",
@@ -103,19 +105,20 @@ describe("user-topic-analysis repository 統合テスト", () => {
       .in("status", ["pending", "running"]);
   });
 
-  it("fetchTargetOpinions は公開同意済み×モデレーションOKの意見だけ返す（§8）", async () => {
-    // A: public × ok（含まれる）
+  it("fetchTargetOpinions は管理者公開×ユーザー公開×モデレーションOKの意見だけ返す（§8）", async () => {
+    // A: admin公開 × user公開 × ok（含まれる）
     const a = await createReportWithOpinions({
       configId,
       userId: testUser.id,
       isPublicByUser: true,
+      isPublicByAdmin: true,
       moderationScore: 5,
       opinions: [
         { title: "A1", content: "賛成" },
         { title: "A2", content: "懸念" },
       ],
     });
-    // B: 非公開（除外）
+    // B: user非公開（除外）
     await createReportWithOpinions({
       configId,
       userId: testUser.id,
@@ -123,13 +126,22 @@ describe("user-topic-analysis repository 統合テスト", () => {
       moderationScore: 5,
       opinions: [{ title: "B1", content: "x" }],
     });
-    // C: public だが moderation ng（除外）
+    // C: user公開 だが moderation ng（除外）
     await createReportWithOpinions({
       configId,
       userId: testUser.id,
       isPublicByUser: true,
       moderationScore: 80,
       opinions: [{ title: "C1", content: "y" }],
+    });
+    // D: user公開 × ok だが admin未公開（除外）
+    await createReportWithOpinions({
+      configId,
+      userId: testUser.id,
+      isPublicByUser: true,
+      isPublicByAdmin: false,
+      moderationScore: 5,
+      opinions: [{ title: "D1", content: "z" }],
     });
 
     const result = await fetchTargetOpinions(billId);


### PR DESCRIPTION
## 概要
トピック分析（意見抽出・集計）の対象を、**管理者公開（is_public_by_admin）× ユーザー公開（is_public_by_user）× モデレーションOK** に絞り込みます。これまでは `is_public_by_user` と `moderation_status='ok'` のみで判定しており、管理者が非公開にしたレポートの意見もトピック分析の対象に含まれていました。

## 変更点
- `packages/topic-analysis-core/src/repositories/analysis-repository.ts` の `fetchTargetOpinions` に `is_public_by_admin = true` 条件を追加（select にも `is_public_by_admin` を追加）。
- DB統合テスト `tests/supabase/user-topic-analysis-repository.test.ts`:
  - `createReportWithOpinions` に `isPublicByAdmin`（既定 true）を追加。
  - 「user公開×OKだが admin未公開」のレポート(D)が分析対象から除外されることを検証するケースを追加。

## 背景
- トピック分析・公開表示の母数を「公開レポート（管理者公開×ユーザー公開）」に揃えるための分析側の対応。表示側（§8 表示時フィルタ）は別PRで対応します。
- このPRはUI変更を含まないため、UIより先に develop へマージする想定です。

## テスト
- `pnpm --filter @mirai-gikai/topic-analysis-core typecheck` 通過
- `pnpm lint` 通過
- `dotenv -e .env -- vitest run --config tests/supabase/vitest.config.mts user-topic-analysis-repository` → 5 tests passed（新規の admin未公開除外ケース含む）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 分析対象意見の取得条件を更新し、管理者が公開した意見のみが分析対象に含まれるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->