### PR TITLE
全議案トピック分析を隠し機能化（ヘッダーナビから除外）

### DIFF
--- a/admin/src/app/(protected)/layout/navigation-links.tsx
+++ b/admin/src/app/(protected)/layout/navigation-links.tsx
@@ -11,7 +11,7 @@ const navigationLinks = [
   { href: routes.dietSessions(), label: "国会会期管理" },
   { href: routes.tags(), label: "タグ管理" },
   { href: routes.interviews(), label: "インタビュー" },
-  { href: routes.userTopicAnalysisAll(), label: "全議案トピック分析" },
+  // 全議案トピック分析(/user-topic-analysis)は隠し機能のためヘッダーに出さない（URL直アクセスのみ）。
   { href: routes.experts(), label: "有識者" },
   { href: routes.admins(), label: "管理者" },
 ];


### PR DESCRIPTION
## 概要
全議案トピック分析ページを**隠し機能**にするため、admin ヘッダーのナビゲーションから「全議案トピック分析」リンクを除去する。意見再抽出バックフィルページと同様、**URL直アクセス（`/user-topic-analysis`）のみ**で利用可能な状態にする。

## 変更
- `navigation-links.tsx` から該当エントリを削除（コメントで隠し機能である旨を明記）。
- ページ本体・API・ルート定義（`routes.userTopicAnalysisAll`）は維持（routes.test の page↔route 整合のため）。

## テスト
- admin typecheck / routes.test / lint 通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)