### PR TITLE
トピック分析の対象意見取得を全件化（1000行上限の取りこぼし解消）

### DIFF
--- a/packages/topic-analysis-core/src/repositories/analysis-repository.ts
+++ b/packages/topic-analysis-core/src/repositories/analysis-repository.ts
@@ -15,49 +15,86 @@ type VersionStatus = "pending" | "running" | "completed" | "failed";
  * → interview_sessions → interview_configs(bill_id) を辿る。
  * 管理者公開・ユーザー公開の両方に同意済みで、かつモデレーションOKの意見のみ分析対象とする。
  */
-export async function fetchTargetOpinions(
-  billId: string
-): Promise<TargetOpinion[]> {
-  const supabase = createAdminClient();
-  const { data, error } = await supabase
-    .from("interview_opinion")
-    .select(
-      `id, opinion_index, title, content, contextual_quote, bill_sentiment, richness, topic_extracted_at, interview_report_id,
+/**
+ * 1回の取得で読むページ幅。Supabase/PostgREST の既定行数上限（1000）に依存せず
+ * 全件取得するため、この幅でページネーションする。1000 未満の安全な値にする。
+ */
+const TARGET_OPINIONS_PAGE_SIZE = 500;
+
+const TARGET_OPINIONS_SELECT = `id, opinion_index, title, content, contextual_quote, bill_sentiment, richness, topic_extracted_at, interview_report_id,
        interview_report!inner(
          is_public_by_admin, is_public_by_user, moderation_status, role,
          interview_sessions!inner(
            interview_configs!inner(bill_id)
          )
-       )`
-    )
-    .eq("interview_report.is_public_by_admin", true)
-    .eq("interview_report.is_public_by_user", true)
-    .eq("interview_report.moderation_status", "ok")
-    .eq("interview_report.interview_sessions.interview_configs.bill_id", billId)
-    .order("interview_report_id", { ascending: true })
-    .order("opinion_index", { ascending: true });
+       )`;
 
-  if (error) {
-    throw new Error(`Failed to fetch target opinions: ${error.message}`);
+export async function fetchTargetOpinions(
+  billId: string
+): Promise<TargetOpinion[]> {
+  const supabase = createAdminClient();
+  const all: TargetOpinion[] = [];
+
+  // keyset(カーソル)ページネーション。(interview_report_id, opinion_index) は一意なので、
+  // 「直前ページ末尾より後ろ」を順に読む。offset 方式と違い、取得中に新規意見が挿入されても
+  // 既読行のズレ（重複・取りこぼし）が起きない（report_id はランダム UUID のため offset では危険）。
+  let cursor: { reportId: string; opinionIndex: number } | null = null;
+
+  for (;;) {
+    let query = supabase
+      .from("interview_opinion")
+      .select(TARGET_OPINIONS_SELECT)
+      .eq("interview_report.is_public_by_admin", true)
+      .eq("interview_report.is_public_by_user", true)
+      .eq("interview_report.moderation_status", "ok")
+      .eq(
+        "interview_report.interview_sessions.interview_configs.bill_id",
+        billId
+      )
+      .order("interview_report_id", { ascending: true })
+      .order("opinion_index", { ascending: true })
+      .limit(TARGET_OPINIONS_PAGE_SIZE);
+
+    if (cursor) {
+      // (report_id, opinion_index) > (cursor) をタプル比較で表現する。
+      query = query.or(
+        `interview_report_id.gt.${cursor.reportId},and(interview_report_id.eq.${cursor.reportId},opinion_index.gt.${cursor.opinionIndex})`
+      );
+    }
+
+    const { data, error } = await query;
+    if (error) {
+      throw new Error(`Failed to fetch target opinions: ${error.message}`);
+    }
+
+    const rows = data ?? [];
+    for (const row of rows) {
+      const report = row.interview_report as unknown as {
+        role: string | null;
+      };
+      all.push({
+        opinion_id: row.id,
+        interview_report_id: row.interview_report_id,
+        opinion_index: row.opinion_index,
+        title: row.title,
+        content: row.content,
+        contextual_quote: row.contextual_quote,
+        bill_sentiment: row.bill_sentiment,
+        role: report?.role ?? null,
+        richness: row.richness ?? null,
+        topic_extracted_at: row.topic_extracted_at ?? null,
+      });
+    }
+
+    if (rows.length < TARGET_OPINIONS_PAGE_SIZE) break;
+    const last = rows[rows.length - 1];
+    cursor = {
+      reportId: last.interview_report_id,
+      opinionIndex: last.opinion_index,
+    };
   }
 
-  return (data ?? []).map((row) => {
-    const report = row.interview_report as unknown as {
-      role: string | null;
-    };
-    return {
-      opinion_id: row.id,
-      interview_report_id: row.interview_report_id,
-      opinion_index: row.opinion_index,
-      title: row.title,
-      content: row.content,
-      contextual_quote: row.contextual_quote,
-      bill_sentiment: row.bill_sentiment,
-      role: report?.role ?? null,
-      richness: row.richness ?? null,
-      topic_extracted_at: row.topic_extracted_at ?? null,
-    };
-  });
+  return all;
 }
 
 /**

--- a/tests/supabase/fetch-target-opinions.test.ts
+++ b/tests/supabase/fetch-target-opinions.test.ts
@@ -1,0 +1,80 @@
+import { fetchTargetOpinions } from "@mirai-gikai/topic-analysis-core/repository";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  adminClient,
+  cleanupTestBill,
+  cleanupTestUser,
+  createTestBill,
+  createTestUser,
+  type TestUser,
+} from "./utils";
+
+// Supabase/PostgREST の既定行数上限（1000）を超えても全件取得できることを検証する。
+const OPINION_COUNT = 1001;
+
+let user: TestUser;
+let billId: string;
+
+describe("fetchTargetOpinions ページネーション統合テスト", () => {
+  beforeAll(async () => {
+    user = await createTestUser();
+    const bill = await createTestBill();
+    billId = bill.id;
+
+    const { data: config } = await adminClient
+      .from("interview_configs")
+      .insert({ bill_id: billId, status: "public", name: "fetch-page-test" })
+      .select()
+      .single();
+    if (!config) throw new Error("config insert failed");
+
+    const { data: session } = await adminClient
+      .from("interview_sessions")
+      .insert({
+        interview_config_id: config.id,
+        user_id: user.id,
+        started_at: new Date().toISOString(),
+        completed_at: new Date().toISOString(),
+      })
+      .select()
+      .single();
+    if (!session) throw new Error("session insert failed");
+
+    // §8 フィルタ（管理者公開・ユーザー公開・モデレーションOK）を通すレポート。
+    const { data: report } = await adminClient
+      .from("interview_report")
+      .insert({
+        interview_session_id: session.id,
+        is_public_by_user: true,
+        is_public_by_admin: true,
+        moderation_score: 5,
+        role: "general_citizen",
+        summary: "s",
+      })
+      .select()
+      .single();
+    if (!report) throw new Error("report insert failed");
+
+    const rows = Array.from({ length: OPINION_COUNT }, (_, i) => ({
+      interview_report_id: report.id,
+      opinion_index: i,
+      title: `意見${i}`,
+      content: `内容${i}`,
+    }));
+    const { error } = await adminClient.from("interview_opinion").insert(rows);
+    if (error) throw new Error(`opinion bulk insert failed: ${error.message}`);
+  });
+
+  afterAll(async () => {
+    await cleanupTestBill(billId);
+    await cleanupTestUser(user.id);
+  });
+
+  it("対象意見が1000件を超えても全件取得する（既定上限で切れない）", async () => {
+    const opinions = await fetchTargetOpinions(billId);
+    expect(opinions.length).toBe(OPINION_COUNT);
+    // opinion_index の取りこぼし・重複が無いこと（0..OPINION_COUNT-1 が一意に揃う）。
+    const indices = new Set(opinions.map((o) => o.opinion_index));
+    expect(indices.size).toBe(OPINION_COUNT);
+  });
+});


### PR DESCRIPTION
## 概要
トピック分析の対象意見取得 `fetchTargetOpinions` が **Supabase/PostgREST の既定行数上限(1000)** により**先頭1000件しか取得できず、対象意見が1000件超の議案は残りが黙って分析対象から欠落**していた。これを **keyset ページネーション** で全件取得するよう修正する。

## 背景・実測
ローカルで単発selectの返却を確認:
```
returned data.length = 1000   ← 実際に返った件数（既定上限で頭打ち）
exact count          = 2901   ← 本当の件数
```
- 取得順は `(interview_report_id, opinion_index)`。1000件を超える議案は**常に先頭1000件だけ**を分析し、それ以降の意見は分析・割当・トピック生成に一切載らない。
- 増分(incremental)でも `topic_extracted_at` 判定が先頭1000件に限られ、**1000件目以降に死角**ができていた。
- 議案ごとのトピック数が母数とちぐはぐだった一因（大規模議案ほど頭打ち）。

## 変更
- `fetchTargetOpinions` を **keyset(カーソル)ページネーション**化（`(interview_report_id, opinion_index)` の「直前ページ末尾より後ろ」を順に読む、500件/ページ）。
  - offset 方式は、取得中に新規意見が挿入されるとランダムUUIDキーでズレて**重複/取りこぼし**が起きるため不採用（Codex指摘 P2 対応）。keyset なら既読行はズレない。
- 統合テスト追加: 1001件の対象意見を**全件取得**でき、index に重複・欠落が無いこと。

## テスト
- `@mirai-gikai/topic-analysis-core` typecheck / 50 unit / 統合テスト（fetch-target-opinions）通過。

## フォローアップ（別PR候補）
- 同じ1000上限の影響を受けうる「全件返す前提」の他クエリも監査が必要:
  - `getTopicsWithOpinions`（admin結果表示）/ web `findPublishedAnalysis`（公開読み取り）のネスト取得。
  - 1版/1トピックにぶら下がる意見が多い場合に欠落しうる。別PRで対応予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 意見データの取得処理を最適化し、処理パフォーマンスが向上しました。
  * データフィルタリング精度が改善され、公開状態が適切な意見のみを取得するようになりました。
  * 大規模データセットでの処理安定性が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->