### PR TITLE
fix: 「もっと見る」の初期表示件数を20に戻す（追加ステップは40）

### DIFF
--- a/web/src/features/user-topic-analysis/client/components/respondent-list.tsx
+++ b/web/src/features/user-topic-analysis/client/components/respondent-list.tsx
@@ -14,7 +14,7 @@ import { useFilteredPagination } from "../hooks/use-filtered-pagination";
 import { TopicFilterChips } from "./topic-filter-chips";
 
 /** 最初に表示する回答件数と、「もっと見る」で1回に追加する件数。 */
-const INITIAL_VISIBLE = 40;
+const INITIAL_VISIBLE = 20;
 const LOAD_STEP = 40;
 
 interface RespondentListProps {

--- a/web/src/features/user-topic-analysis/client/components/topic-list.tsx
+++ b/web/src/features/user-topic-analysis/client/components/topic-list.tsx
@@ -16,7 +16,7 @@ import { useFilteredPagination } from "../hooks/use-filtered-pagination";
 import { TopicFilterChips } from "./topic-filter-chips";
 
 /** 最初に表示するトピック件数と、「もっと見る」で1回に追加する件数。 */
-const INITIAL_VISIBLE = 40;
+const INITIAL_VISIBLE = 20;
 const LOAD_STEP = 40;
 
 interface TopicListProps {


### PR DESCRIPTION
## 概要
#862 で「もっと見る」のページング件数を 20→40 にした際、初期表示件数（`INITIAL_VISIBLE`）も40にしていたが、**初期表示は20件**に戻す。「もっと見る」1回の追加件数（`LOAD_STEP`）は **40** のまま維持する。

## 変更内容
- `respondent-list.tsx` / `topic-list.tsx`: `INITIAL_VISIBLE` を 40 → 20（`LOAD_STEP` は 40 のまま）

## テスト
- `pnpm lint` / `pnpm --filter web typecheck` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)