### PR TITLE
全議案トピック分析ログ: bill_id ではなく議案タイトルを表示

### DIFF
--- a/packages/topic-analysis-core/src/analyze.ts
+++ b/packages/topic-analysis-core/src/analyze.ts
@@ -4,7 +4,7 @@ import {
   fetchTargetOpinions,
   finalizeVersion,
   getTopicsWithOpinions,
-  listAllBillIds,
+  listAllBills,
   listVersionsByBill,
   loadProgress,
   markOpinionsExtracted,
@@ -250,8 +250,8 @@ export async function runAnalysis(
 export async function runAnalyzeAll(
   strategy: AnalysisStrategy = "incremental"
 ): Promise<void> {
-  const billIds = await listAllBillIds();
-  const total = billIds.length;
+  const bills = await listAllBills();
+  const total = bills.length;
   console.log(
     `[topic-analysis] start analyze-all bills=${total} strategy=${strategy}`
   );
@@ -260,18 +260,18 @@ export async function runAnalyzeAll(
   let failed = 0;
 
   for (let i = 0; i < total; i++) {
-    const billId = billIds[i];
-    // 全体進捗（何件目／全何件）と議案ごとの開始・終了をログに出す。
+    const { id: billId, name } = bills[i];
+    // 全体進捗（何件目／全何件）と議案ごとの開始・終了をログに出す（議案はタイトルで表示）。
     const progress = `${i + 1}/${total}`;
     console.log(
-      `[topic-analysis] analyze-all (${progress}) start bill=${billId}`
+      `[topic-analysis] analyze-all (${progress}) start 議案=${name}`
     );
     try {
       const targets = await fetchTargetOpinions(billId);
       if (targets.length === 0) {
         skipped++;
         console.log(
-          `[topic-analysis] analyze-all (${progress}) skip bill=${billId} (対象意見なし)`
+          `[topic-analysis] analyze-all (${progress}) skip 議案=${name} (対象意見なし)`
         );
         continue;
       }
@@ -283,7 +283,7 @@ export async function runAnalyzeAll(
         if (hasCompleted && !hasNew) {
           skipped++;
           console.log(
-            `[topic-analysis] analyze-all (${progress}) skip bill=${billId} (新規意見なし)`
+            `[topic-analysis] analyze-all (${progress}) skip 議案=${name} (新規意見なし)`
           );
           continue;
         }
@@ -298,25 +298,25 @@ export async function runAnalyzeAll(
         // 実行中/保留中の版が既にある（one_active_version_per_bill）。
         skipped++;
         console.log(
-          `[topic-analysis] analyze-all (${progress}) skip bill=${billId} (実行中の版あり)`
+          `[topic-analysis] analyze-all (${progress}) skip 議案=${name} (実行中の版あり)`
         );
         continue;
       }
       await runAnalysis(version.id, billId, strategy);
       analyzed++;
       console.log(
-        `[topic-analysis] analyze-all (${progress}) done bill=${billId} version=${version.id}`
+        `[topic-analysis] analyze-all (${progress}) done 議案=${name} version=${version.id}`
       );
     } catch (error) {
       failed++;
       const message = error instanceof Error ? error.message : "unknown error";
       console.error(
-        `[topic-analysis] analyze-all (${progress}) failed bill=${billId}: ${message}`
+        `[topic-analysis] analyze-all (${progress}) failed 議案=${name}: ${message}`
       );
     }
   }
 
   console.log(
-    `[topic-analysis] analyze-all done: analyzed=${analyzed} skipped=${skipped} failed=${failed} (bills=${billIds.length}) strategy=${strategy}`
+    `[topic-analysis] analyze-all done: analyzed=${analyzed} skipped=${skipped} failed=${failed} (bills=${total}) strategy=${strategy}`
   );
 }

--- a/packages/topic-analysis-core/src/repositories/analysis-repository.ts
+++ b/packages/topic-analysis-core/src/repositories/analysis-repository.ts
@@ -79,14 +79,16 @@ export async function markOpinionsExtracted(
   }
 }
 
-/** 全議案の id 一覧を取得する（全議案トピック分析の対象列挙用）。 */
-export async function listAllBillIds(): Promise<string[]> {
+/** 全議案の id・タイトルを取得する（全議案トピック分析の対象列挙・ログ表示用）。 */
+export async function listAllBills(): Promise<
+  Array<{ id: string; name: string }>
+> {
   const supabase = createAdminClient();
-  const { data, error } = await supabase.from("bills").select("id");
+  const { data, error } = await supabase.from("bills").select("id, name");
   if (error) {
     throw new Error(`Failed to list bills: ${error.message}`);
   }
-  return (data ?? []).map((b) => b.id);
+  return (data ?? []).map((b) => ({ id: b.id, name: b.name }));
 }
 
 /** 議案コンテキスト（プロンプト接地用）を取得する。本文は bill_contents（normal）から。 */


### PR DESCRIPTION
## 概要
全議案トピック分析（`runAnalyzeAll`）の進捗ログで、議案を **bill_id ではなく議案タイトル** で表示する。#852（進捗ログ i/total）のフォローアップ。

## 変更
- `listAllBillIds()`（id配列）→ `listAllBills()`（`{id, name}` 配列）に変更し、`bills` の `name` も取得。
- analyze-all のログを `bill=<uuid>` → `議案=<タイトル>` に変更（start / done / skip / failed すべて）。
- ロジック・挙動は不変（ログ表示のみ）。

## テスト
- `@mirai-gikai/topic-analysis-core` typecheck / 50 tests 通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 提案分析プロセスのログメッセージを改善。提案の識別表示がより詳細になり、処理の進行状況（完了、スキップ、失敗など）の報告がわかりやすくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->