### PR TITLE
fix: トピック一覧のフィルタを戻り遷移時に維持する

### DIFF
--- a/web/src/features/user-topic-analysis/client/hooks/use-filtered-pagination.ts
+++ b/web/src/features/user-topic-analysis/client/hooks/use-filtered-pagination.ts
@@ -1,7 +1,15 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import type { TopicFilter } from "../../shared/utils/filter-topics";
+import {
+  parseTopicFilter,
+  type TopicFilter,
+} from "../../shared/utils/filter-topics";
+
+/** persistKey から、フィルタ保存用の sessionStorage キーを導出する。 */
+function filterStorageKey(persistKey: string): string {
+  return `${persistKey}:filter`;
+}
 
 /**
  * トピック一覧・意見一覧で共通の「フィルタ + 段階表示」状態を管理するフック。
@@ -9,8 +17,9 @@ import type { TopicFilter } from "../../shared/utils/filter-topics";
  * - フィルタchipを再選択したら all に戻す（トグル解除）。
  * - フィルタ変更時は表示件数を初期値にリセットする。
  * - filterFn は安定参照のモジュール関数を渡すこと（毎レンダー生成しない）。
- * - persistKey を渡すと表示件数を sessionStorage に保存し、別ページから戻った際に復元する
- *   （トピック詳細→一覧の「戻る」でページネーション位置を維持する用途）。
+ * - persistKey を渡すと表示件数とフィルタを sessionStorage に保存し、別ページから
+ *   戻った際に復元する（トピック詳細→一覧の「戻る」でフィルタ・ページネーション位置を
+ *   維持する用途）。
  */
 export function useFilteredPagination<T>(
   items: T[],
@@ -22,8 +31,8 @@ export function useFilteredPagination<T>(
   const [filter, setFilter] = useState<TopicFilter>("all");
   const [visibleCount, setVisibleCount] = useState(initialVisible);
 
-  // 戻り遷移時にページネーション位置を復元する。
-  // ハイドレーション不整合を避けるため初期値は initialVisible のままにし、
+  // 戻り遷移時にフィルタとページネーション位置を復元する。
+  // ハイドレーション不整合を避けるため初期値はそのままにし、
   // マウント後の effect で sessionStorage の値を反映する。
   useEffect(() => {
     if (!persistKey) return;
@@ -32,10 +41,20 @@ export function useFilteredPagination<T>(
     if (Number.isFinite(n) && n > initialVisible) {
       setVisibleCount(n);
     }
+    const storedFilter = sessionStorage.getItem(filterStorageKey(persistKey));
+    if (storedFilter) {
+      setFilter(parseTopicFilter(storedFilter));
+    }
   }, [persistKey, initialVisible]);
 
   const persist = (n: number) => {
     if (persistKey) sessionStorage.setItem(persistKey, String(n));
+  };
+
+  const persistFilter = (next: TopicFilter) => {
+    if (persistKey) {
+      sessionStorage.setItem(filterStorageKey(persistKey), next);
+    }
   };
 
   const filtered = useMemo(
@@ -44,9 +63,12 @@ export function useFilteredPagination<T>(
   );
 
   const selectFilter = (next: TopicFilter) => {
-    setFilter((prev) => (prev === next ? "all" : next));
+    // トグル解除（同じchip再選択）も考慮して、確定後のフィルタ値を保存する。
+    const resolved = filter === next ? "all" : next;
+    setFilter(resolved);
     setVisibleCount(initialVisible);
     persist(initialVisible);
+    persistFilter(resolved);
   };
 
   const loadMore = () => {


### PR DESCRIPTION
## 概要
トピック一覧でフィルタを適用 → トピック詳細へ遷移 → 「戻る」で一覧に戻ると、**フィルタ適用状態が `all` にリセット**されていた。フィルタを維持するように修正する。

## 原因
`useFilteredPagination` は表示件数（`visibleCount`）のみ sessionStorage に保存・復元しており、フィルタ（`filter`）は保存していなかったため、一覧の再マウント時に既定値 `all` に戻っていた。

## 変更内容
- `use-filtered-pagination.ts`: `persistKey` 指定時、フィルタも sessionStorage（`${persistKey}:filter`）に保存し、マウント時に復元する。
  - 復元値は `parseTopicFilter` で検証（不正値は `all`）。
  - `persistKey` を渡しているのはトピック一覧のみ。意見一覧・回答一覧は対象外で挙動不変。
  - `persistKey` は議案ごと（`topic-list-pagination:${billId}`）のため、議案間で混ざらない。

## テスト
- `pnpm lint` / `pnpm --filter web typecheck` / `pnpm build` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)