### PR TITLE
意見再抽出は interview_opinion テーブルのみ更新（JSONBは原本として保持）

### DIFF
--- a/packages/topic-analysis-core/src/repositories/backfill-repository.ts
+++ b/packages/topic-analysis-core/src/repositories/backfill-repository.ts
@@ -129,30 +129,6 @@ export async function resetReextractionForBill(
 }
 
 /**
- * 再抽出した意見でレポートを更新し、処理時刻を記録する（成功時）。
- * opinions 以外のカラム（summary/stance/role/richness/moderation/公開フラグ）は変更しない。
- */
-export async function updateReportOpinions(
-  reportId: string,
-  opinions: unknown,
-  reextractedAtIso: string
-): Promise<void> {
-  const supabase = createAdminClient();
-  // opinions は呼び出し側で enrich 済みの配列。JSONB カラムの厳密型を満たすため as never でキャスト。
-  const { error } = await supabase
-    .from("interview_report")
-    .update({
-      opinions: opinions as never,
-      opinions_reextracted_at: reextractedAtIso,
-    })
-    .eq("id", reportId);
-
-  if (error) {
-    throw new Error(`Failed to update report opinions: ${error.message}`);
-  }
-}
-
-/**
  * 再抽出を試行したが失敗したレポートに処理時刻だけ記録する。
  * 公開同意優先の並びで失敗レポートが先頭に滞留して前進が止まるのを防ぐため、
  * 失敗時もウォーターマークを進める（再実行時は当該行を NULL に戻す）。

--- a/packages/topic-analysis-core/src/services/reextract-report-opinions.ts
+++ b/packages/topic-analysis-core/src/services/reextract-report-opinions.ts
@@ -8,10 +8,7 @@ import {
 } from "@mirai-gikai/shared/interview-report/schema";
 import { syncInterviewOpinions } from "@mirai-gikai/shared/interview-report/sync-opinions";
 import { generateObject } from "ai";
-import {
-  markReextractionAttempted,
-  updateReportOpinions,
-} from "../repositories/backfill-repository";
+import { markReextractionAttempted } from "../repositories/backfill-repository";
 import {
   fetchBillWithContents,
   findInterviewConfigById,
@@ -44,11 +41,13 @@ function createDefaultGenerateReport(model: string): GenerateReportFn {
 }
 
 /**
- * 1レポートの意見を新プロンプトで再抽出し、opinions だけを更新する。
- * summary/stance/role/content_richness/moderation/公開フラグは保持する。
- * 成功時は更新とともに、恒久的にスキップ（セッション/設定/メッセージ無し）の場合も
- * ウォーターマーク（opinions_reextracted_at）を進める。
- * ただし生成・更新・同期の失敗時は進めない（次回再実行で再試行される）。
+ * 1レポートの意見を新プロンプトで再抽出し、**interview_opinion テーブルのみ**更新する。
+ * interview_report.opinions(JSONB) は「ユーザーが確認した当時のレポート」の記録として
+ * 書き換えない（再抽出はトピック分析用の意見だけを更新する）。summary/stance/role 等の
+ * report カラムも保持する。
+ * 成功時はテーブル同期に加えてウォーターマーク（opinions_reextracted_at）を進める。
+ * 恒久的にスキップ（セッション/設定/メッセージ無し）の場合も進める。
+ * ただし生成・同期の失敗時は進めない（次回再実行で再試行される）。
  */
 export async function reextractReportOpinions(
   target: BackfillTargetReport,
@@ -102,21 +101,20 @@ export async function reextractReportOpinions(
 
     const report = await generateReport({ systemPrompt });
 
-    // source_message_id を元発言に解決し source_message_content を付与
+    // source_message_id を元発言に解決して interview_opinion 行を作る。
     const enrichedOpinions = enrichOpinionsWithSourceContent(
       report.opinions,
       messages ?? []
     );
 
-    // interview_opinion（正規化プロジェクション）を先に同期し、
-    // 最後に opinions + ウォーターマークを書く。こうすることで
-    // ウォーターマークが立つ = update と sync の両方が成功した状態のみとなり、
-    // sync 失敗時に「opinions だけ更新されて projection が古いまま完了扱い」になるのを防ぐ。
+    // 再抽出は interview_opinion テーブルのみ更新する（JSONB は原本として書き換えない）。
+    // テーブル同期に成功した場合だけウォーターマークを進める。こうすることで
+    // 「同期は失敗したのに完了扱い」になるのを防ぐ（次回再実行で再試行される）。
     await syncInterviewOpinions(
       reportId,
       buildInterviewOpinionRows(reportId, enrichedOpinions)
     );
-    await updateReportOpinions(reportId, enrichedOpinions, nowIso);
+    await markReextractionAttempted(reportId, nowIso);
 
     return { reportId, status: "updated" };
   } catch (error) {

--- a/supabase/migrations/20260616100000_update_interview_opinion_table_comment.sql
+++ b/supabase/migrations/20260616100000_update_interview_opinion_table_comment.sql
@@ -1,0 +1,6 @@
+-- interview_opinion は当初 interview_report.opinions(JSONB) から導出する
+-- 「正規化プロジェクション」として作られたが、意見再抽出は JSONB を書き換えず
+-- interview_opinion テーブルのみ更新する方針に変更した。
+-- そのため本テーブルは JSONB の派生ではなく、トピック分析用の意見ストアとして独立する。
+-- （新規インタビュー完了時のみ JSONB と本テーブルの両方へ互換目的で書き込む。）
+COMMENT ON TABLE interview_opinion IS 'トピック分析用の意見ストア。新規インタビュー完了時は interview_report.opinions(JSONB) と本テーブルの両方へ書き込み、意見再抽出は本テーブルのみ更新する（JSONB は原本として保持）';

--- a/tests/supabase/interview-opinion-backfill-repository.test.ts
+++ b/tests/supabase/interview-opinion-backfill-repository.test.ts
@@ -4,7 +4,6 @@ import {
   findReportsToReextract,
   markReextractionAttempted,
   resetReextractionForBill,
-  updateReportOpinions,
 } from "@mirai-gikai/topic-analysis-core/repository";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
@@ -123,44 +122,6 @@ describe("interview-opinion-backfill repository 統合テスト", () => {
       publicNew.id,
       privateOldest.id,
     ]);
-  });
-
-  it("updateReportOpinions は opinions と処理時刻のみ更新し他カラムは保持する", async () => {
-    const report = await createReport({
-      configId,
-      userId: testUser.id,
-      isPublicByUser: true,
-      createdAt: "2023-01-01T00:00:00Z",
-      summary: "保持されるサマリ",
-      opinions: [{ title: "旧", content: "旧内容", source_message_id: null }],
-    });
-
-    const newOpinions = [
-      {
-        title: "新意見",
-        content: "新内容",
-        source_message_id: null,
-        contextual_quote: "（議案について）新引用",
-        bill_sentiment: "期待",
-        source_message_content: null,
-      },
-    ];
-    const iso = "2026-06-08T00:00:00Z";
-    await updateReportOpinions(report.id, newOpinions, iso);
-
-    const { data: updated } = await adminClient
-      .from("interview_report")
-      .select("opinions, opinions_reextracted_at, summary, stance")
-      .eq("id", report.id)
-      .single();
-
-    expect(updated?.opinions).toEqual(newOpinions);
-    expect(new Date(updated?.opinions_reextracted_at ?? 0).getTime()).toBe(
-      new Date(iso).getTime()
-    );
-    // 他フィールドは不変
-    expect(updated?.summary).toBe("保持されるサマリ");
-    expect(updated?.stance).toBe("for");
   });
 
   it("countPendingReextraction は markReextractionAttempted で減る", async () => {

--- a/web/src/features/interview-session/server/services/complete-interview-session.ts
+++ b/web/src/features/interview-session/server/services/complete-interview-session.ts
@@ -90,9 +90,11 @@ export async function completeInterviewSession({
     })
   );
 
-  // interview_opinion（正規化プロジェクション）へ dual-write（§3.1）
-  // 失敗してもインタビュー完了はブロックしない（report の JSONB が正本）。
-  // 未同期分は Step2 のバックフィル（パスA）と日次再実行が結果整合的に取り込む。
+  // 新規インタビュー完了時は JSONB（report.opinions）と interview_opinion テーブルの
+  // 両方へ書き込む（既存互換のため。JSONB はユーザーが確認するレポート記録、
+  // interview_opinion はトピック分析用の意見ストア）。
+  // 失敗してもインタビュー完了はブロックしない。未同期分は意見再抽出バックフィルが取り込む
+  // （再抽出は JSONB を書き換えず interview_opinion のみ更新する）。
   try {
     const storedOpinions = Array.isArray(report.opinions)
       ? (report.opinions as InterviewOpinionSource[])

--- a/web/src/features/interview-session/shared/utils/complete-interview-report.test.ts
+++ b/web/src/features/interview-session/shared/utils/complete-interview-report.test.ts
@@ -57,6 +57,8 @@ describe("buildCompletedInterviewReportInsert", () => {
         is_public_by_admin: true,
         moderation_score: 29,
         moderation_reasoning: "問題なし",
+        // 完了時は再抽出ウォーターマークを未処理へ戻す（再完了後もバックフィルで復旧可能にする）
+        opinions_reextracted_at: null,
       })
     );
     expect(insert.opinions).toEqual([

--- a/web/src/features/interview-session/shared/utils/complete-interview-report.ts
+++ b/web/src/features/interview-session/shared/utils/complete-interview-report.ts
@@ -44,6 +44,10 @@ export function buildCompletedInterviewReportInsert({
     role_description: reportData.role_description,
     role_title: reportData.role_title,
     opinions: enrichedOpinions,
+    // 完了（再完了含む）時はレポート内容が（再）確定するため、意見再抽出の
+    // ウォーターマークを未処理(NULL)に戻す。これにより再完了で interview_opinion が
+    // JSONB 由来の内容へ同期され直しても、次回バックフィルが再抽出して品質を復旧できる。
+    opinions_reextracted_at: null,
     content_richness: reportData.content_richness,
     moderation_score: moderationScore,
     moderation_reasoning: moderationReasoning,


### PR DESCRIPTION
## 概要
意見再抽出（バックフィル）が `interview_report.opinions`(JSONB) を書き換えないようにし、**`interview_opinion` テーブルのみ**を更新する。これにより interview_opinion は JSONB の派生（projection）ではなく、トピック分析用の独立した意見ストアになる。

### 方針（依頼どおり）
- **再抽出**: dual-write をやめ、`interview_opinion` テーブルのみ更新（JSONB は「ユーザーが確認した当時のレポート」の原本として保持）。
- **新規インタビュー完了時**: 互換のため JSONB と `interview_opinion` の両方へ書き込む（dual-write を維持）。

## 変更内容
- `reextractReportOpinions`: `updateReportOpinions`（JSONB更新）→ `markReextractionAttempted`（ウォーターマークのみ）に変更。テーブル同期成功時だけウォーターマークを進める。
- 不要になった `updateReportOpinions`（リポジトリ関数）と、その統合テストを削除。
- `complete-interview-session.ts`: dual-write は維持（コメントを新モデルに更新）。
- **完了時に `opinions_reextracted_at` を NULL リセット**（`buildCompletedInterviewReportInsert`）。再完了で interview_opinion が JSONB 由来に巻き戻っても、ウォーターマークが未処理に戻るため次回バックフィルが再抽出し直して品質を復旧できる（下記P2対応）。
- マイグレーション追加: `interview_opinion` テーブルの COMMENT を「JSONBから導出する正規化プロジェクション」→「独立した意見ストア」に更新（コメントのみ・型変更なし）。

## 動作確認（ローカル）
- 実レポートで再抽出を実行 → **interview_report.opinions(JSONB) は前後で完全に不変**（`JSONB UNCHANGED: true`）、`interview_opinion` テーブルのみ更新されることを確認。
- `pnpm --filter @mirai-gikai/topic-analysis-core test`(41) / `--filter web`（complete-interview-report 含む）/ 各 typecheck 通過。
- ※ ローカルの `findReportsToReextract` 統合テスト1件は、開発用DBに大量の未再抽出レポート（dump等）が滞留しているため失敗するが、本変更と無関係（当該関数は未変更・議案スコープ版テストは合格）。CI のクリーンDBでは通る想定。

## レビュー対応（Codex）
- **P2（再完了で再抽出が巻き戻る）: 対応済み**。完了時に `opinions_reextracted_at` を NULL に戻すことで、再完了後も次回バックフィルが再抽出してテーブル品質を復旧する。
- **P1（admin 旧トピック分析が JSONB を読む）: 一旦現状維持**。`admin/features/topic-analysis`（`/api/topic-analysis/run` 系）はバックフィル済み議案で原本(再抽出前)を分析するが、user-topic-analysis（テーブル参照）へ一本化する前提で当面許容（別タスク）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)