### PR TITLE
admin: 全議案トピック分析ページ＋差分実行 (PR②/増分トピック分析)

### DIFF
--- a/admin/src/app/(protected)/layout/navigation-links.tsx
+++ b/admin/src/app/(protected)/layout/navigation-links.tsx
@@ -11,6 +11,7 @@ const navigationLinks = [
   { href: routes.dietSessions(), label: "国会会期管理" },
   { href: routes.tags(), label: "タグ管理" },
   { href: routes.interviews(), label: "インタビュー" },
+  { href: routes.userTopicAnalysisAll(), label: "全議案トピック分析" },
   { href: routes.experts(), label: "有識者" },
   { href: routes.admins(), label: "管理者" },
 ];

--- a/admin/src/app/(protected)/user-topic-analysis/page.tsx
+++ b/admin/src/app/(protected)/user-topic-analysis/page.tsx
@@ -1,0 +1,29 @@
+import { redirect } from "next/navigation";
+import { getCurrentAdmin } from "@/features/auth/server/lib/auth-server";
+import { AllBillsAnalysisRunner } from "@/features/user-topic-analysis/client/components/all-bills-analysis-runner";
+import { routes } from "@/lib/routes";
+
+export default async function AllBillsUserTopicAnalysisPage() {
+  const currentAdmin = await getCurrentAdmin();
+
+  if (!currentAdmin) {
+    redirect(routes.login());
+  }
+
+  return (
+    <div className="container mx-auto py-8">
+      <h1 className="text-2xl font-bold mb-2">全議案トピック分析</h1>
+      <p className="mb-2 text-sm text-muted-foreground">
+        すべての議案を対象にユーザー向けトピック分析を実行します。差分追加（増分）では、各議案で新しく増えた意見だけを抽出して既存トピックへ追加するため低コストです。
+      </p>
+      <p className="mb-8 text-sm text-muted-foreground">
+        ※
+        全議案を順次処理するため完了まで時間がかかります。実行中（処理が完了するまで）は再実行しないでください。個別議案の結果は各議案のトピック分析ページで確認できます。
+      </p>
+
+      <section className="rounded-lg border bg-card p-6">
+        <AllBillsAnalysisRunner />
+      </section>
+    </div>
+  );
+}

--- a/admin/src/app/api/user-topic-analysis/dispatch-all/route.ts
+++ b/admin/src/app/api/user-topic-analysis/dispatch-all/route.ts
@@ -1,0 +1,60 @@
+import { requireAdmin } from "@/features/auth/server/lib/auth-server";
+import { executeTopicAnalysisJob } from "@/lib/cloud-run-job";
+
+export const maxDuration = 60;
+
+const json = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+
+/**
+ * 全議案トピック分析の手動実行入口（Admin）。
+ * version は worker 側で議案ごとに作成するため、ここでは Cloud Run Job を起動するだけ。
+ * 既定は incremental（差分）。1 実行で全議案を順次処理する。
+ */
+export async function POST(request: Request) {
+  try {
+    await requireAdmin();
+  } catch {
+    return json({ error: "Unauthorized" }, 401);
+  }
+
+  // ボディは任意（空なら既定 incremental）。空文字以外は JSON として厳密に検証し、
+  // 不正な JSON は高コストな副作用の前に 400 で弾く（握り潰して既定実行しない）。
+  let strategy: "full" | "incremental" = "incremental";
+  const text = await request.text();
+  if (text.trim() !== "") {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      return json({ error: "Invalid JSON body" }, 400);
+    }
+    if (typeof parsed !== "object" || parsed === null) {
+      return json({ error: "Invalid JSON body" }, 400);
+    }
+    const raw = (parsed as { strategy?: unknown }).strategy;
+    if (raw !== undefined) {
+      if (raw !== "full" && raw !== "incremental") {
+        return json({ error: "strategy must be 'full' or 'incremental'" }, 400);
+      }
+      strategy = raw;
+    }
+  }
+
+  try {
+    await executeTopicAnalysisJob([
+      "--mode=analyze-all",
+      `--strategy=${strategy}`,
+    ]);
+    return json({ started: true, strategy });
+  } catch (error) {
+    console.error("[UserTopicAnalysis] dispatch-all failed:", error);
+    return json(
+      { error: error instanceof Error ? error.message : "dispatch failed" },
+      502
+    );
+  }
+}

--- a/admin/src/app/api/user-topic-analysis/dispatch/route.ts
+++ b/admin/src/app/api/user-topic-analysis/dispatch/route.ts
@@ -28,16 +28,23 @@ export async function POST(request: Request) {
   }
 
   let billId: string;
+  let strategy: "full" | "incremental" = "full";
   try {
     const body: unknown = await request.json();
-    const rawBillId =
+    const obj =
       typeof body === "object" && body !== null
-        ? (body as { billId?: unknown }).billId
-        : undefined;
-    if (typeof rawBillId !== "string" || rawBillId.trim() === "") {
+        ? (body as { billId?: unknown; strategy?: unknown })
+        : {};
+    if (typeof obj.billId !== "string" || obj.billId.trim() === "") {
       return json({ error: "billId is required" }, 400);
     }
-    billId = rawBillId.trim();
+    billId = obj.billId.trim();
+    if (obj.strategy !== undefined) {
+      if (obj.strategy !== "full" && obj.strategy !== "incremental") {
+        return json({ error: "strategy must be 'full' or 'incremental'" }, 400);
+      }
+      strategy = obj.strategy;
+    }
   } catch {
     return json({ error: "Invalid JSON body" }, 400);
   }
@@ -77,6 +84,7 @@ export async function POST(request: Request) {
         "--mode=analyze",
         `--bill-id=${billId}`,
         `--version-id=${version.id}`,
+        `--strategy=${strategy}`,
       ]);
     } catch (triggerError) {
       // ジョブ起動に失敗した場合は version を failed にして残骸（pending のまま）を防ぐ。

--- a/admin/src/features/user-topic-analysis/client/components/all-bills-analysis-runner.tsx
+++ b/admin/src/features/user-topic-analysis/client/components/all-bills-analysis-runner.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { CheckCircle2, Loader2, Play } from "lucide-react";
+import { useCallback, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+type AnalysisStrategy = "full" | "incremental";
+
+/**
+ * 全議案トピック分析の実行ボタン。
+ * 1 ジョブで全議案を順次処理するため進捗は粗く、起動の成否のみ表示する
+ * （詳細は各議案のトピック分析ページで確認する）。
+ */
+export function AllBillsAnalysisRunner() {
+  const [strategy, setStrategy] = useState<AnalysisStrategy>("incremental");
+  const [isStarting, setIsStarting] = useState(false);
+  const [started, setStarted] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleRun = useCallback(async () => {
+    setError(null);
+    setStarted(false);
+    setIsStarting(true);
+    try {
+      const res = await fetch("/api/user-topic-analysis/dispatch-all", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ strategy }),
+      });
+      if (!res.ok) {
+        const data = (await res.json().catch(() => ({}))) as {
+          error?: string;
+        };
+        throw new Error(data.error ?? `実行開始に失敗しました (${res.status})`);
+      }
+      setStarted(true);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "実行開始に失敗しました");
+    } finally {
+      setIsStarting(false);
+    }
+  }, [strategy]);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-1">
+        <Label htmlFor="all-bills-strategy" className="text-sm">
+          実行方式
+        </Label>
+        <Select
+          value={strategy}
+          onValueChange={(v) => setStrategy(v as AnalysisStrategy)}
+          disabled={isStarting}
+        >
+          <SelectTrigger id="all-bills-strategy" className="w-96">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="incremental">
+              差分追加（新規意見のみ・低コスト・推奨）
+            </SelectItem>
+            <SelectItem value="full">
+              フル再分析（全意見を再抽出・高コスト）
+            </SelectItem>
+          </SelectContent>
+        </Select>
+        <p className="text-xs text-muted-foreground">
+          差分追加:
+          各議案で「まだ抽出されていない新規意見」だけを抽出し、既存トピックへ追加します。新規意見が無い議案はスキップします。
+        </p>
+      </div>
+
+      {/* 起動後はボタンを無効化し、同一ページからの多重起動（全議案の重複分析・コスト増）を防ぐ。
+          再実行したい場合はページを再読み込みする。 */}
+      <Button
+        onClick={handleRun}
+        disabled={isStarting || started}
+        className="w-fit"
+      >
+        {isStarting ? (
+          <Loader2 className="size-4 animate-spin" />
+        ) : (
+          <Play className="size-4" />
+        )}
+        全議案トピック分析を実行
+      </Button>
+
+      {started && (
+        <p className="flex items-center gap-2 text-sm text-green-700">
+          <CheckCircle2 className="size-4" />
+          実行を開始しました。全議案を順次処理するため完了まで時間がかかります。多重起動を避けるため、完了前の再実行は控えてください（再実行する場合はページを再読み込み）。進捗は各議案のトピック分析ページで確認してください。
+        </p>
+      )}
+      {error && <p className="text-sm text-red-600">{error}</p>}
+    </div>
+  );
+}

--- a/admin/src/features/user-topic-analysis/client/components/run-analysis-button.tsx
+++ b/admin/src/features/user-topic-analysis/client/components/run-analysis-button.tsx
@@ -4,6 +4,16 @@ import { Loader2, Play } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+type AnalysisStrategy = "full" | "incremental";
 
 type VersionStatus = {
   status: "pending" | "running" | "completed" | "failed";
@@ -24,6 +34,7 @@ const STEP_LABEL: Record<string, string> = {
 export function RunAnalysisButton({ billId }: { billId: string }) {
   const router = useRouter();
   const [isRunning, setIsRunning] = useState(false);
+  const [strategy, setStrategy] = useState<AnalysisStrategy>("full");
   const [step, setStep] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const pollingRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -82,7 +93,7 @@ export function RunAnalysisButton({ billId }: { billId: string }) {
       const res = await fetch("/api/user-topic-analysis/dispatch", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ billId }),
+        body: JSON.stringify({ billId, strategy }),
       });
       if (!res.ok) throw new Error(`実行開始に失敗しました (${res.status})`);
       const data = (await res.json()) as { versionId?: string };
@@ -92,10 +103,30 @@ export function RunAnalysisButton({ billId }: { billId: string }) {
       setIsRunning(false);
       setError(e instanceof Error ? e.message : "実行開始に失敗しました");
     }
-  }, [billId, poll]);
+  }, [billId, strategy, poll]);
 
   return (
     <div className="flex flex-col gap-2">
+      <div className="flex flex-col gap-1">
+        <Label htmlFor="analysis-strategy" className="text-xs text-gray-500">
+          実行方式
+        </Label>
+        <Select
+          value={strategy}
+          onValueChange={(v) => setStrategy(v as AnalysisStrategy)}
+          disabled={isRunning}
+        >
+          <SelectTrigger id="analysis-strategy" className="w-72">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="full">フル再分析（全意見を再抽出）</SelectItem>
+            <SelectItem value="incremental">
+              差分追加（新規意見のみ・低コスト）
+            </SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
       <Button onClick={handleRun} disabled={isRunning} className="w-fit">
         {isRunning ? (
           <Loader2 className="size-4 animate-spin" />

--- a/admin/src/lib/routes.ts
+++ b/admin/src/lib/routes.ts
@@ -17,6 +17,7 @@ export const routes = {
   experts: () => "/experts" as const,
   interviews: () => "/interviews" as const,
   interviewOpinionBackfill: () => "/interview-opinion-backfill" as const,
+  userTopicAnalysisAll: () => "/user-topic-analysis" as const,
 
   // ── 議案配下 ──────────────────────────────────────
   billEdit: (billId: string) => `/bills/${billId}/edit` as const,


### PR DESCRIPTION
## 概要
増分トピック分析の **admin UI（PR②）**。PR① (#850, core+worker) の上に積む（base = `docs-incremental-topic-analysis`。#850 マージ後に develop へ retarget）。

## 変更
- **per-bill**: トピック分析実行ボタンに**実行方式（フル再分析／差分追加）**の選択を追加。dispatch に `strategy` を渡す。
- **dispatch API**: `/api/user-topic-analysis/dispatch` が `strategy`（full|incremental、既定 full＝後方互換）を受け取り `--strategy=` を worker へ渡す。
- **全議案 API**: `/api/user-topic-analysis/dispatch-all` を新設。`--mode=analyze-all --strategy=`（既定 incremental）で Cloud Run Job を起動。
- **全議案ページ** `/user-topic-analysis`: 差分/フルを選んで「全議案トピック分析を実行」。バックフィルページに倣う。
- routes / ナビゲーションにエントリ追加。

## Codex 指摘対応
- **P2**: `dispatch-all` は空ボディのみ既定許容し、不正 JSON は 400 で弾く（高コストな副作用前に検証）。
- **P1（多重起動）**: 起動後はボタンを無効化し、同一ページからの再起動を抑止（ページ再読込で再実行可）。ページにも「実行中は再実行しない」注記。
  - ※ サーバー側の厳密な全議案ロック（Cloud Run 実行の重複検出）は未実装。per-bill の `one_active_version_per_bill` ＋ incremental のウォーターマーク自己制限＋UI抑止で実務上の重複コストは限定的。完全なロックは別途検討（バックフィルページにも厳密ロックは無い）。

## 動作確認
- admin typecheck / routes.test / 変更ファイル lint 通過。
- UIスクリーンショットは別途添付。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 全議案トピック分析機能を追加しました。管理画面から複数議案のトピック分析を一括実行できます。
  * 分析方式として「full」（全議案を再分析）と「incremental」（差分のみ）の2つのモードから選択できるようになりました。
  * 管理ナビゲーションに新しい分析実行オプションを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->