### PR TITLE
docs: 意見richnessのトピックカード表示設計

### DIFF
--- a/docs/20260615_1500_意見richnessのトピックカード表示設計.md
+++ b/docs/20260615_1500_意見richnessのトピックカード表示設計.md
@@ -1,0 +1,114 @@
+# 意見 richness のトピックカード表示・並べ替え 設計
+
+## 目的
+意見（opinion）単位の情報充実度 `richness`（0-100）を使って、**トピックカード等の引用表示で「情報が充実した引用」を優先表示**する。
+
+## 前提（データ層は別PRで対応済み）
+- PR #845（`opinion-content-richness` ブランチ）で以下を実装済み:
+  - `interview_opinion.richness`（INTEGER・0-100・nullable）を意見抽出時に生成・保存（content＋contextual_quote を踏まえて評価）。
+  - `packages/topic-analysis-core` の `fetchTargetOpinions` / `getTopicsWithOpinions` と `TargetOpinion` 型に richness を持ち回り。
+- **本設計（UI側）は PR #845 のマージを前提**にする（`interview_opinion.richness` にデータが入っている状態）。`packages/supabase` の型（`interview_opinion` Row に `richness: number | null`）も #845 時点で利用可能。
+
+## 重要: web 公開読み取りは #845 と別経路
+ユーザー向け公開ページの読み取りは `packages/topic-analysis-core` ではなく **web 独自の経路**で、#845 では未変更。本作業で richness を通す必要がある:
+- `web/src/features/user-topic-analysis/server/repositories/topic-analysis-read-repository.ts`（公開中versionの生データ取得 SQL）
+- `web/src/features/user-topic-analysis/shared/types.ts`（`RawOpinionRow` / `PublicOpinion`）
+- `web/src/features/user-topic-analysis/shared/utils/build-public-topic-analysis.ts`（生データ→表示用への変換・純粋関数）
+
+## 変更内容
+
+### 1. 生データ取得に richness を追加
+`topic-analysis-read-repository.ts` の select に `richness` を追加し、`RawOpinionRow` にマップする。
+
+```ts
+// findPublishedAnalysis 内の select
+interview_opinion(
+  id, title, content, contextual_quote, bill_sentiment, richness,
+  interview_report!inner(is_public_by_user, moderation_status, role)
+)
+```
+```ts
+// opinions.push(...) に追加
+richness: o.richness,
+```
+※ `o` の Omit 型にも `richness` が含まれるよう `RawOpinionRow` を更新する（下記）。
+
+### 2. 型に richness を追加
+`web/src/features/user-topic-analysis/shared/types.ts`
+
+```ts
+export type RawOpinionRow = {
+  id: string;
+  title: string;
+  content: string;
+  contextual_quote: string | null;
+  bill_sentiment: string | null;
+  richness: number | null; // ← 追加
+  is_public_by_user: boolean;
+  moderation_status: string | null;
+  role: string | null;
+};
+
+export type PublicOpinion = {
+  id: string;
+  title: string;
+  content: string;
+  user_category: UserCategory;
+  bill_sentiment: "期待" | "懸念" | null;
+  contextual_quote: string | null;
+  richness: number | null; // ← 追加
+  question_snippet: string | null;
+  // 既存: source_message_id / interview_report_id / report_public 等（launch UI 側で追加済みのものは維持）
+};
+```
+
+### 3. 変換時に richness を引き渡し、意見を richness 降順で並べる
+`build-public-topic-analysis.ts` の `buildPublicTopicAnalysis`。
+
+- `PublicOpinion` に `richness: o.richness` を渡す。
+- **`displayable` を richness 降順で安定ソート**してから `opinions` を構築する（カード・詳細とも「充実した引用が先頭」になる）。
+  - null は最後に倒す。
+  - 同点は既存順（`interview_report_id`, `opinion_index`）を維持＝安定ソート。
+
+```ts
+// §8 フィルタ後にソート（純粋関数内で完結）
+const displayable = rawTopic.opinions
+  .filter(isDisplayable)
+  .slice() // 元配列を壊さない
+  .sort((a, b) => (b.richness ?? -1) - (a.richness ?? -1)); // 安定ソート前提（V8は安定）
+```
+※ 件数・属性内訳・期待/懸念の集計はソートの影響を受けない（集合は不変）。`total_opinions` も不変。
+
+### 4. トピックカードの代表引用は「richness が高い引用」を優先
+`web/src/features/user-topic-analysis/shared/components/topic-card.tsx`（launch UI）。
+
+現状は `withQuote(...).slice(0, maxQuotes)` で **配列先頭から** 引用付き意見を拾う。3 で `opinions` を richness 降順にしておけば、**この実装のまま richness 上位の引用が選ばれる**（追加変更不要）。
+
+- フィルタ選択時（`filterOpinions`）も順序を保つため、richness 優先が維持される。
+- もし「カードだけ richness 優先・詳細は別順」にしたい場合は、3 では並べ替えず、`topic-card.tsx` 側で `withQuote(...).sort((a,b)=>(b.richness??-1)-(a.richness??-1)).slice(0,maxQuotes)` とする（**どちらか一方**に寄せる。推奨は 3 の一括ソート）。
+
+### 5. 詳細ページの意見一覧
+`topic-detail-page.tsx` → `TopicOpinionList`（`client/components/topic-opinion-list.tsx`）は `topic.opinions` をそのまま表示。3 のソートにより自動的に richness 降順になる。意図的に別順（例: 期待/懸念バランス）にしたい要件があればここで再ソートする。
+
+## 設計判断（推奨）
+- **並べ替えは `build-public-topic-analysis.ts` に一元化**（純粋関数・テスト容易・カード/詳細で一貫）。表示コンポーネント側ではソートを持たない。
+- richness が null（旧データ・未生成）は最後尾。全件 null のトピックでも既存順で表示され壊れない。
+- スコアはあくまで「引用選択の優先度」。件数・割合などの集計には一切使わない。
+
+## テスト（必須）
+- `build-public-topic-analysis.test.ts` に追加:
+  - richness 降順で `opinions` が並ぶこと。
+  - null richness が最後に来ること。
+  - 同点で元順序（report_id, opinion_index 由来）が保たれること（安定ソート）。
+  - 件数・属性内訳・sentiment 集計がソートで変わらないこと（既存アサーションで担保）。
+- `topic-card.tsx` のロジックを純粋関数に切り出す場合（4のカード側ソート案を採る場合）は、その関数の単体テストを追加。
+
+## 影響範囲・非対象
+- 公開 API（`/api/bills/[billId]/topic-analysis`）のレスポンスに `richness` が増える（`PublicOpinion`）。破壊的ではない（追加のみ）。
+- 既存データは #845 のバックフィル再抽出で richness を埋めてから表示する（未再抽出だと全 null＝既存順表示）。
+- admin プレビュー（`admin/.../user-topic-analysis-page.tsx`）は対象外（必要なら別途）。
+
+## 作業順序
+1. PR #845 マージ後に develop から worktree を作成。
+2. 型（`RawOpinionRow`/`PublicOpinion`）→ 読み取り SQL → `build-public-topic-analysis`（ソート）→ テストの順で実装。
+3. `topic-card.tsx` は変更不要の想定（3 の一括ソート採用時）。挙動をスクリーンショットで確認（UI差分のため `/pr-screenshot`）。


### PR DESCRIPTION
意見単位 richness（PR #845）を使った、トピックカードの代表引用の優先表示・並べ替えの実装設計。UI実装を担当する別セッションへの引き継ぎ用。

- web公開読み取り経路（#845とは別経路）への richness 追加箇所
- build-public-topic-analysis での richness 降順ソート（一元化）
- TopicCard は一括ソート採用時は変更不要
- 必要なテスト

🤖 Generated with [Claude Code](https://claude.com/claude-code)