### PR TITLE
意見カード: 引用下の区切り線を削除し日付を肩書行へ移動 (Figma準拠)

### DIFF
--- a/web/src/features/user-topic-analysis/shared/components/opinion-card.tsx
+++ b/web/src/features/user-topic-analysis/shared/components/opinion-card.tsx
@@ -136,15 +136,19 @@ export function OpinionCard({
             {opinion.role_title}
           </span>
         )}
+        {dateLabel && (
+          <span className="text-[12px] leading-[14px] text-topic-label">
+            {dateLabel}
+          </span>
+        )}
       </div>
 
       {/* 引用 */}
       {quote && <Quote quote={quote} />}
 
-      {/* 区切り線 + 日時 + レポートリンク */}
-      <div className="flex items-center justify-between border-t border-mirai-border pt-3">
-        <span className="text-[11px] text-topic-label">{dateLabel}</span>
-        {reportVisible && (
+      {/* レポートリンク */}
+      {reportVisible && (
+        <div className="flex items-center justify-end pt-3">
           <Link
             href={reportHref as Route}
             prefetch={false}
@@ -153,8 +157,8 @@ export function OpinionCard({
             インタビューレポートを読む
             <ChevronRight className="size-[14px] shrink-0" />
           </Link>
-        )}
-      </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## 概要
トピック詳細ページの意見カード(`OpinionCard`)のレイアウトを Figma (`node-id=9981-7900`) に合わせて調整。

- **引用文下の区切り線（横棒 `border-t`）を削除**。カード下部はインタビューレポートリンクのみを右寄せ表示。
- **左下にあった日付を、カテゴリ/肩書chipと同じ行（肩書の後ろ）へ移動**。色は既存トークン `text-topic-label`、サイズ 12px。
- `reportVisible` でない場合は下部ブロックごと非表示にし、空の余白が出ないようにした。

## テスト
- `pnpm lint` / `pnpm typecheck` / `pnpm build` / `pnpm --filter web test` 通過
- 既存の `ERR_REQUIRE_ESM` 系15件はdevelopでも発生する既存事象（本変更とは無関係）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * OpinionCardのレイアウトを改善しました。日時ラベルはスタンス・カテゴリ行の直下に表示され、存在する場合にのみ表示されます。レポートリンクは引用ブロック直後に独立した右寄せコンテナとして表示されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->