### PR TITLE
インタビュー導線を全幅化・市民バッジのハイライト・レポートボタン順を修正

### DIFF
--- a/web/src/features/interview-config/client/components/interview-landing-section.tsx
+++ b/web/src/features/interview-config/client/components/interview-landing-section.tsx
@@ -81,7 +81,7 @@ export function InterviewLandingSection({
   billId,
 }: InterviewLandingSectionProps) {
   return (
-    <div className="relative overflow-hidden rounded-xl bg-white p-6 mx-auto">
+    <div className="relative w-full overflow-hidden rounded-xl bg-white p-6">
       <_InterviewIllustration />
 
       <div className="relative z-1 flex flex-col gap-2">

--- a/web/src/features/interview-report/server/components/public-report-page.tsx
+++ b/web/src/features/interview-report/server/components/public-report-page.tsx
@@ -104,8 +104,8 @@ export async function PublicReportPage({
               ogImageUrl={ogImageUrl}
               shareMessage={data.summary}
             />
-            <ReportProblemButton />
             <BackToBillButton billId={data.bill_id} from={from} />
+            <ReportProblemButton />
           </div>
         </div>
       </Container>

--- a/web/src/features/user-topic-analysis/shared/components/topic-card.tsx
+++ b/web/src/features/user-topic-analysis/shared/components/topic-card.tsx
@@ -5,7 +5,12 @@ import Link from "next/link";
 import { getInterviewMessageLink } from "@/features/interview-config/shared/utils/interview-links";
 import { ClampedQuote } from "../../client/components/clamped-quote";
 import type { PublicOpinion, PublicTopic } from "../types";
-import { filterOpinions, type TopicFilter } from "../utils/filter-topics";
+import {
+  filterOpinions,
+  sentimentOfFilter,
+  type TopicFilter,
+  userCategoryOfFilter,
+} from "../utils/filter-topics";
 import { opinionAttributionLabel } from "../utils/topic-category";
 import { TopicCategoryChips, TopicSentiment } from "./topic-meta";
 
@@ -72,12 +77,8 @@ export function TopicCard({
   ).slice(0, maxQuotes);
 
   // フィルタ選択中の次元をカード側でもハイライトする
-  const highlightCategory =
-    filter === "affected" || filter === "industry" || filter === "expert"
-      ? filter
-      : null;
-  const highlightSentiment =
-    filter === "期待" || filter === "懸念" ? filter : null;
+  const highlightCategory = userCategoryOfFilter(filter);
+  const highlightSentiment = sentimentOfFilter(filter);
 
   // レポート詳細が表示可能な意見のみ、該当メッセージへのリンクにする
   const messageHrefFor = (opinion: PublicOpinion): string | null => {

--- a/web/src/features/user-topic-analysis/shared/utils/filter-topics.test.ts
+++ b/web/src/features/user-topic-analysis/shared/utils/filter-topics.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from "vitest";
-import type { PublicOpinion, PublicTopic } from "../types";
+import type { PublicOpinion, PublicTopic, UserCategory } from "../types";
 import {
   filterAndSortTopics,
   filterOpinions,
   parseTopicFilter,
+  sentimentOfFilter,
   type TopicFilter,
   topicSortLabel,
+  userCategoryOfFilter,
 } from "./filter-topics";
 
 function makeOpinion(
@@ -150,5 +152,41 @@ describe("topicSortLabel", () => {
     ["懸念", "懸念が多い順"],
   ])("%s のラベルは %s", (filter, expected) => {
     expect(topicSortLabel(filter)).toBe(expected);
+  });
+});
+
+describe("userCategoryOfFilter", () => {
+  it.each<[UserCategory]>([
+    ["affected"],
+    ["industry"],
+    ["expert"],
+    ["citizen"],
+  ])("カテゴリ %s はそのまま返す（市民の取りこぼし回帰防止）", (filter) => {
+    expect(userCategoryOfFilter(filter)).toBe(filter);
+  });
+
+  it.each<[TopicFilter]>([
+    ["all"],
+    ["期待"],
+    ["懸念"],
+  ])("カテゴリ以外 %s は null", (filter) => {
+    expect(userCategoryOfFilter(filter)).toBeNull();
+  });
+});
+
+describe("sentimentOfFilter", () => {
+  it("期待・懸念はそのまま返す", () => {
+    expect(sentimentOfFilter("期待")).toBe("期待");
+    expect(sentimentOfFilter("懸念")).toBe("懸念");
+  });
+
+  it.each<[TopicFilter]>([
+    ["all"],
+    ["affected"],
+    ["industry"],
+    ["expert"],
+    ["citizen"],
+  ])("感情以外 %s は null", (filter) => {
+    expect(sentimentOfFilter(filter)).toBeNull();
   });
 });

--- a/web/src/features/user-topic-analysis/shared/utils/filter-topics.ts
+++ b/web/src/features/user-topic-analysis/shared/utils/filter-topics.ts
@@ -47,6 +47,27 @@ export function topicSortLabel(filter: TopicFilter): string | null {
   return option ? `${option.label}が多い順` : null;
 }
 
+/**
+ * フィルタがカテゴリ次元なら対応する UserCategory を返す（感情/all は null）。
+ * カード側のカテゴリchipハイライト判定に使う。
+ */
+export function userCategoryOfFilter(filter: TopicFilter): UserCategory | null {
+  switch (filter) {
+    case "affected":
+    case "industry":
+    case "expert":
+    case "citizen":
+      return filter;
+    default:
+      return null;
+  }
+}
+
+/** フィルタが感情次元なら対応する 期待/懸念 を返す（カテゴリ/all は null）。 */
+export function sentimentOfFilter(filter: TopicFilter): "期待" | "懸念" | null {
+  return filter === "期待" || filter === "懸念" ? filter : null;
+}
+
 /** トピックから、指定フィルタ次元の件数を取り出す。 */
 function countFor(topic: PublicTopic, filter: TopicFilterChip): number {
   switch (filter) {


### PR DESCRIPTION
## 概要
6/18ローンチUI（トピック/レポート関連ページ）のUI微修正3点。

### 1. インタビュー導線(AIインタビューCTA)をPCで横幅いっぱいに
`InterviewLandingSection` のルートに付いていた `mx-auto` が、flexコンテナ（`flex flex-col`）の子要素として配置されたときに **クロス軸のauto marginが `align-items: stretch` を打ち消し**、コンテンツ幅まで縮んで中央寄せになっていた。法案詳細ページではブロック要素(`<div className="my-8">`)でラップされているため全幅で表示されており、見た目が揃っていなかった。

`mx-auto` → `w-full` に変更し、全呼び出し箇所で法案詳細ページと同じ全幅表示に統一。
- 対象ページ: トピック一覧 / トピック詳細 / インタビュー回答一覧 / レポート詳細
- ブロック配置の法案詳細・意見一覧ページは元々 `mx-auto` が無効だったため挙動不変。

### 2. トピック一覧カード: 市民フィルタで市民バッジがハイライトされない不具合
`topic-card.tsx` の `highlightCategory` 判定が `affected`/`industry`/`expert` のみで **`citizen`（市民）が漏れていた**ため、市民フィルタ選択時にカード側の市民バッジがアクティブにならなかった。

判定ロジックを純粋関数 `userCategoryOfFilter` / `sentimentOfFilter` として `filter-topics.ts` に切り出し、列挙漏れを防止（テスト追加・市民の回帰防止ケース含む）。

### 3. レポート詳細ページ下部のボタン表示順を変更
`記事を共有する → 問題を報告 → 法案へ戻る` を **`記事を共有する → 法案の記事に戻る → 問題を報告する`** の順に変更。

## テスト
- `pnpm --filter web test`（filter-topics.test.ts に13ケース追加、全パス）
- `pnpm lint` / `pnpm typecheck` / `pnpm build` 通過
- 既存の `ERR_REQUIRE_ESM` 系15件はdevelopでも発生する既存事象（本変更とは無関係）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### 4. トピック詳細の意見カードのレイアウト調整（Figma準拠）
Figma `node-id=9981-7900` に合わせて意見カード(`OpinionCard`)を調整。
- **引用文下の区切り線(横棒)を削除**。カード下部はインタビューレポートリンクのみ右寄せ表示。
- **左下にあった日付をカテゴリ/肩書chipと同じ行へ移動**（肩書の後ろ、`text-topic-label` / 12px）。
- `reportVisible` でない場合は下部ブロックごと非表示。
