### PR TITLE
fix: 法案詳細の「N件のご意見」を意見数に修正（回答者数ではなく）

### DIFF
--- a/web/src/features/bills/server/components/bill-detail/bill-detail-header.tsx
+++ b/web/src/features/bills/server/components/bill-detail/bill-detail-header.tsx
@@ -19,6 +19,7 @@ import type { BillWithContent } from "../../../shared/types";
 interface BillDetailHeaderProps {
   bill: BillWithContent;
   hasInterviewConfig?: boolean;
+  /** 意見数（トピック分析の total_opinions）。回答者数（人数）ではない点に注意。 */
   opinionCount?: number;
   /** 公開トピック数。1件以上ならトピック一覧への導線として件数を併記する。 */
   topicCount?: number;

--- a/web/src/features/bills/server/components/bill-detail/bill-detail-layout.tsx
+++ b/web/src/features/bills/server/components/bill-detail/bill-detail-layout.tsx
@@ -47,7 +47,7 @@ export async function BillDetailLayout({
         <BillDetailHeader
           bill={bill}
           hasInterviewConfig={interviewConfig != null}
-          opinionCount={publicReportsResult.totalCount}
+          opinionCount={topicAnalysis?.total_opinions ?? 0}
           topicCount={topicAnalysis?.topics.length ?? 0}
         />
         <Container>


### PR DESCRIPTION
## 概要
法案詳細ページの「◯件のトピック・◯件のご意見」の **ご意見の件数が回答者の人数になっていた**ため、意見数に修正する。

`BillDetailHeader` の `opinionCount` に `publicReportsResult.totalCount`（= 公開レポート数 = 回答者の人数）を渡していたのが原因。トピック分析の `total_opinions`（意見数）を渡すよう変更した。

## 変更内容
- `bill-detail-layout.tsx`: `opinionCount={publicReportsResult.totalCount}` → `opinionCount={topicAnalysis?.total_opinions ?? 0}`
- `bill-detail-header.tsx`: `opinionCount` prop に「意見数（人数ではない）」である旨のコメントを追加。

なお `publicReportsResult.totalCount` は `BillTopicsPreviewSection` のレポート公開判定で引き続き使用しているため残しています。

## テスト
- `pnpm lint` / `pnpm --filter web typecheck` / `pnpm build` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * 意見数の集計ロジックを更新しました。従来の公開レポート件数ではなく、トピック分析の総意見数に基づいて表示されるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->