### PR TITLE
インタビュー: レポート未生成時のデッドエンドUIを解消

### DIFF
--- a/web/src/app/dev/_lib/registry.ts
+++ b/web/src/app/dev/_lib/registry.ts
@@ -53,6 +53,11 @@ export const previewRegistry: PreviewGroup[] = [
         label: "InterviewRatingWidget",
         description: "満足度評価ウィジェット（星評価＋フィードバック）",
       },
+      {
+        path: "/dev/features/interview/summary-input",
+        label: "InterviewSummaryInput",
+        description: "要約フェーズの入力欄（レポート提出／未生成時の安全網）",
+      },
     ],
   },
 ];

--- a/web/src/app/dev/features/interview/summary-input/page.tsx
+++ b/web/src/app/dev/features/interview/summary-input/page.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useState } from "react";
+import { InterviewSummaryInput } from "@/features/interview-session/client/components/interview-summary-input";
+import { ComponentShowcase } from "../../../_components/component-showcase";
+import { PreviewSection } from "../../../_components/preview-section";
+
+export default function SummaryInputPreview() {
+  const [input, setInput] = useState("");
+
+  return (
+    <>
+      <h1 className="text-3xl font-bold text-mirai-text mb-8">
+        InterviewSummaryInput
+      </h1>
+
+      <ComponentShowcase
+        title="No Report（レポート未生成時の安全網）"
+        description="summaryフェーズに来たがレポートを生成できなかった場合。理由を伝え、インタビュー続行/終了を選べる。"
+      >
+        <PreviewSection label="hasReport = false">
+          <div className="w-full max-w-md">
+            <InterviewSummaryInput
+              sessionId="mock-session-001"
+              billId="mock-bill-001"
+              hasReport={false}
+              input={input}
+              onInputChange={setInput}
+              onSubmit={() => {}}
+              isLoading={false}
+              error={null}
+            />
+          </div>
+        </PreviewSection>
+      </ComponentShowcase>
+
+      <ComponentShowcase
+        title="With Report（レポート生成済み）"
+        description="レポートが生成された通常時。内容に同意して提出するボタンと、修正要望の入力欄を表示。"
+      >
+        <PreviewSection label="hasReport = true">
+          <div className="w-full max-w-md">
+            <InterviewSummaryInput
+              sessionId="mock-session-001"
+              billId="mock-bill-001"
+              hasReport={true}
+              input={input}
+              onInputChange={setInput}
+              onSubmit={() => {}}
+              isLoading={false}
+              error={null}
+            />
+          </div>
+        </PreviewSection>
+      </ComponentShowcase>
+    </>
+  );
+}

--- a/web/src/features/interview-session/client/components/interview-summary-input.tsx
+++ b/web/src/features/interview-session/client/components/interview-summary-input.tsx
@@ -50,11 +50,23 @@ export function InterviewSummaryInput({
               {isCompleting ? "送信中..." : "レポート内容に同意して提出"}
             </Button>
           ) : (
-            <Button variant="outline" asChild>
-              <Link href={getBillDetailLink(billId, previewToken) as Route}>
-                インタビューを終了する
-              </Link>
-            </Button>
+            <>
+              <p className="text-sm text-mirai-text">
+                お話しいただいた内容が短く、レポートを作成できませんでした。もう少しインタビューを続けると、レポートを作成できます。
+              </p>
+              <Button
+                onClick={() =>
+                  onSubmit({ text: "もう少しインタビューを続けたいです。" })
+                }
+              >
+                インタビューを続ける
+              </Button>
+              <Button variant="outline" asChild>
+                <Link href={getBillDetailLink(billId, previewToken) as Route}>
+                  インタビューを終了する
+                </Link>
+              </Button>
+            </>
           )}
           {completeError && (
             <p className="text-sm text-red-500">{completeError}</p>


### PR DESCRIPTION
## 背景・問題

AIインタビューで「インタビューを終了したい」と伝えたあと、summaryフェーズでLLMが `report: null` を返すと、**レポートも理由説明も無いまま「インタビューを終了する」リンク（法案詳細へ戻るだけ）だけが表示**されることがあった。**インタビュー内容が短いときに起きやすい**。

ユーザーは「レポートが出ていないのに終了ボタンだけ出る。内容が足りずレポートにできなかった、とちゃんと伝えてほしい」という体験を問題視していた。

## 変更内容

`interview-summary-input.tsx`: `hasReport === false`（=summaryフェーズに来たがレポート未生成）のとき、素の終了リンクではなく以下を表示する。

- 説明文「お話しいただいた内容が短く、レポートを作成できませんでした。もう少しインタビューを続けると、レポートを作成できます。」
- **「インタビューを続ける」**（既存の送信経路で再開メッセージを送る）
- **「インタビューを終了する」**（従来どおり法案詳細へ）

あわせて Component Gallery に `InterviewSummaryInput` を追加（`/dev/features/interview/summary-input`、`hasReport` の両状態を表示）。

> 補足: 当初は「自動リトライ（ガード）＋プロンプトで短くても必ずレポート生成」も含めて提案したが、レビューの結果、まずはシンプルかつ正直なUI変更のみに絞る方針とした。

## スクリーンショット（Component Gallery）

`/dev/features/interview/summary-input` の表示。上＝今回追加した安全網（`hasReport=false`）、下＝通常時（`hasReport=true`）。

<img src="https://pub-d6de2fb179d948d18c6b1ed89fcf1061.r2.dev/pr-872/summary-input-states.png" width="820" />

## 検証

- ✅ web 型チェック（`tsc --noEmit`）: pass
- ✅ interview-session unit tests: 334 pass
- ✅ biome（変更ファイル）: クリーン
- ✅ Component Gallery で両状態を目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)