### PR TITLE
fix: 引用ハイライトを該当メッセージ(source_message_id)に限定する

### DIFF
--- a/web/src/app/(main)/report/[reportId]/page.tsx
+++ b/web/src/app/(main)/report/[reportId]/page.tsx
@@ -11,6 +11,7 @@ interface PublicReportRouteProps {
   searchParams: Promise<{
     from?: string | string[];
     quote?: string | string[];
+    mid?: string | string[];
   }>;
 }
 
@@ -71,15 +72,17 @@ export default async function PublicReportRoute({
   searchParams,
 }: PublicReportRouteProps) {
   const { reportId } = await params;
-  const { from, quote } = await searchParams;
+  const { from, quote, mid } = await searchParams;
   // 同一キーが複数指定されると配列になり得るため、先頭の値に正規化する。
   const fromValue = Array.isArray(from) ? from[0] : from;
   const quoteValue = Array.isArray(quote) ? quote[0] : quote;
+  const midValue = Array.isArray(mid) ? mid[0] : mid;
   return (
     <PublicReportPage
       reportId={reportId}
       from={fromValue === "opinions" ? "opinions" : undefined}
       highlightQuote={quoteValue}
+      highlightMessageId={midValue}
     />
   );
 }

--- a/web/src/features/interview-config/shared/utils/interview-links.test.ts
+++ b/web/src/features/interview-config/shared/utils/interview-links.test.ts
@@ -107,7 +107,7 @@ describe("getInterviewMessageLink", () => {
     );
   });
 
-  it("appends encoded quote as query before the hash", () => {
+  it("appends encoded quote and mid as query before the hash", () => {
     expect(
       getInterviewMessageLink(
         "report-456",
@@ -116,7 +116,7 @@ describe("getInterviewMessageLink", () => {
         "戻ったら違う部署"
       )
     ).toBe(
-      `/report/report-456?quote=${encodeURIComponent("戻ったら違う部署")}#message-abc-123`
+      `/report/report-456?quote=${encodeURIComponent("戻ったら違う部署")}&mid=abc-123#message-abc-123`
     );
   });
 
@@ -124,7 +124,7 @@ describe("getInterviewMessageLink", () => {
     expect(
       getInterviewMessageLink("report-456", "abc-123", "opinions", "引用")
     ).toBe(
-      `/report/report-456?from=opinions&quote=${encodeURIComponent("引用")}#message-abc-123`
+      `/report/report-456?from=opinions&quote=${encodeURIComponent("引用")}&mid=abc-123#message-abc-123`
     );
   });
 });

--- a/web/src/features/interview-config/shared/utils/interview-links.ts
+++ b/web/src/features/interview-config/shared/utils/interview-links.ts
@@ -101,7 +101,9 @@ export function getInterviewChatLogLink(
 /**
  * インタビュー会話ログ内の個別メッセージへのリンクを取得
  * @param from - 遷移元のコンテキスト。"complete" の場合は完了ページ内、"opinions" の場合は公開レポート一覧からの戻り文脈を維持する
- * @param quote - 引用文（逐語）。指定すると `?quote=` で渡し、レポート側で該当メッセージ内の該当部分を太字表示する
+ * @param quote - 引用文（逐語）。指定すると `?quote=` で渡し、レポート側で該当メッセージ内の該当部分を太字表示する。
+ *   このとき `?mid=`（メッセージID）も併せて渡し、ハイライト対象を該当メッセージ1件に限定する
+ *   （テキスト一致だけだと無関係なメッセージまで太字になるため）。
  */
 export function getInterviewMessageLink(
   reportId: string,
@@ -110,8 +112,9 @@ export function getInterviewMessageLink(
   quote?: string | null
 ): string {
   const base = getReportLinkForChatLogContext(reportId, from);
+  const sep = base.includes("?") ? "&" : "?";
   const query = quote
-    ? `${base.includes("?") ? "&" : "?"}quote=${encodeURIComponent(quote)}`
+    ? `${sep}quote=${encodeURIComponent(quote)}&mid=${encodeURIComponent(messageId)}`
     : "";
   return `${base}${query}#message-${messageId}`;
 }

--- a/web/src/features/interview-report/server/components/public-report-page.tsx
+++ b/web/src/features/interview-report/server/components/public-report-page.tsx
@@ -24,12 +24,15 @@ interface PublicReportPageProps {
   from?: "opinions";
   /** 引用元の逐語テキスト。会話ログ内の該当箇所を太字表示する。 */
   highlightQuote?: string;
+  /** ハイライト対象のメッセージID。指定したメッセージ内のみ太字化し、無関係なメッセージは対象外にする。 */
+  highlightMessageId?: string;
 }
 
 export async function PublicReportPage({
   reportId,
   from,
   highlightQuote,
+  highlightMessageId,
 }: PublicReportPageProps) {
   const data = await getPublicReportById(reportId);
 
@@ -88,6 +91,7 @@ export async function PublicReportPage({
             <ChatLogSection
               messages={data.messages}
               highlightQuote={highlightQuote}
+              highlightMessageId={highlightMessageId}
             />
           )}
 

--- a/web/src/features/interview-report/shared/components/chat-log-section.test.tsx
+++ b/web/src/features/interview-report/shared/components/chat-log-section.test.tsx
@@ -37,4 +37,37 @@ describe("ChatLogSection", () => {
 
     expect(container).toBeEmptyDOMElement();
   });
+
+  it("highlights only the message matching highlightMessageId", () => {
+    render(
+      <ChatLogSection
+        messages={[
+          { id: "m1", role: "user", content: "同じ引用文です" },
+          { id: "m2", role: "user", content: "同じ引用文です" },
+        ]}
+        highlightQuote="引用文"
+        highlightMessageId="m2"
+      />
+    );
+
+    // 対象外メッセージ(m1)は同じ文言でも太字化しない
+    expect(document.querySelector("#message-m1 strong")).toBeNull();
+    // 対象メッセージ(m2)のみ太字化する
+    expect(document.querySelector("#message-m2 strong")).toBeInTheDocument();
+  });
+
+  it("falls back to highlighting all matches when no highlightMessageId", () => {
+    render(
+      <ChatLogSection
+        messages={[
+          { id: "m1", role: "user", content: "同じ引用文です" },
+          { id: "m2", role: "user", content: "同じ引用文です" },
+        ]}
+        highlightQuote="引用文"
+      />
+    );
+
+    expect(document.querySelector("#message-m1 strong")).toBeInTheDocument();
+    expect(document.querySelector("#message-m2 strong")).toBeInTheDocument();
+  });
 });

--- a/web/src/features/interview-report/shared/components/chat-log-section.tsx
+++ b/web/src/features/interview-report/shared/components/chat-log-section.tsx
@@ -6,6 +6,11 @@ interface ChatLogSectionProps {
   messages: ChatLogMessage[];
   /** 引用元の逐語テキスト。該当メッセージ内の一致部分を太字表示する。 */
   highlightQuote?: string;
+  /**
+   * ハイライト対象のメッセージID。指定時はこのIDのメッセージ内だけを太字化し、
+   * 同じ文言を含む無関係なメッセージはハイライトしない。
+   */
+  highlightMessageId?: string;
 }
 
 interface ChatLogMessage {
@@ -36,10 +41,16 @@ function MessageText({ text, quote }: { text: string; quote?: string }) {
 export function ChatLogSection({
   messages,
   highlightQuote,
+  highlightMessageId,
 }: ChatLogSectionProps) {
   if (messages.length === 0) {
     return null;
   }
+
+  // highlightMessageId が指定されている場合は該当メッセージのみハイライトする。
+  // 未指定（古いリンク等）の場合は従来どおり全メッセージをテキスト一致で対象にする。
+  const shouldHighlight = (message: ChatLogMessage) =>
+    highlightMessageId == null || message.id === highlightMessageId;
 
   return (
     <section id="chat-log" className="flex flex-col gap-4 scroll-mt-24">
@@ -50,7 +61,9 @@ export function ChatLogSection({
             <ChatMessage
               key={message.id}
               message={message}
-              highlightQuote={highlightQuote}
+              highlightQuote={
+                shouldHighlight(message) ? highlightQuote : undefined
+              }
             />
           ))}
         </div>


### PR DESCRIPTION
## 概要
インタビューレポートに引用リンクから飛んだとき、会話ログの引用ハイライトが**テキスト一致のみ**で判定されており、同じ文言を含む無関係なメッセージまで太字になっていた。`source_message_id` を使ってハイライト対象を該当メッセージ1件に限定する。

## 原因
`source_message_id` は URL の**ハッシュ**（`#message-<id>`、スクロール用）にしか無くサーバーに渡らないため、サーバーレンダリングの `ChatLogSection` は全メッセージを `quote` のテキスト一致でハイライトしていた。

## 変更内容
- `getInterviewMessageLink`: `quote` 指定時に `?mid=<messageId>` も付与（ハイライト対象の限定用。スクロール用のハッシュは維持）。
- `report/[reportId]/page.tsx`: `mid` を読み取り `highlightMessageId` として `PublicReportPage` に渡す。
- `PublicReportPage` → `ChatLogSection`: `highlightMessageId` を伝播。
- `ChatLogSection`: `highlightMessageId` 指定時は**該当メッセージのみ**ハイライト。未指定（古いリンク等）は従来どおり全一致にフォールバック。

## テスト
- `interview-links.test.ts`: `mid` 付与を検証（更新）
- `chat-log-section.test.tsx`: 該当メッセージのみハイライト / 未指定時フォールバック を追加
- `pnpm lint` / `pnpm --filter web typecheck` / `pnpm build` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 共有レポートリンクでメッセージIDパラメータをサポート
  * レポート表示時に指定メッセージのみをハイライト表示可能に

* **Tests**
  * メッセージハイライト機能の検証テストを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->