### PR TITLE
インタビュー: レポート未生成時の「インタビューを続ける」が無反応になるバグを修正

### DIFF
--- a/web/src/features/interview-session/client/components/interview-chat-client.tsx
+++ b/web/src/features/interview-session/client/components/interview-chat-client.tsx
@@ -68,6 +68,7 @@ export function InterviewChatClient({
     handleSubmit,
     handleQuickReply,
     handleRetry,
+    handleResumeInterview,
   } = useInterviewChat({
     billId,
     initialMessages,
@@ -297,6 +298,7 @@ export function InterviewChatClient({
               input={input}
               onInputChange={setInput}
               onSubmit={handleSubmit}
+              onResume={handleResumeInterview}
               isLoading={isLoading}
               error={error}
             />

--- a/web/src/features/interview-session/client/components/interview-summary-input.tsx
+++ b/web/src/features/interview-session/client/components/interview-summary-input.tsx
@@ -18,6 +18,8 @@ interface InterviewSummaryInputProps {
   input: string;
   onInputChange: (value: string) => void;
   onSubmit: (message: PromptInputMessage) => void;
+  /** レポート未生成時の「インタビューを続ける」で呼ぶ再開処理 */
+  onResume?: () => void;
   isLoading: boolean;
   error: Error | null | undefined;
 }
@@ -30,6 +32,7 @@ export function InterviewSummaryInput({
   input,
   onInputChange,
   onSubmit,
+  onResume,
   isLoading,
   error,
 }: InterviewSummaryInputProps) {
@@ -51,16 +54,10 @@ export function InterviewSummaryInput({
             </Button>
           ) : (
             <>
-              <p className="text-sm text-mirai-text">
+              <p className="text-sm font-medium leading-[1.8] text-mirai-text mb-2">
                 お話しいただいた内容が短く、レポートを作成できませんでした。もう少しインタビューを続けると、レポートを作成できます。
               </p>
-              <Button
-                onClick={() =>
-                  onSubmit({ text: "もう少しインタビューを続けたいです。" })
-                }
-              >
-                インタビューを続ける
-              </Button>
+              <Button onClick={() => onResume?.()}>インタビューを続ける</Button>
               <Button variant="outline" asChild>
                 <Link href={getBillDetailLink(billId, previewToken) as Route}>
                   インタビューを終了する

--- a/web/src/features/interview-session/client/hooks/use-interview-chat.test.ts
+++ b/web/src/features/interview-session/client/hooks/use-interview-chat.test.ts
@@ -384,6 +384,56 @@ describe("useInterviewChat", () => {
     });
   });
 
+  describe("handleResumeInterview（レポート未生成時の続行）", () => {
+    it("summary_completeでもsubmitがcurrentStage=chatで呼ばれ、stageがchatに戻る", () => {
+      const { result } = renderHook(() =>
+        useInterviewChat({ billId: DEFAULT_BILL_ID, initialMessages: [] })
+      );
+
+      // チャット送信 → summary_complete へ遷移
+      act(() => {
+        result.current.handleSubmit({ text: "終了したい" });
+      });
+      act(() => {
+        mockState.onFinish?.({
+          object: { text: "完了しました", next_stage: "summary_complete" },
+          error: undefined,
+        });
+      });
+      expect(result.current.stage).toBe("summary_complete");
+
+      // 既存仕様: summary_complete では handleSubmit はブロックされる（これがバグの原因）
+      mockSubmit.mockClear();
+      act(() => {
+        result.current.handleSubmit({ text: "続けたい" });
+      });
+      expect(mockSubmit).not.toHaveBeenCalled();
+
+      // 修正: handleResumeInterview なら chat フェーズで再開できる
+      act(() => {
+        result.current.handleResumeInterview();
+      });
+      expect(result.current.stage).toBe("chat");
+      expect(mockSubmit).toHaveBeenCalledOnce();
+      expect(mockSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({ currentStage: "chat" })
+      );
+    });
+
+    it("ローディング中はsubmitを呼ばない", () => {
+      mockState.isLoading = true;
+      const { result } = renderHook(() =>
+        useInterviewChat({ billId: DEFAULT_BILL_ID, initialMessages: [] })
+      );
+
+      act(() => {
+        result.current.handleResumeInterview();
+      });
+
+      expect(mockSubmit).not.toHaveBeenCalled();
+    });
+  });
+
   describe("handleRetry", () => {
     it("canRetryがfalse: submitを呼ばない", () => {
       const { result } = renderHook(() =>

--- a/web/src/features/interview-session/client/hooks/use-interview-chat.ts
+++ b/web/src/features/interview-session/client/hooks/use-interview-chat.ts
@@ -210,6 +210,29 @@ export function useInterviewChat({
     handleSubmit({ text: reply });
   };
 
+  // レポート未生成時（hasReport=false）の「インタビューを続ける」用の再開処理。
+  // handleSubmit は stage==="summary_complete" のとき送信をブロックするため、
+  // そのまま流用すると summary_complete に到達したケースでボタンが無反応になる。
+  // ここでは stage を chat に戻し、chatフェーズで再開メッセージを送ることで、
+  // レポートが作れなかった状態から確実にインタビューを継続できるようにする
+  // （LLM の next_stage 判定に依存しない）。
+  const handleResumeInterview = () => {
+    if (isChatLoading) return;
+
+    const resumeText = "もう少しインタビューを続けたいです。";
+    setConversationMessages((prev) => [
+      ...prev,
+      {
+        id: `user-${Date.now()}`,
+        role: "user",
+        content: resumeText,
+      },
+    ]);
+    setInput("");
+    setStage("chat");
+    submitChatMessage(resumeText, "chat");
+  };
+
   // 手動リトライ関数
   const handleRetry = () => {
     if (!retry.canRetry) return;
@@ -236,5 +259,6 @@ export function useInterviewChat({
     handleSubmit,
     handleQuickReply,
     handleRetry,
+    handleResumeInterview,
   };
 }


### PR DESCRIPTION
## 背景・バグ

#872（マージ済み）で追加したレポート未生成時の「インタビューを続ける」ボタンが、**staging で押下しても無反応**だった。

### 原因
ボタンは `onSubmit`（= `useInterviewChat` の `handleSubmit`）を呼ぶが、`handleSubmit` は `stage === "summary_complete"` のとき送信を早期 return でブロックする。summary フェーズの LLM が `report=null` かつ `next_stage="summary_complete"` を返すと、**レポート未生成のまま `summary_complete` に到達**し、続行用ボタンが完全に無反応になっていた。

## 修正

- `useInterviewChat` に **`handleResumeInterview`** を追加。`stage` を `chat` に戻し、**chat フェーズで再開メッセージを送信**することで、レポートが作れなかった状態から確実にインタビューを継続できるようにした（LLM の `next_stage` 判定に依存しない決定論的な再開）。
- `InterviewSummaryInput` に任意プロップ `onResume` を追加し「インタビューを続ける」を配線。`onResume` は任意のため **Component Gallery は無改変**。
- あわせて未生成メッセージを **AIチャット本文と同じテキストスタイル**（`text-sm font-medium leading-[1.8] text-mirai-text`）に揃え、**8px（`mb-2`）の下マージン**を追加。

## 検証

- ✅ web 型チェック（`tsc --noEmit`）: pass
- ✅ interview-session unit tests: 336 pass（追加: `summary_complete` で `handleSubmit` はブロックされること／`handleResumeInterview` は `currentStage=chat` で送信し `stage` を `chat` に戻すこと）
- ✅ biome（変更ファイル）: クリーン
- ✅ Component Gallery で表示確認（下記）

> 注: 「無反応」の根本原因（`summary_complete` ブロック）は unit test で再現・修正を確認済み。実 LLM がこの状態を返す頻度自体は staging 依存のため、`handleResumeInterview` は phase に依らず確実に再開できる設計にしている。

## スクリーンショット（Component Gallery）

`/dev/features/interview/summary-input`。説明文はAIチャット本文と同じスタイル＋下8px余白。

<img src="https://pub-d6de2fb179d948d18c6b1ed89fcf1061.r2.dev/pr-873/summary-input-v3.png" width="820" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * インタビューセッション中、レポート生成前の要約画面から「インタビューを続ける」ボタンで、インタビューを再開できるようになりました。
  * ユーザーは中断せずにインタビューを継続できます。

* **改善**
  * レポート未生成時の案内文のスタイルを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->