### PR TITLE
fix: 会話ログの引用ハイライトのテキスト色をFigma準拠に

### DIFF
--- a/web/src/features/interview-report/shared/components/chat-log-section.tsx
+++ b/web/src/features/interview-report/shared/components/chat-log-section.tsx
@@ -14,14 +14,14 @@ interface ChatLogMessage {
   content: string;
 }
 
-/** メッセージ本文を表示し、引用一致部分を太字にする。 */
+/** メッセージ本文を表示し、引用一致部分を太字＋プライマリ色で強調する。 */
 function MessageText({ text, quote }: { text: string; quote?: string }) {
   return (
     <p className="text-sm font-medium leading-relaxed whitespace-pre-wrap text-gray-800">
       {splitByQuote(text, quote).map((segment, index) =>
         segment.highlight ? (
           // biome-ignore lint/suspicious/noArrayIndexKey: セグメントは順序固定で再並びしない
-          <strong key={index} className="font-bold text-mirai-text">
+          <strong key={index} className="font-bold text-primary-accent">
             {segment.text}
           </strong>
         ) : (


### PR DESCRIPTION
## 概要
インタビューレポートの会話ログで、引用元の一致部分（クリックで該当箇所にジャンプして強調表示される部分）の**テキスト色をFigma準拠**に変更する。

Figma `node-id=9638-122790` では強調部分が `#0f8472`（プライマリ緑）のため、`text-mirai-text`（黒）→ `text-primary-accent`（= `#0f8472`）に変更。太字（font-bold）は維持。

## 変更内容
- `chat-log-section.tsx` の `MessageText`: 引用一致セグメントの `<strong>` を `text-mirai-text` → `text-primary-accent`。

## テスト
- `pnpm lint` / `pnpm --filter web typecheck` 通過
- ※ `chat-log-section.test.tsx` はハイライト色のクラスを検証していないため変更不要。ローカルでは既存の `ERR_REQUIRE_ESM`（jsdom系）でこのtsxテストが読み込めない既知事象のためCIで検証。

🤖 Generated with [Claude Code](https://claude.com/claude-code)