### PR TITLE
provision.sh: Cloud Run 実行基盤を環境別(Secret名/Job名)に分離

### DIFF
--- a/.github/workflows/deploy_worker.yml
+++ b/.github/workflows/deploy_worker.yml
@@ -23,7 +23,9 @@ jobs:
       GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
       GCP_REGION: ${{ secrets.GCP_REGION || 'asia-northeast1' }}
       GCP_AR_REPO: ${{ secrets.GCP_AR_REPO || 'topic-analysis' }}
-      GCP_TOPIC_ANALYSIS_JOB: ${{ secrets.GCP_TOPIC_ANALYSIS_JOB || 'topic-analysis-worker' }}
+      # 既定は環境別 Job 名（provision.sh の topic-analysis-worker-<DEPLOY_ENV> に合わせる）。
+      # provision 時に別名を使った場合は各環境の Secret GCP_TOPIC_ANALYSIS_JOB で上書きすること。
+      GCP_TOPIC_ANALYSIS_JOB: ${{ secrets.GCP_TOPIC_ANALYSIS_JOB || (github.ref_name == 'main' && 'topic-analysis-worker-production' || 'topic-analysis-worker-staging') }}
     steps:
       # Environment の Secret は job 開始後のステップでしか参照できない
       # （job-level if からは Environment スコープの vars/secrets が見えない）。

--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,7 @@ node_modules
 !.env.example
 
 # Cloud Run infra（秘密・鍵はコミットしない）
+# config.env / config.env.<env>（環境別）をまとめて除外（config.example.env は対象外）
 infra/cloud-run/config.env
+infra/cloud-run/config.env.*
 *-key.json

--- a/infra/cloud-run/README.md
+++ b/infra/cloud-run/README.md
@@ -13,11 +13,34 @@
 | --- | --- |
 | API | run / artifactregistry / secretmanager を有効化 |
 | Artifact Registry | docker リポジトリ（既定 `topic-analysis`） |
-| Secret Manager | `SUPABASE_URL` / `SUPABASE_SECRET_KEY` / `AI_GATEWAY_API_KEY`（**コンテナのみ**。値は別途） |
+| Secret Manager | `SUPABASE_URL` / `SUPABASE_SECRET_KEY` / `AI_GATEWAY_API_KEY` に **環境サフィックス**を付けたもの（例 `SUPABASE_URL_STAGING`）。**コンテナのみ**・値は別途 |
 | SA: runtime | Job 実行用。secret 読み取り権限 |
 | SA: invoker | admin が `jobs:run` を呼ぶ用。run.invoker + runtime への actAs |
 | SA: deployer | CI（`deploy_worker.yml`）用。AR writer + run.developer + actAs |
-| Cloud Run Job | `topic-analysis-worker`（batch 向け設定）。**無ければ作成**、以後の image 更新は CI |
+| Cloud Run Job | `topic-analysis-worker-<DEPLOY_ENV>`（batch 向け設定）。**無ければ作成**、以後の image 更新は CI |
+
+## 環境（staging / production）の分離
+
+Secret Manager は **プロジェクトでグローバル（名前が一意）** なため、同一プロジェクトに
+複数環境を置く場合は **Secret 名と Job 名を環境ごとに分離**する必要がある。
+本スクリプトは必須の `DEPLOY_ENV`（例 `staging` / `production`）から自動で分離する。
+
+- Secret 名: `SUPABASE_URL` → `SUPABASE_URL_<DEPLOY_ENV 大文字>`（例 `SUPABASE_URL_STAGING`）
+- Job 名（既定）: `topic-analysis-worker-<DEPLOY_ENV>`
+- worker が読む **環境変数名は固定**（`SUPABASE_URL` 等）。Job の `--set-secrets` が
+  「`SUPABASE_URL=SUPABASE_URL_STAGING:latest`」のように環境別 Secret へマッピングする。
+
+> ⚠️ `DEPLOY_ENV` を指定しないとエラーで停止する（環境を跨いで Secret を上書きする事故を防ぐため）。
+
+**CI（`deploy_worker.yml`）との対応**: ワークフローは `main`→`topic-analysis-worker-production` /
+`develop`→`topic-analysis-worker-staging` を既定 Job 名として更新する。provision 時に別名の Job を
+作った場合は、各 GitHub Environment の Secret `GCP_TOPIC_ANALYSIS_JOB` を**その Job 名に合わせて**設定すること
+（不一致だと `gcloud run jobs update` が `NOT_FOUND` で失敗する）。
+
+**サービスアカウントの分離（任意）**: 既定では runtime / invoker / deployer SA は環境間で**共有**される
+（runtime SA は `*_STAGING` と `*_PRODUCTION` の両 Secret にアクセス可能）。環境ごとに IAM を完全分離したい場合は
+`RUNTIME_SA_NAME` / `INVOKER_SA_NAME` / `DEPLOYER_SA_NAME` を環境別の名前（例 `topic-analysis-runtime-staging`）で
+上書きして実行する。
 
 ## 前提
 
@@ -27,12 +50,22 @@
 ## 使い方
 
 ```bash
-# 1. 設定（実値は config.env に。gitignore 済み）
+# 1. 設定（実値は config.env に。config.env* は gitignore 済み）
 cp infra/cloud-run/config.example.env infra/cloud-run/config.env
-$EDITOR infra/cloud-run/config.env        # GCP_PROJECT_ID は必須
+$EDITOR infra/cloud-run/config.env        # GCP_PROJECT_ID と DEPLOY_ENV は必須
 
 # 2. 実行（冪等。何度実行しても安全）
 bash infra/cloud-run/provision.sh
+```
+
+環境を分けて運用する場合は、環境別の設定ファイルを `CONFIG_FILE` で指定する（いずれも gitignore 対象）:
+
+```bash
+cp infra/cloud-run/config.example.env infra/cloud-run/config.env.staging      # DEPLOY_ENV=staging + staging 値
+cp infra/cloud-run/config.example.env infra/cloud-run/config.env.production    # DEPLOY_ENV=production + 本番値
+
+CONFIG_FILE=infra/cloud-run/config.env.staging    bash infra/cloud-run/provision.sh
+CONFIG_FILE=infra/cloud-run/config.env.production bash infra/cloud-run/provision.sh
 ```
 
 ## OSS・セキュリティ上の約束

--- a/infra/cloud-run/config.example.env
+++ b/infra/cloud-run/config.example.env
@@ -1,18 +1,32 @@
 # infra/cloud-run/provision.sh の設定ひな型。
-# 実値を記入して `config.env` としてコピーする（config.env は gitignore 済み・コミットしない）。
+# 実値を記入して `config.env` としてコピーする（config.env* は gitignore 済み・コミットしない）。
 #   cp infra/cloud-run/config.example.env infra/cloud-run/config.env
+# 環境を分ける場合は config.env.<env> を作り、CONFIG_FILE で指定して実行する:
+#   cp infra/cloud-run/config.example.env infra/cloud-run/config.env.staging
+#   CONFIG_FILE=infra/cloud-run/config.env.staging bash infra/cloud-run/provision.sh
 
 # ── 必須 ──
 export GCP_PROJECT_ID="your-gcp-project-id"
+# 環境名。同一プロジェクトに staging / production を同居させる前提で、
+# Secret 名（接尾辞）と Job 名をこの値で分離する。**必須**。
+#   - Secret 名: SUPABASE_URL_STAGING / SUPABASE_URL_PRODUCTION のように接尾辞が付く
+#   - Job 名（既定）: topic-analysis-worker-<DEPLOY_ENV>
+# 環境ごとに config.env を分け、それぞれ DEPLOY_ENV を変えて provision.sh を実行する。
+export DEPLOY_ENV="staging"   # or "production"
 
 # ── 任意（未指定ならスクリプトの汎用デフォルトを使用） ──
 export GCP_REGION="asia-northeast1"
 export GCP_AR_REPO="topic-analysis"
-export GCP_TOPIC_ANALYSIS_JOB="topic-analysis-worker"
+# Job 名を明示指定したい場合のみ（既定: topic-analysis-worker-<DEPLOY_ENV>）。
+# export GCP_TOPIC_ANALYSIS_JOB="topic-analysis-worker-staging"
+# Secret 名の接尾辞を明示指定したい場合のみ（既定: _<DEPLOY_ENV を大文字化>）。
+# export SECRET_SUFFIX="_STAGING"
 
 # ── Secret 値（任意・一括投入する場合のみ） ──
+# キーは worker の環境変数名で指定する（実 Secret 名は接尾辞付きで作られる）。
 # 未設定なら空のシークレットコンテナだけ作られる（値は手動で versions add）。
-# export SECRET_VALUE_SUPABASE_URL="https://xxxx.supabase.co"
+# **その環境（DEPLOY_ENV）の Supabase の値を入れること**（取り違え注意）。
+# export SECRET_VALUE_SUPABASE_URL="https://xxxx.supabase.co"   # db. を付けない（API URL）
 # export SECRET_VALUE_SUPABASE_SECRET_KEY="sb_secret_xxx"
 # export SECRET_VALUE_AI_GATEWAY_API_KEY="xxx"
 

--- a/infra/cloud-run/provision.sh
+++ b/infra/cloud-run/provision.sh
@@ -16,17 +16,27 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 
-# config.env があれば読み込む（実値はここに置く・gitignore 済み）
-if [[ -f "${SCRIPT_DIR}/config.env" ]]; then
-  # shellcheck disable=SC1091
-  source "${SCRIPT_DIR}/config.env"
+# 設定ファイルを読み込む（実値はここに置く・config.env* は gitignore 済み）。
+# 環境ごとに分けたい場合は CONFIG_FILE で指定する:
+#   CONFIG_FILE=infra/cloud-run/config.env.staging bash infra/cloud-run/provision.sh
+# 既定は config.env。相対パス指定はカレントからでも SCRIPT_DIR 基準でも解決できるようにする。
+CONFIG_FILE="${CONFIG_FILE:-${SCRIPT_DIR}/config.env}"
+if [[ ! -f "$CONFIG_FILE" && -f "${SCRIPT_DIR}/${CONFIG_FILE}" ]]; then
+  CONFIG_FILE="${SCRIPT_DIR}/${CONFIG_FILE}"
+fi
+if [[ -f "$CONFIG_FILE" ]]; then
+  echo "▶ 設定ファイルを読み込み: ${CONFIG_FILE}"
+  # shellcheck disable=SC1090
+  source "$CONFIG_FILE"
 fi
 
 # ── 設定（プロジェクト識別子以外は汎用デフォルトを持つ） ──
 PROJECT_ID="${GCP_PROJECT_ID:-}"
+# 環境（staging / production 等）。同一プロジェクトに複数環境を同居させる前提で、
+# Secret 名と Job 名をこの値で分離する（必須）。
+DEPLOY_ENV="${DEPLOY_ENV:-}"
 REGION="${GCP_REGION:-asia-northeast1}"
 AR_REPO="${GCP_AR_REPO:-topic-analysis}"
-JOB="${GCP_TOPIC_ANALYSIS_JOB:-topic-analysis-worker}"
 RUNTIME_SA_NAME="${RUNTIME_SA_NAME:-topic-analysis-runtime}"
 INVOKER_SA_NAME="${INVOKER_SA_NAME:-topic-analysis-invoker}"
 DEPLOYER_SA_NAME="${DEPLOYER_SA_NAME:-topic-analysis-deployer}"
@@ -37,13 +47,33 @@ if [[ -z "$PROJECT_ID" ]]; then
   echo "ERROR: GCP_PROJECT_ID が未設定です（config.env か環境変数で指定）。" >&2
   exit 1
 fi
+if [[ -z "$DEPLOY_ENV" ]]; then
+  echo "ERROR: DEPLOY_ENV が未設定です（例: staging / production）。" >&2
+  echo "       Secret Manager はプロジェクトでグローバルなため、環境を指定しないと" >&2
+  echo "       他環境のシークレットを上書きする恐れがあります。" >&2
+  exit 1
+fi
+
+# Secret はプロジェクトでグローバル（名前が一意）。同一プロジェクトに複数環境を
+# 置くため、Secret 名を環境サフィックスで分離する（例: SUPABASE_URL_STAGING）。
+# Job 名も環境ごとに分ける。いずれも明示指定で上書き可能。
+ENV_UPPER="$(printf '%s' "$DEPLOY_ENV" | tr '[:lower:]' '[:upper:]')"
+SECRET_SUFFIX="${SECRET_SUFFIX:-_${ENV_UPPER}}"
+JOB="${GCP_TOPIC_ANALYSIS_JOB:-topic-analysis-worker-${DEPLOY_ENV}}"
 
 RUNTIME_SA="${RUNTIME_SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
 INVOKER_SA="${INVOKER_SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
 DEPLOYER_SA="${DEPLOYER_SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
-SECRETS=(SUPABASE_URL SUPABASE_SECRET_KEY AI_GATEWAY_API_KEY)
+# worker が読む環境変数名（固定）。実体の Secret 名は ${ENV_VAR}${SECRET_SUFFIX}。
+SECRET_ENV_VARS=(SUPABASE_URL SUPABASE_SECRET_KEY AI_GATEWAY_API_KEY)
+# この環境で作成・参照する実 Secret 名。
+SECRETS=()
+for ev in "${SECRET_ENV_VARS[@]}"; do
+  SECRETS+=("${ev}${SECRET_SUFFIX}")
+done
 
 log() { echo "▶ $*"; }
+log "環境: DEPLOY_ENV=${DEPLOY_ENV} / Secret 接尾辞=${SECRET_SUFFIX} / Job=${JOB}"
 
 gcloud config set project "$PROJECT_ID" >/dev/null
 
@@ -68,8 +98,11 @@ else
     --description="Topic analysis worker images"
 fi
 
-# ── 3. Secret Manager（コンテナのみ作成。値は SECRET_VALUE_<NAME> があれば version 追加） ──
-for s in "${SECRETS[@]}"; do
+# ── 3. Secret Manager（環境別の実 Secret 名で作成。値は SECRET_VALUE_<ENV_VAR> があれば version 追加） ──
+# 値の指定は worker の環境変数名で行う（例: SECRET_VALUE_SUPABASE_URL）。
+# 実 Secret 名は環境サフィックス付き（例: SUPABASE_URL_STAGING）に分離して衝突を防ぐ。
+for ev in "${SECRET_ENV_VARS[@]}"; do
+  s="${ev}${SECRET_SUFFIX}"
   if gcloud secrets describe "$s" --project "$PROJECT_ID" >/dev/null 2>&1; then
     log "secret '$s' は既存（コンテナ skip）"
   else
@@ -77,8 +110,8 @@ for s in "${SECRETS[@]}"; do
     gcloud secrets create "$s" \
       --replication-policy="automatic" --project "$PROJECT_ID"
   fi
-  # 値はスクリプトに埋め込まず env から（あれば）。SECRET_VALUE_SUPABASE_URL など。
-  val_var="SECRET_VALUE_${s}"
+  # 値はスクリプトに埋め込まず env から（あれば）。キーは環境変数名で統一: SECRET_VALUE_SUPABASE_URL など。
+  val_var="SECRET_VALUE_${ev}"
   val="${!val_var:-}"
   if [[ -n "$val" ]]; then
     log "secret '$s' に新しい version を追加"
@@ -86,7 +119,7 @@ for s in "${SECRETS[@]}"; do
       --data-file=- --project "$PROJECT_ID" >/dev/null
   elif ! gcloud secrets versions list "$s" \
     --project "$PROJECT_ID" --format="value(name)" 2>/dev/null | grep -q .; then
-    echo "  ⚠ secret '$s' に値が未登録です。SECRET_VALUE_${s} を設定して再実行するか、" \
+    echo "  ⚠ secret '$s' に値が未登録です。SECRET_VALUE_${ev} を設定して再実行するか、" \
       "手動で 'gcloud secrets versions add $s --data-file=-' で値を入れてください。" >&2
   fi
 done
@@ -132,13 +165,20 @@ else
       -f "${REPO_ROOT}/worker/Dockerfile" -t "$WORKER_IMAGE" "$REPO_ROOT"
     docker push "$WORKER_IMAGE"
   fi
+  # env 変数名（固定）→ 環境別 Secret 名（接尾辞付き）のマッピングを組み立てる。
+  set_secrets=""
+  for ev in "${SECRET_ENV_VARS[@]}"; do
+    set_secrets+="${ev}=${ev}${SECRET_SUFFIX}:latest,"
+  done
+  set_secrets="${set_secrets%,}"
   log "Job '$JOB' を作成（batch 向け: tasks=1 / parallelism=1 / retry=1 / timeout=3600s）"
+  log "  --set-secrets ${set_secrets}"
   gcloud run jobs create "$JOB" \
     --image "$WORKER_IMAGE" \
     --region "$REGION" \
     --project "$PROJECT_ID" \
     --service-account "$RUNTIME_SA" \
-    --set-secrets "SUPABASE_URL=SUPABASE_URL:latest,SUPABASE_SECRET_KEY=SUPABASE_SECRET_KEY:latest,AI_GATEWAY_API_KEY=AI_GATEWAY_API_KEY:latest" \
+    --set-secrets "$set_secrets" \
     --max-retries 1 \
     --task-timeout 3600 \
     --tasks 1 \


### PR DESCRIPTION
## 背景
Secret Manager は **GCPプロジェクトでグローバル（名前が一意）**。同一プロジェクトに staging / production を同居させる構成で、`provision.sh` が固定 Secret 名（`SUPABASE_URL` 等）を使っていたため、**ある環境向けに再実行すると他環境のシークレットを上書き**してしまう問題があった（実際に prod の provision で staging のシークレットが prod 値に置き換わり、staging worker が本番DBを指す事故が発生）。`GCP_TOPIC_ANALYSIS_JOB` で Job 名を分けても、Secret は名前で共有されるため分離されない。

## 変更
- **`DEPLOY_ENV` を必須化**。未指定はエラー停止（環境跨ぎの上書き事故を防ぐ）。
- **Secret 名と Job 名を環境ごとに分離**:
  - Secret: `SUPABASE_URL` → `SUPABASE_URL_<DEPLOY_ENV 大文字>`（例 `SUPABASE_URL_STAGING`）
  - Job 既定: `topic-analysis-worker-<DEPLOY_ENV>`
  - worker が読む **環境変数名は固定**のまま、Job の `--set-secrets` が環境別 Secret にマッピング（`SUPABASE_URL=SUPABASE_URL_STAGING:latest`）。worker コードは不変。
- **`CONFIG_FILE`** で環境別設定ファイル（`config.env.<env>`）を読み込めるように。
- **`.gitignore` を `config.env*` に拡張**（`config.env.staging` 等の実値ファイルの誤コミット防止）。
- **`deploy_worker.yml`** の既定 Job 名を環境別（`topic-analysis-worker-production` / `-staging`）に整合（旧既定の `topic-analysis-worker` のままだと、新 Job 名と不一致で `gcloud run jobs update` が `NOT_FOUND` になるため）。別名運用時は各 Environment の Secret `GCP_TOPIC_ANALYSIS_JOB` で上書き。
- README / config.example を更新（環境分離の理屈・CONFIG_FILE 運用・SA 共有の注意）。

## 動作確認
- `bash -n`（構文）通過。
- `DEPLOY_ENV` 未指定でエラー停止することを確認。
- 変数導出を確認: `DEPLOY_ENV=staging` → Job `topic-analysis-worker-staging` / Secret `*_STAGING` / `--set-secrets SUPABASE_URL=SUPABASE_URL_STAGING:latest,...`。
- `.gitignore` 拡張で `config.env.staging` が ignore されることを確認（`git check-ignore`）。

## 補足（要相談・本PRスコープ外）
- **サービスアカウントは既定で環境共有**（runtime SA が `*_STAGING`/`*_PRODUCTION` 双方の Secret にアクセス可能）。IAM まで環境分離したい場合は `RUNTIME_SA_NAME`/`INVOKER_SA_NAME`/`DEPLOYER_SA_NAME` を環境別名で上書き可能にしてある（README に明記）。既存 prod の SA 張り替えを伴うため、完全分離するかは別途判断。
- 既存の prod Job 名が `topic-analysis-worker-prod` 等、上記既定（`-production`）と異なる場合は、各 GitHub Environment の `GCP_TOPIC_ANALYSIS_JOB` Secret を実 Job 名に合わせて設定すること。

🤖 Generated with [Claude Code](https://claude.com/claude-code)