### PR TITLE
fix: 廃止されたSupabaseの設定項目の削除

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -277,8 +277,6 @@ skip_nonce_check = false
 enabled = true
 client_id = "env(SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID)"
 secret = "env(SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET)"
-redirect_uri = ""
-url = ""
 skip_nonce_check = false
 
 # Allow Solana wallet holders to sign in to your project via the Sign in with Solana (SIWS, EIP-4361) standard.


### PR DESCRIPTION
## Overview

これらの項目は廃止されたようなので削除。

```toml
redirect_uri = ""
url = ""
```

`supabase@2.106.0`以降にて動作せず公式ドキュメントからも削除されていた。

## Related Issue

クローズした #876 に関連します。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Google連携の外部認証設定を整理し、不要な上書き設定を削除しました。
  * 認証設定は必要最小限の項目に統一され、挙動のばらつきが起きにくくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->