### PR TITLE
fix(sp): ヘッダー上余白をグローバルから元に戻し、パンくずページのみ個別対応

### DIFF
--- a/web/src/components/layouts/main-layout.tsx
+++ b/web/src/components/layouts/main-layout.tsx
@@ -2,11 +2,7 @@
 
 import { usePathname } from "next/navigation";
 import type { ReactNode } from "react";
-import {
-  isInterviewSection,
-  isMainPage,
-  isTopPage,
-} from "@/lib/page-layout-utils";
+import { isInterviewSection, isMainPage } from "@/lib/page-layout-utils";
 import { cn } from "@/lib/utils";
 
 interface MainLayoutProps {
@@ -17,17 +13,14 @@ export function MainLayout({ children }: MainLayoutProps) {
   const pathname = usePathname();
   const useSidebarLayout = isMainPage(pathname);
   const isInterview = isInterviewSection(pathname);
-  const isTop = isTopPage(pathname);
 
   return (
     <div
       className={cn(
-        "relative max-w-[700px] mx-auto",
-        // 固定ヘッダー（top-4 + h-16 ≈ 80px）に本文が潜らないよう上余白を確保する。
-        // パンくず等が埋もれるのを防ぐため全幅で mt-24 を適用する。
-        // ただしTOPページはヒーローを画面最上部に出す元の仕様に戻し、
-        // モバイルでは余白なし・md以上でのみ mt-24 とする。
-        isTop ? "md:mt-24" : "mt-24",
+        // モバイルは余白なし（ヒーロー/サムネイルを画面最上部に表示）、md以上で固定
+        // ヘッダー分の上余白を確保する。パンくずを持つページは各ページ側で
+        // モバイル時の上余白（pt-24 md:pt-0）を付与してヘッダー埋もれを回避する。
+        "relative max-w-[700px] mx-auto md:mt-24",
         // インタビューページ以外ではshadowを表示
         !isInterview && "sm:shadow-lg",
         // TOPページと法案詳細ページのみ、チャットサイドバー用のオフセット

--- a/web/src/features/interview-report/server/components/public-report-page.tsx
+++ b/web/src/features/interview-report/server/components/public-report-page.tsx
@@ -50,7 +50,7 @@ export async function PublicReportPage({
   ];
 
   return (
-    <div className="min-h-dvh bg-mirai-surface">
+    <div className="min-h-dvh bg-mirai-surface pt-24 md:pt-0">
       <Container>
         <div className="flex flex-col gap-8 py-8">
           {/* パンくず + 法案タイトル */}

--- a/web/src/features/user-topic-analysis/server/components/bill-opinions-page.tsx
+++ b/web/src/features/user-topic-analysis/server/components/bill-opinions-page.tsx
@@ -38,7 +38,7 @@ export async function BillOpinionsPage({ billId }: BillOpinionsPageProps) {
   ];
 
   return (
-    <div className="min-h-dvh bg-mirai-surface">
+    <div className="min-h-dvh bg-mirai-surface pt-24 md:pt-0">
       <Container>
         <div className="flex flex-col gap-8 py-8">
           {/* パンくず + 法案タイトル */}

--- a/web/src/features/user-topic-analysis/server/components/topic-detail-page.tsx
+++ b/web/src/features/user-topic-analysis/server/components/topic-detail-page.tsx
@@ -115,7 +115,7 @@ export async function TopicDetailPage({
   ];
 
   return (
-    <div className="min-h-dvh bg-mirai-surface">
+    <div className="min-h-dvh bg-mirai-surface pt-24 md:pt-0">
       <Container>
         <div className="flex flex-col gap-6 py-8">
           {/* パンくず + 法案タイトル */}

--- a/web/src/features/user-topic-analysis/server/components/topic-list-page.tsx
+++ b/web/src/features/user-topic-analysis/server/components/topic-list-page.tsx
@@ -42,7 +42,7 @@ export async function TopicListPage({ billId }: TopicListPageProps) {
   ];
 
   return (
-    <div className="min-h-dvh bg-mirai-surface">
+    <div className="min-h-dvh bg-mirai-surface pt-24 md:pt-0">
       <Container>
         <div className="flex flex-col gap-8 py-8">
           {/* パンくず + 法案タイトル */}

--- a/web/src/lib/page-layout-utils.test.ts
+++ b/web/src/lib/page-layout-utils.test.ts
@@ -5,22 +5,7 @@ import {
   isInterviewPage,
   isInterviewSection,
   isMainPage,
-  isTopPage,
 } from "./page-layout-utils";
-
-describe("isTopPage", () => {
-  it("returns true only for the root path", () => {
-    expect(isTopPage("/")).toBe(true);
-  });
-
-  it("returns false for a bill detail page", () => {
-    expect(isTopPage("/bills/abc-123")).toBe(false);
-  });
-
-  it("returns false for unrelated paths", () => {
-    expect(isTopPage("/about")).toBe(false);
-  });
-});
 
 describe("isMainPage", () => {
   it("returns true for the top page", () => {

--- a/web/src/lib/page-layout-utils.ts
+++ b/web/src/lib/page-layout-utils.ts
@@ -6,11 +6,6 @@
  * - チャットサイドバー用のオフセットレイアウトを使用
  */
 
-/** TOPページ（ルート）かどうかを判定 */
-export function isTopPage(pathname: string): boolean {
-  return pathname === "/";
-}
-
 /** メインページ（TOP、法案詳細）かどうかを判定 */
 export function isMainPage(pathname: string): boolean {
   // トップページ


### PR DESCRIPTION
## 概要
モバイルの固定ヘッダー余白対応がまだ不十分（法案詳細などヒーロー/サムネイルを最上部に出すページにモバイルで不要な余白が残る）だったため、グローバルの上余白変更を**元に戻し**、パンくずを持つページだけ個別に余白を付与する方式に変更する。

### revert 対象
- **#860**（`isTopPage` + `mt-24`/`md:mt-24` の出し分け）
- **#857 のコミット `2ec491da`**（`MainLayout` を `md:mt-24` → `mt-24` に全幅化）

## 変更内容
- `MainLayout` を元の `md:mt-24`（モバイル余白なし）に戻す。これによりヒーロー/サムネイルを最上部に出す TOP・法案詳細などのモバイル余白問題が解消。
- `isTopPage` ヘルパー（および対応テスト）を削除。
- パンくずを持つ4ページに、モバイル時のみ固定ヘッダー回避の上余白 `pt-24 md:pt-0` を個別付与：
  - トピック一覧（`topic-list-page`）
  - トピック詳細（`topic-detail-page`）
  - インタビュー回答一覧（`bill-opinions-page`）
  - レポート詳細（`public-report-page`）
- これは既存の `interview-disclosure-page`（`pt-24 md:pt-12`）や `report-complete-page`（`pt-30 md:pt-16`）と同じ「ページ単位で上余白を付与」する方式に揃えたもの。

## テスト
- `pnpm --filter web exec vitest run src/lib/page-layout-utils.test.ts`（18件パス）
- `pnpm lint` / `pnpm --filter web typecheck` / `pnpm build` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **リファクタ**
  * ページレイアウト判定機能の内部ロジックを整理・統一
  * 対応するテストも更新

* **スタイル**
  * 複数ページでモバイル/デスクトップ向けの上部余白を最適化

<!-- end of auto-generated comment: release notes by coderabbit.ai -->