### PR TITLE
fix: 回答一覧・トピック一覧の「もっと見る」件数を20→40に

### DIFF
--- a/web/src/features/user-topic-analysis/client/components/respondent-list.tsx
+++ b/web/src/features/user-topic-analysis/client/components/respondent-list.tsx
@@ -14,8 +14,8 @@ import { useFilteredPagination } from "../hooks/use-filtered-pagination";
 import { TopicFilterChips } from "./topic-filter-chips";
 
 /** 最初に表示する回答件数と、「もっと見る」で1回に追加する件数。 */
-const INITIAL_VISIBLE = 20;
-const LOAD_STEP = 20;
+const INITIAL_VISIBLE = 40;
+const LOAD_STEP = 40;
 
 interface RespondentListProps {
   respondents: PublicRespondent[];

--- a/web/src/features/user-topic-analysis/client/components/topic-list.tsx
+++ b/web/src/features/user-topic-analysis/client/components/topic-list.tsx
@@ -16,8 +16,8 @@ import { useFilteredPagination } from "../hooks/use-filtered-pagination";
 import { TopicFilterChips } from "./topic-filter-chips";
 
 /** 最初に表示するトピック件数と、「もっと見る」で1回に追加する件数。 */
-const INITIAL_VISIBLE = 20;
-const LOAD_STEP = 20;
+const INITIAL_VISIBLE = 40;
+const LOAD_STEP = 40;
 
 interface TopicListProps {
   billId: string;


### PR DESCRIPTION
## 概要
「あと N 人のインタビュー回答を見る」「あと N 件のトピックを見る」のページング件数が 20 だったため、**40** に変更する。

## 変更内容
- `respondent-list.tsx`（インタビュー回答一覧）: `INITIAL_VISIBLE` / `LOAD_STEP` を 20 → 40
- `topic-list.tsx`（トピック一覧）: `INITIAL_VISIBLE` / `LOAD_STEP` を 20 → 40

いずれもクライアント側で配列をスライスする表示制御で、サーバー側の取得ロジックには影響しません。

## 補足（要確認）
トピック詳細ページの意見一覧 `topic-opinion-list.tsx`（「あと N 件の意見を見る」）も同じく 20 のままです。今回はご指示にあった2箇所のみ変更しています。こちらも 40 に揃える場合はお知らせください。

## テスト
- `pnpm lint` / `pnpm --filter web typecheck` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)