### PR TITLE
インタビュー: 「インタビューを終了する」でセッションをアーカイブし中断扱いを解消

### DIFF
--- a/web/src/features/interview-session/client/components/interview-summary-input.tsx
+++ b/web/src/features/interview-session/client/components/interview-summary-input.tsx
@@ -1,12 +1,10 @@
 "use client";
 
-import type { Route } from "next";
-import Link from "next/link";
 import { useState } from "react";
 import type { PromptInputMessage } from "@/components/ai-elements/prompt-input";
 import { Button } from "@/components/ui/button";
-import { getBillDetailLink } from "@/features/interview-config/shared/utils/interview-links";
 import { InterviewPublicConsentModal } from "@/features/interview-report/client/components/interview-public-consent-modal";
+import { useEndInterview } from "../hooks/use-end-interview";
 import { useInterviewCompletion } from "../hooks/use-interview-completion";
 import { InterviewChatInput } from "./interview-chat-input";
 
@@ -40,6 +38,11 @@ export function InterviewSummaryInput({
   const { isCompleting, completeError, handleSubmit } = useInterviewCompletion({
     sessionId,
   });
+  const { endInterview, isEnding } = useEndInterview(
+    sessionId,
+    billId,
+    previewToken
+  );
 
   return (
     <>
@@ -58,10 +61,12 @@ export function InterviewSummaryInput({
                 お話しいただいた内容が短く、レポートを作成できませんでした。もう少しインタビューを続けると、レポートを作成できます。
               </p>
               <Button onClick={() => onResume?.()}>インタビューを続ける</Button>
-              <Button variant="outline" asChild>
-                <Link href={getBillDetailLink(billId, previewToken) as Route}>
-                  インタビューを終了する
-                </Link>
+              <Button
+                variant="outline"
+                onClick={endInterview}
+                disabled={isEnding}
+              >
+                {isEnding ? "終了中..." : "インタビューを終了する"}
               </Button>
             </>
           )}

--- a/web/src/features/interview-session/client/hooks/use-end-interview.test.ts
+++ b/web/src/features/interview-session/client/hooks/use-end-interview.test.ts
@@ -33,8 +33,44 @@ describe("useEndInterview", () => {
     });
 
     expect(mockArchive).toHaveBeenCalledWith("session-1");
-    expect(mockPush).toHaveBeenCalledOnce();
-    expect(typeof mockPush.mock.calls[0][0]).toBe("string");
+    expect(mockPush).toHaveBeenCalledWith("/bills/bill-1");
+    // archive → push の順序を固定（順序逆転の回帰を検出）
+    expect(mockArchive.mock.invocationCallOrder[0]).toBeLessThan(
+      mockPush.mock.invocationCallOrder[0]
+    );
+  });
+
+  it("previewToken 付きではプレビュー詳細URLへ遷移する", async () => {
+    mockArchive.mockResolvedValue({ success: true });
+
+    const { result } = renderHook(() =>
+      useEndInterview("session-1", "bill-1", "token-1")
+    );
+
+    await act(async () => {
+      await result.current.endInterview();
+    });
+
+    expect(mockPush).toHaveBeenCalledWith(
+      "/preview/bills/bill-1?token=token-1"
+    );
+  });
+
+  it("連続呼び出しでも archive と push は一度だけ実行される（再入ガード）", async () => {
+    mockArchive.mockResolvedValue({ success: true });
+
+    const { result } = renderHook(() => useEndInterview("session-1", "bill-1"));
+
+    await act(async () => {
+      // setIsEnding の反映を待たずに連続実行
+      await Promise.all([
+        result.current.endInterview(),
+        result.current.endInterview(),
+      ]);
+    });
+
+    expect(mockArchive).toHaveBeenCalledTimes(1);
+    expect(mockPush).toHaveBeenCalledTimes(1);
   });
 
   it("アーカイブが失敗してもユーザーは法案詳細へ遷移させる", async () => {
@@ -47,7 +83,7 @@ describe("useEndInterview", () => {
     });
 
     expect(mockArchive).toHaveBeenCalledWith("session-1");
-    expect(mockPush).toHaveBeenCalledOnce();
+    expect(mockPush).toHaveBeenCalledWith("/bills/bill-1");
   });
 
   it("アーカイブが例外を投げてもユーザーは遷移させる", async () => {
@@ -59,6 +95,6 @@ describe("useEndInterview", () => {
       await result.current.endInterview();
     });
 
-    expect(mockPush).toHaveBeenCalledOnce();
+    expect(mockPush).toHaveBeenCalledWith("/bills/bill-1");
   });
 });

--- a/web/src/features/interview-session/client/hooks/use-end-interview.test.ts
+++ b/web/src/features/interview-session/client/hooks/use-end-interview.test.ts
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockArchive, mockPush } = vi.hoisted(() => ({
+  mockArchive: vi.fn(),
+  mockPush: vi.fn(),
+}));
+
+vi.mock("../../server/actions/archive-interview-session", () => ({
+  archiveInterviewSession: mockArchive,
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+import { useEndInterview } from "./use-end-interview";
+
+describe("useEndInterview", () => {
+  beforeEach(() => {
+    mockArchive.mockReset();
+    mockPush.mockReset();
+  });
+
+  it("セッションをアーカイブしてから法案詳細へ遷移する", async () => {
+    mockArchive.mockResolvedValue({ success: true });
+
+    const { result } = renderHook(() => useEndInterview("session-1", "bill-1"));
+
+    await act(async () => {
+      await result.current.endInterview();
+    });
+
+    expect(mockArchive).toHaveBeenCalledWith("session-1");
+    expect(mockPush).toHaveBeenCalledOnce();
+    expect(typeof mockPush.mock.calls[0][0]).toBe("string");
+  });
+
+  it("アーカイブが失敗してもユーザーは法案詳細へ遷移させる", async () => {
+    mockArchive.mockResolvedValue({ success: false, error: "boom" });
+
+    const { result } = renderHook(() => useEndInterview("session-1", "bill-1"));
+
+    await act(async () => {
+      await result.current.endInterview();
+    });
+
+    expect(mockArchive).toHaveBeenCalledWith("session-1");
+    expect(mockPush).toHaveBeenCalledOnce();
+  });
+
+  it("アーカイブが例外を投げてもユーザーは遷移させる", async () => {
+    mockArchive.mockRejectedValue(new Error("network"));
+
+    const { result } = renderHook(() => useEndInterview("session-1", "bill-1"));
+
+    await act(async () => {
+      await result.current.endInterview();
+    });
+
+    expect(mockPush).toHaveBeenCalledOnce();
+  });
+});

--- a/web/src/features/interview-session/client/hooks/use-end-interview.ts
+++ b/web/src/features/interview-session/client/hooks/use-end-interview.ts
@@ -1,0 +1,39 @@
+"use client";
+
+import type { Route } from "next";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { getBillDetailLink } from "@/features/interview-config/shared/utils/interview-links";
+import { archiveInterviewSession } from "../../server/actions/archive-interview-session";
+
+/**
+ * 「インタビューを終了する」用のフック。
+ *
+ * レポート未生成のまま終了するとセッションが active（=「中断中」）のまま残り、
+ * 中断扱い・再開導線が表示されてしまう。終了時はセッションをアーカイブして
+ * status を none にし、中断扱いを解消したうえで法案詳細ページへ遷移する。
+ * アーカイブに失敗してもユーザーは離脱させる（status が変わらなくても致命的ではない）。
+ */
+export function useEndInterview(
+  sessionId: string,
+  billId: string,
+  previewToken?: string
+) {
+  const router = useRouter();
+  const [isEnding, setIsEnding] = useState(false);
+
+  const endInterview = async () => {
+    setIsEnding(true);
+    try {
+      const result = await archiveInterviewSession(sessionId);
+      if (!result.success) {
+        console.error("Failed to archive session on end:", result.error);
+      }
+    } catch (error) {
+      console.error("Failed to archive session on end:", error);
+    }
+    router.push(getBillDetailLink(billId, previewToken) as Route);
+  };
+
+  return { endInterview, isEnding };
+}

--- a/web/src/features/interview-session/client/hooks/use-end-interview.ts
+++ b/web/src/features/interview-session/client/hooks/use-end-interview.ts
@@ -2,7 +2,7 @@
 
 import type { Route } from "next";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { getBillDetailLink } from "@/features/interview-config/shared/utils/interview-links";
 import { archiveInterviewSession } from "../../server/actions/archive-interview-session";
 
@@ -21,8 +21,15 @@ export function useEndInterview(
 ) {
   const router = useRouter();
   const [isEnding, setIsEnding] = useState(false);
+  // setIsEnding は即時反映されないため、UI の disabled だけでは
+  // 連続呼び出し時に二重実行されうる。ref で再入を確実にガードする。
+  const isEndingRef = useRef(false);
 
   const endInterview = async () => {
+    if (isEndingRef.current) {
+      return;
+    }
+    isEndingRef.current = true;
     setIsEnding(true);
     try {
       const result = await archiveInterviewSession(sessionId);


### PR DESCRIPTION
## 背景・問題

レポート未生成時の安全網（#872 / #873）の「**インタビューを終了する**」は単なるリンクで法案詳細へ遷移するだけだった。そのためセッションが `active`（`completed_at`=null, `archived_at`=null）のまま残り、インタビューLPで **「中断中」バッジ・「AIインタビューを再開する」導線**が表示され、**中断扱い**になっていた。

ユーザーは「終了を選んだのに中断扱いになる」のを問題視していた。

## 仕様（前提）

`interview_session` に `status` カラムは無く、`completed_at`/`archived_at` から導出される:
- **active**（中断中）: 両方 null
- **completed**（回答完了）: `completed_at` あり
- **none**: アーカイブ済み or セッションなし

## 修正

`useEndInterview` を追加し、「インタビューを終了する」押下時に **`archiveInterviewSession` でセッションをアーカイブ**（→ status=none）してから法案詳細ページへ遷移する。

- 中断扱い（「中断中」バッジ・再開導線）が解消され、LP は「AIインタビューをはじめる」（新規）になる
- レポートが無いため `completed`（回答完了）にはしない（バッジとアクションボタンの不整合を避けるため）
- アーカイブに失敗してもユーザーは離脱させる（status が変わらなくても致命的ではない）

## 検証

- ✅ web 型チェック（`tsc --noEmit`）: pass
- ✅ interview-session unit tests: 339 pass（追加: `useEndInterview` がアーカイブ→遷移すること／失敗・例外時もユーザーを遷移させること）
- ✅ biome（変更ファイル）: クリーン

> 視覚的な変化はなし（「インタビューを終了する」ボタンの見た目は同じ、押下時のみ「終了中...」を表示）。挙動（アーカイブ）の変更のため、スクリーンショットは省略。
> ⚠️ staging 実機での最終確認（終了 → LP が新規表示になる）は未実施。マージ後に確認推奨。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 「インタビュー終了」操作をリンク遷移から終了処理ボタン実行へ変更しました。
  * 終了処理中はボタンを無効化し、ボタン文言を切り替えるようにしました。
  * 終了処理後は法案詳細ページへ遷移します（プレビュー指定に対応）。
* **Tests**
  * 終了処理の挙動を検証するテスト一式を新規追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->