### PR TITLE
fix(sp): TOPページのモバイル上余白を元の仕様に戻す

### DIFF
--- a/web/src/components/layouts/main-layout.tsx
+++ b/web/src/components/layouts/main-layout.tsx
@@ -2,7 +2,11 @@
 
 import { usePathname } from "next/navigation";
 import type { ReactNode } from "react";
-import { isInterviewSection, isMainPage } from "@/lib/page-layout-utils";
+import {
+  isInterviewSection,
+  isMainPage,
+  isTopPage,
+} from "@/lib/page-layout-utils";
 import { cn } from "@/lib/utils";
 
 interface MainLayoutProps {
@@ -13,13 +17,17 @@ export function MainLayout({ children }: MainLayoutProps) {
   const pathname = usePathname();
   const useSidebarLayout = isMainPage(pathname);
   const isInterview = isInterviewSection(pathname);
+  const isTop = isTopPage(pathname);
 
   return (
     <div
       className={cn(
+        "relative max-w-[700px] mx-auto",
         // 固定ヘッダー（top-4 + h-16 ≈ 80px）に本文が潜らないよう上余白を確保する。
-        // モバイルで余白が無くパンくず等が埋もれていたため md: 限定をやめ全幅で適用。
-        "relative max-w-[700px] mx-auto mt-24",
+        // パンくず等が埋もれるのを防ぐため全幅で mt-24 を適用する。
+        // ただしTOPページはヒーローを画面最上部に出す元の仕様に戻し、
+        // モバイルでは余白なし・md以上でのみ mt-24 とする。
+        isTop ? "md:mt-24" : "mt-24",
         // インタビューページ以外ではshadowを表示
         !isInterview && "sm:shadow-lg",
         // TOPページと法案詳細ページのみ、チャットサイドバー用のオフセット

--- a/web/src/lib/page-layout-utils.test.ts
+++ b/web/src/lib/page-layout-utils.test.ts
@@ -5,7 +5,22 @@ import {
   isInterviewPage,
   isInterviewSection,
   isMainPage,
+  isTopPage,
 } from "./page-layout-utils";
+
+describe("isTopPage", () => {
+  it("returns true only for the root path", () => {
+    expect(isTopPage("/")).toBe(true);
+  });
+
+  it("returns false for a bill detail page", () => {
+    expect(isTopPage("/bills/abc-123")).toBe(false);
+  });
+
+  it("returns false for unrelated paths", () => {
+    expect(isTopPage("/about")).toBe(false);
+  });
+});
 
 describe("isMainPage", () => {
   it("returns true for the top page", () => {

--- a/web/src/lib/page-layout-utils.ts
+++ b/web/src/lib/page-layout-utils.ts
@@ -6,6 +6,11 @@
  * - チャットサイドバー用のオフセットレイアウトを使用
  */
 
+/** TOPページ（ルート）かどうかを判定 */
+export function isTopPage(pathname: string): boolean {
+  return pathname === "/";
+}
+
 /** メインページ（TOP、法案詳細）かどうかを判定 */
 export function isMainPage(pathname: string): boolean {
   // トップページ


### PR DESCRIPTION
## 概要
#857 で固定ヘッダーにパンくずが潜る問題を直すため、`MainLayout` の上余白を `md:mt-24` → `mt-24`（全幅適用）に変更した。しかしパンくずを持たない **TOPページ** では、モバイルでヒーロー画像の上に不要な余白が入ってしまっていた。

TOPページのSP（モバイル）ヘッダー余白を**元の仕様に戻す**。

## 変更内容
- `isTopPage(pathname)` ヘルパーを `page-layout-utils.ts` に追加（+ユニットテスト）。
- `MainLayout` で TOPページのみ `md:mt-24`（モバイル余白なし・md以上で mt-24）、それ以外は `mt-24` を維持。
- パンくずを持つトピック/レポート等のページは #857 の修正（mt-24）をそのまま維持。

## テスト
- `pnpm --filter web exec vitest run src/lib/page-layout-utils.test.ts`（21件パス）
- `pnpm lint` / `pnpm --filter web typecheck` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * トップページのモバイル表示時の上余白を最適化しました。
  * その他のページではデスクトップ表示と同様の余白を保持します。

* **Tests**
  * ページ判定ロジックの検証テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->