### PR TITLE
全議案トピック分析の進捗ログ（議案ごと開始/終了・i/total）

### DIFF
--- a/packages/topic-analysis-core/src/analyze.ts
+++ b/packages/topic-analysis-core/src/analyze.ts
@@ -251,18 +251,28 @@ export async function runAnalyzeAll(
   strategy: AnalysisStrategy = "incremental"
 ): Promise<void> {
   const billIds = await listAllBillIds();
+  const total = billIds.length;
   console.log(
-    `[topic-analysis] start analyze-all bills=${billIds.length} strategy=${strategy}`
+    `[topic-analysis] start analyze-all bills=${total} strategy=${strategy}`
   );
   let analyzed = 0;
   let skipped = 0;
   let failed = 0;
 
-  for (const billId of billIds) {
+  for (let i = 0; i < total; i++) {
+    const billId = billIds[i];
+    // 全体進捗（何件目／全何件）と議案ごとの開始・終了をログに出す。
+    const progress = `${i + 1}/${total}`;
+    console.log(
+      `[topic-analysis] analyze-all (${progress}) start bill=${billId}`
+    );
     try {
       const targets = await fetchTargetOpinions(billId);
       if (targets.length === 0) {
         skipped++;
+        console.log(
+          `[topic-analysis] analyze-all (${progress}) skip bill=${billId} (対象意見なし)`
+        );
         continue;
       }
       if (strategy === "incremental") {
@@ -272,6 +282,9 @@ export async function runAnalyzeAll(
         // 既に分析済みで新規意見が無ければ何もしない。
         if (hasCompleted && !hasNew) {
           skipped++;
+          console.log(
+            `[topic-analysis] analyze-all (${progress}) skip bill=${billId} (新規意見なし)`
+          );
           continue;
         }
       }
@@ -284,15 +297,21 @@ export async function runAnalyzeAll(
       if (!version) {
         // 実行中/保留中の版が既にある（one_active_version_per_bill）。
         skipped++;
+        console.log(
+          `[topic-analysis] analyze-all (${progress}) skip bill=${billId} (実行中の版あり)`
+        );
         continue;
       }
       await runAnalysis(version.id, billId, strategy);
       analyzed++;
+      console.log(
+        `[topic-analysis] analyze-all (${progress}) done bill=${billId} version=${version.id}`
+      );
     } catch (error) {
       failed++;
       const message = error instanceof Error ? error.message : "unknown error";
       console.error(
-        `[topic-analysis] analyze-all bill=${billId} failed: ${message}`
+        `[topic-analysis] analyze-all (${progress}) failed bill=${billId}: ${message}`
       );
     }
   }


### PR DESCRIPTION
## 概要
`runAnalyzeAll`（全議案トピック分析）に、**議案ごとの開始・終了ログと全体進捗（i/total）** を追加。長時間ジョブの進み具合をログで追えるようにする。

## 変更
- 各議案の処理前に `analyze-all (i/total) start bill=...` を出力。
- 各議案の結果を出力:
  - 完了: `analyze-all (i/total) done bill=... version=...`
  - スキップ: `analyze-all (i/total) skip bill=... (対象意見なし | 新規意見なし | 実行中の版あり)`
  - 失敗: `analyze-all (i/total) failed bill=...: <reason>`
- ループを index 付きに変更（進捗表示のため）。ロジック・挙動は不変（console出力の追加のみ）。

## テスト
- `@mirai-gikai/topic-analysis-core` typecheck / 50 tests・worker typecheck 通過（ログのみの変更）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * 分析処理の進捗ログを強化しました。処理対象の進捗状況（件数表示）がより詳しく出力されるようになります。
  * スキップ理由や完了情報などの詳細ログが追加され、処理状況の可視化が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->