### PR TITLE
本番デプロイ 06/17 23:42

### DIFF
--- a/web/src/app/(main)/bills/[id]/topics/[topicId]/page.tsx
+++ b/web/src/app/(main)/bills/[id]/topics/[topicId]/page.tsx
@@ -1,7 +1,11 @@
 import type { Metadata } from "next";
 import { getBillById } from "@/features/bills/server/loaders/get-bill-by-id";
+import { resolveBillShareImageUrl } from "@/features/bills/shared/utils/bill-share-image";
 import { TopicDetailPage } from "@/features/user-topic-analysis/server/components/topic-detail-page";
+import { getPublicTopicDetail } from "@/features/user-topic-analysis/server/loaders/get-public-topic-detail";
 import { parseTopicFilter } from "@/features/user-topic-analysis/shared/utils/filter-topics";
+import { env } from "@/lib/env";
+import { routes } from "@/lib/routes";
 
 interface TopicDetailRouteProps {
   params: Promise<{ id: string; topicId: string }>;
@@ -11,13 +15,47 @@ interface TopicDetailRouteProps {
 export async function generateMetadata({
   params,
 }: TopicDetailRouteProps): Promise<Metadata> {
-  const { id } = await params;
-  const bill = await getBillById(id);
-  const title = bill?.bill_content?.title || bill?.name || "法案";
+  const { id, topicId } = await params;
+  // タイトル/説明はフィルタに依存しないため絞り込みなし（all）で取得する。
+  // DB取得は getPublicTopicAnalysis の React cache() でページ本体と共有され、
+  // リクエスト内で重複クエリにならない。
+  const [bill, location] = await Promise.all([
+    getBillById(id),
+    getPublicTopicDetail(id, topicId),
+  ]);
+  const billName = bill?.bill_content?.title || bill?.name || "法案";
+  const topic = location?.topic;
+
+  const title = topic
+    ? `${topic.title} - ${billName}`
+    : `トピック詳細 - ${billName}`;
+  const description =
+    topic?.description || `${billName}に寄せられた意見トピックの詳細`;
+  const shareImageUrl = resolveBillShareImageUrl(bill, env.webUrl);
 
   return {
-    title: `トピック詳細 - ${title}`,
-    description: `${title}に寄せられた意見トピックの詳細`,
+    title,
+    description,
+    alternates: {
+      canonical: routes.billTopicDetail(id, topicId),
+    },
+    openGraph: {
+      title,
+      description,
+      type: "article",
+      images: [
+        {
+          url: shareImageUrl,
+          alt: `${title} のOGPイメージ`,
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+      images: [shareImageUrl],
+    },
   };
 }
 

--- a/web/src/app/(main)/bills/[id]/topics/page.tsx
+++ b/web/src/app/(main)/bills/[id]/topics/page.tsx
@@ -1,6 +1,9 @@
 import type { Metadata } from "next";
 import { getBillById } from "@/features/bills/server/loaders/get-bill-by-id";
+import { resolveBillShareImageUrl } from "@/features/bills/shared/utils/bill-share-image";
 import { TopicListPage } from "@/features/user-topic-analysis/server/components/topic-list-page";
+import { env } from "@/lib/env";
+import { routes } from "@/lib/routes";
 
 interface TopicsPageProps {
   params: Promise<{ id: string }>;
@@ -11,11 +14,34 @@ export async function generateMetadata({
 }: TopicsPageProps): Promise<Metadata> {
   const { id } = await params;
   const bill = await getBillById(id);
-  const title = bill?.bill_content?.title || bill?.name || "法案";
+  const billName = bill?.bill_content?.title || bill?.name || "法案";
+  const title = `法案のトピック一覧 - ${billName}`;
+  const description = `${billName}に寄せられた意見をAIが整理したトピック一覧`;
+  const shareImageUrl = resolveBillShareImageUrl(bill, env.webUrl);
 
   return {
-    title: `法案のトピック一覧 - ${title}`,
-    description: `${title}に寄せられた意見をAIが整理したトピック一覧`,
+    title,
+    description,
+    alternates: {
+      canonical: routes.billTopics(id),
+    },
+    openGraph: {
+      title,
+      description,
+      type: "website",
+      images: [
+        {
+          url: shareImageUrl,
+          alt: `${billName} のOGPイメージ`,
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+      images: [shareImageUrl],
+    },
   };
 }
 

--- a/web/src/features/bills/shared/utils/bill-share-image.test.ts
+++ b/web/src/features/bills/shared/utils/bill-share-image.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { resolveBillShareImageUrl } from "./bill-share-image";
+
+const WEB_URL = "https://example.com";
+
+describe("resolveBillShareImageUrl", () => {
+  it("share_thumbnail_url を最優先で返す", () => {
+    expect(
+      resolveBillShareImageUrl(
+        {
+          share_thumbnail_url: "https://img/share.jpg",
+          thumbnail_url: "https://img/thumb.jpg",
+        },
+        WEB_URL
+      )
+    ).toBe("https://img/share.jpg");
+  });
+
+  it("share_thumbnail_url が無ければ thumbnail_url を返す", () => {
+    expect(
+      resolveBillShareImageUrl(
+        { share_thumbnail_url: null, thumbnail_url: "https://img/thumb.jpg" },
+        WEB_URL
+      )
+    ).toBe("https://img/thumb.jpg");
+  });
+
+  it("どちらも無ければ webUrl 基準のデフォルトOGPを返す", () => {
+    expect(
+      resolveBillShareImageUrl(
+        { share_thumbnail_url: null, thumbnail_url: null },
+        WEB_URL
+      )
+    ).toBe("https://example.com/ogp.jpg");
+  });
+
+  it("bill が null でもデフォルトOGPを返す", () => {
+    expect(resolveBillShareImageUrl(null, WEB_URL)).toBe(
+      "https://example.com/ogp.jpg"
+    );
+  });
+});

--- a/web/src/features/bills/shared/utils/bill-share-image.ts
+++ b/web/src/features/bills/shared/utils/bill-share-image.ts
@@ -1,0 +1,17 @@
+import type { Bill } from "../types";
+
+/**
+ * SNSシェア用のOGP画像URLを解決する。
+ * 優先順位: share_thumbnail_url（シェア専用画像）> thumbnail_url（表示用画像）> デフォルトOGP。
+ * 議案配下のページ（トピック等）も議案の画像を流用するため共通化している。
+ */
+export function resolveBillShareImageUrl(
+  bill: Pick<Bill, "share_thumbnail_url" | "thumbnail_url"> | null | undefined,
+  webUrl: string
+): string {
+  return (
+    bill?.share_thumbnail_url ||
+    bill?.thumbnail_url ||
+    new URL("/ogp.jpg", webUrl).toString()
+  );
+}

--- a/web/src/features/user-topic-analysis/server/loaders/get-public-topic-analysis.ts
+++ b/web/src/features/user-topic-analysis/server/loaders/get-public-topic-analysis.ts
@@ -1,5 +1,6 @@
 import "server-only";
 
+import { cache } from "react";
 import type { PublicTopicAnalysis } from "../../shared/types";
 import { buildPublicTopicAnalysis } from "../../shared/utils/build-public-topic-analysis";
 import { findPublishedAnalysis } from "../repositories/topic-analysis-read-repository";
@@ -8,11 +9,14 @@ import { findPublishedAnalysis } from "../repositories/topic-analysis-read-repos
  * 議案の公開中トピック分析を、§8 の表示時フィルタ適用後の表示用データで取得する。
  * Server Components から直接呼ぶ（公開 API と同じデータ契約）。
  * 公開版が無ければ null（呼び出し側で「分析準備中」扱いにする）。
+ *
+ * React cache() でリクエスト内のDB呼び出しを重複排除する
+ * （generateMetadata とページ本体で同じ billId を取得しても1回のクエリで済む）。
  */
-export async function getPublicTopicAnalysis(
-  billId: string
-): Promise<PublicTopicAnalysis | null> {
-  const data = await findPublishedAnalysis(billId);
-  if (!data) return null;
-  return buildPublicTopicAnalysis(data.meta, data.rawTopics);
-}
+export const getPublicTopicAnalysis = cache(
+  async (billId: string): Promise<PublicTopicAnalysis | null> => {
+    const data = await findPublishedAnalysis(billId);
+    if (!data) return null;
+    return buildPublicTopicAnalysis(data.meta, data.rawTopics);
+  }
+);


### PR DESCRIPTION
- 詳細ページのメタ情報を実際のトピック（title/description）から生成（従来は法案名のみ）
- 両ページに openGraph / twitter / canonical を追加（OG画像は議案の画像を流用）
- 議案シェア画像の解決ロジックを resolveBillShareImageUrl に共通化（テスト付き）
- getPublicTopicAnalysis を React cache() でラップしリクエスト内の重複クエリを排除