### PR TITLE
feat: AIインタビュー内容・トピック分析の内部向け取得MCPツールを追加

### DIFF
--- a/admin/src/features/mcp/server/create-handler.ts
+++ b/admin/src/features/mcp/server/create-handler.ts
@@ -8,6 +8,7 @@ import { registerBillsTools } from "./tools/register-bills-tools";
 import { registerDietSessionsTools } from "./tools/register-diet-sessions-tools";
 import { registerPreviewTools } from "./tools/register-preview-tools";
 import { registerTagsTools } from "./tools/register-tags-tools";
+import { registerTopicAnalysisTools } from "./tools/register-topic-analysis-tools";
 import { verifyMcpToken } from "./verify-token";
 
 export function createAdminMcpHandler() {
@@ -17,6 +18,7 @@ export function createAdminMcpHandler() {
       registerDietSessionsTools(server);
       registerPreviewTools(server);
       registerTagsTools(server);
+      registerTopicAnalysisTools(server);
     },
     {
       serverInfo: {

--- a/admin/src/features/mcp/server/tools/register-topic-analysis-tools.ts
+++ b/admin/src/features/mcp/server/tools/register-topic-analysis-tools.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import {
   getPublicBillRespondents,
+  getPublicRespondentDetail,
   getPublicTopicAnalysis,
 } from "@mirai-gikai/topic-analysis-core/public-server";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -11,9 +12,11 @@ import { jsonResult } from "../utils/json-result";
 /**
  * ユーザー向けトピック分析・公開インタビュー回答の「公開（PII セーフ）読み取り」ツール群。
  *
- * 返却データは web 公開表示と同一の §8 フィルタ
- * （管理者公開 × ユーザー公開 × モデレーションOK）を通過したもののみ。
- * user_id・email・会話生ログ等の個人情報は構造的に含まれない。
+ * 集計系（get_public_topic_analysis / list_public_respondents）は web 公開表示と同一の
+ * §8 フィルタを通過した構造化データのみで、会話生ログ等は含まない。
+ * get_respondent_detail は分析用に role_description・会話ログ（自由記述）を返すが、
+ * いずれもレポート公開判定（管理者公開 × ユーザー公開）を通過した公開レポートに限り、
+ * user_id・email・有識者登録情報（expert_registrations）等の識別子は含めない。
  */
 export function registerTopicAnalysisTools(server: McpServer): void {
   server.registerTool(
@@ -48,6 +51,28 @@ export function registerTopicAnalysisTools(server: McpServer): void {
     async ({ billId }) => {
       const respondents = await getPublicBillRespondents(billId);
       return jsonResult(respondents);
+    }
+  );
+
+  server.registerTool(
+    "get_respondent_detail",
+    {
+      title: "公開インタビュー回答の詳細（会話ログ）を取得",
+      description:
+        "指定レポートID（list_public_respondents の id）の公開AIインタビュー回答の詳細を返す。立場区分・肩書・立場説明（role_description）・賛否・要約に加え、AIとの会話ログ（質問と回答のやり取り）を含む。公開済み（ユーザー同意×管理者公開）のレポートのみ。立場説明・会話ログは回答者の自由記述のため固有名詞等が含まれ得る点に留意。見つからない／非公開なら status=not_found。user_id・email・有識者登録情報は含まない。",
+      inputSchema: {
+        reportId: z
+          .string()
+          .uuid()
+          .describe("対象レポートID（list_public_respondents の id）"),
+      },
+    },
+    async ({ reportId }) => {
+      const detail = await getPublicRespondentDetail(reportId);
+      if (!detail) {
+        return jsonResult({ status: "not_found", report_id: reportId });
+      }
+      return jsonResult(detail);
     }
   );
 }

--- a/admin/src/features/mcp/server/tools/register-topic-analysis-tools.ts
+++ b/admin/src/features/mcp/server/tools/register-topic-analysis-tools.ts
@@ -1,0 +1,53 @@
+import "server-only";
+
+import {
+  getPublicBillRespondents,
+  getPublicTopicAnalysis,
+} from "@mirai-gikai/topic-analysis-core/public-server";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { jsonResult } from "../utils/json-result";
+
+/**
+ * ユーザー向けトピック分析・公開インタビュー回答の「公開（PII セーフ）読み取り」ツール群。
+ *
+ * 返却データは web 公開表示と同一の §8 フィルタ
+ * （管理者公開 × ユーザー公開 × モデレーションOK）を通過したもののみ。
+ * user_id・email・会話生ログ等の個人情報は構造的に含まれない。
+ */
+export function registerTopicAnalysisTools(server: McpServer): void {
+  server.registerTool(
+    "get_public_topic_analysis",
+    {
+      title: "公開トピック分析を取得",
+      description:
+        "指定議案の公開中トピック分析を返す。トピックごとの意見件数・属性内訳（当事者/事業者/専門家/市民）・期待/懸念の集計と、公開済み意見（タイトル・本文・引用）を含む。公開済み（ユーザー同意×管理者公開×モデレーションOK）の意見のみ。公開版が無ければ status=not_ready を返す。個人を特定する情報（user_id・email等）は含まない。",
+      inputSchema: {
+        billId: z.string().uuid().describe("対象議案のID"),
+      },
+    },
+    async ({ billId }) => {
+      const analysis = await getPublicTopicAnalysis(billId);
+      if (!analysis) {
+        return jsonResult({ status: "not_ready", bill_id: billId });
+      }
+      return jsonResult(analysis);
+    }
+  );
+
+  server.registerTool(
+    "list_public_respondents",
+    {
+      title: "公開インタビュー回答一覧を取得",
+      description:
+        "指定議案の公開済みAIインタビュー回答（回答者1人=1件）を新しい順で返す。各件は立場区分・肩書・賛否（期待/懸念）・要約を含む。公開済み（ユーザー同意×管理者公開）のレポートのみ。個人を特定する情報（user_id・email・会話生ログ等）は含まない。",
+      inputSchema: {
+        billId: z.string().uuid().describe("対象議案のID"),
+      },
+    },
+    async ({ billId }) => {
+      const respondents = await getPublicBillRespondents(billId);
+      return jsonResult(respondents);
+    }
+  );
+}

--- a/admin/src/features/mcp/server/tools/register-topic-analysis-tools.ts
+++ b/admin/src/features/mcp/server/tools/register-topic-analysis-tools.ts
@@ -1,36 +1,63 @@
 import "server-only";
 
 import {
-  getPublicBillRespondents,
-  getPublicRespondentDetail,
-  getPublicTopicAnalysis,
-} from "@mirai-gikai/topic-analysis-core/public-server";
+  getRespondentDetail,
+  getTopicAnalysis,
+  listRespondents,
+} from "@mirai-gikai/topic-analysis-core/internal-server";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { jsonResult } from "../utils/json-result";
 
 /**
- * ユーザー向けトピック分析・公開インタビュー回答の「公開（PII セーフ）読み取り」ツール群。
+ * AIインタビュー内容・トピック分析の**内部向け**読み取りツール群。
  *
- * 集計系（get_public_topic_analysis / list_public_respondents）は web 公開表示と同一の
- * §8 フィルタを通過した構造化データのみで、会話生ログ等は含まない。
- * get_respondent_detail は分析用に role_description・会話ログ（自由記述）を返すが、
- * いずれもレポート公開判定（管理者公開 × ユーザー公開）を通過した公開レポートに限り、
- * user_id・email・有識者登録情報（expert_registrations）等の識別子は含めない。
+ * これは管理者トークン（ADMIN_MCP_TOKEN）で到達する内部ツールであり、**既定では
+ * 公開・非公開・モデレーション状態を問わず全件取得**する。プロンプト等から取得条件
+ * （公開フラグ・モデレーション状態・公開件数ゲート）を指定したときのみ、その条件で
+ * クエリを絞り込む。
+ *
+ * 取得対象には未公開・未モデレーションのレポートや会話ログ（自由記述）が含まれ得る。
+ * ただし user_id・email・有識者登録情報（expert_registrations）等の**直接識別子は
+ * 返却型に含めない**。web 公開ページの「公開（§8 固定）」表示とは別経路。
  */
+
+/** 全ツール共通の任意フィルタ。未指定の項目は絞り込まない（＝全件対象）。 */
+const filterInput = {
+  isPublicByAdmin: z
+    .boolean()
+    .optional()
+    .describe("管理者公開フラグで絞り込む（未指定なら絞らない）"),
+  isPublicByUser: z
+    .boolean()
+    .optional()
+    .describe("ユーザー公開（同意）フラグで絞り込む（未指定なら絞らない）"),
+  moderationStatus: z
+    .enum(["ok", "warning", "ng"])
+    .optional()
+    .describe("モデレーション状態で絞り込む（例: ok のみ対象にする）"),
+  requireDisplayThreshold: z
+    .boolean()
+    .optional()
+    .describe(
+      "true で web と同じ k-匿名性ゲート（公開レポートが20件以上の議案のみ）を適用する"
+    ),
+};
+
 export function registerTopicAnalysisTools(server: McpServer): void {
   server.registerTool(
-    "get_public_topic_analysis",
+    "get_topic_analysis",
     {
-      title: "公開トピック分析を取得",
+      title: "トピック分析を取得（内部向け）",
       description:
-        "指定議案の公開中トピック分析を返す。トピックごとの意見件数・属性内訳（当事者/事業者/専門家/市民）・期待/懸念の集計と、公開済み意見（タイトル・本文・引用）を含む。公開済み（ユーザー同意×管理者公開×モデレーションOK）の意見のみ。公開版が無ければ status=not_ready を返す。個人を特定する情報（user_id・email等）は含まない。",
+        "指定議案の最新トピック分析（公開・非公開を問わず最新版）を返す。トピックごとの意見件数・属性内訳（当事者/事業者/専門家/市民）・期待/懸念の集計と意見（タイトル・本文・引用）を含む。既定では全意見が対象。任意フィルタ（公開フラグ・モデレーション状態・公開件数ゲート）で絞り込める。版が無い／件数ゲートで隠す場合は status=not_ready。user_id・email 等の直接識別子は含まない。",
       inputSchema: {
         billId: z.string().uuid().describe("対象議案のID"),
+        ...filterInput,
       },
     },
-    async ({ billId }) => {
-      const analysis = await getPublicTopicAnalysis(billId);
+    async ({ billId, ...filter }) => {
+      const analysis = await getTopicAnalysis(billId, filter);
       if (!analysis) {
         return jsonResult({ status: "not_ready", bill_id: billId });
       }
@@ -39,17 +66,21 @@ export function registerTopicAnalysisTools(server: McpServer): void {
   );
 
   server.registerTool(
-    "list_public_respondents",
+    "list_respondents",
     {
-      title: "公開インタビュー回答一覧を取得",
+      title: "インタビュー回答一覧を取得（内部向け）",
       description:
-        "指定議案の公開済みAIインタビュー回答（回答者1人=1件）を新しい順で返す。各件は立場区分・肩書・賛否（期待/懸念）・要約を含む。公開済み（ユーザー同意×管理者公開）のレポートのみ。個人を特定する情報（user_id・email・会話生ログ等）は含まない。",
+        "指定議案のAIインタビュー回答（回答者1人=1件）を新しい順で返す。各件は立場区分・肩書・賛否（期待/懸念）・要約を含む。既定では公開・非公開を問わず全件。任意フィルタ（公開フラグ・モデレーション状態・公開件数ゲート）で絞り込める。件数ゲートで隠す場合は status=below_threshold。user_id・email 等の直接識別子は含まない。",
       inputSchema: {
         billId: z.string().uuid().describe("対象議案のID"),
+        ...filterInput,
       },
     },
-    async ({ billId }) => {
-      const respondents = await getPublicBillRespondents(billId);
+    async ({ billId, ...filter }) => {
+      const respondents = await listRespondents(billId, filter);
+      if (respondents === null) {
+        return jsonResult({ status: "below_threshold", bill_id: billId });
+      }
       return jsonResult(respondents);
     }
   );
@@ -57,18 +88,19 @@ export function registerTopicAnalysisTools(server: McpServer): void {
   server.registerTool(
     "get_respondent_detail",
     {
-      title: "公開インタビュー回答の詳細（会話ログ）を取得",
+      title: "インタビュー回答の詳細（会話ログ）を取得（内部向け）",
       description:
-        "指定レポートID（list_public_respondents の id）の公開AIインタビュー回答の詳細を返す。立場区分・肩書・立場説明（role_description）・賛否・要約に加え、AIとの会話ログ（質問と回答のやり取り）を含む。公開済み（ユーザー同意×管理者公開）のレポートのみ。立場説明・会話ログは回答者の自由記述のため固有名詞等が含まれ得る点に留意。見つからない／非公開なら status=not_found。user_id・email・有識者登録情報は含まない。",
+        "指定レポートID（list_respondents の id）の回答詳細を返す。立場区分・肩書・立場説明（role_description）・賛否・要約に加え、AIとの会話ログ（質問と回答のやり取り）を含む。既定では公開・非公開・モデレーション状態を問わず取得。任意フィルタ（公開フラグ・モデレーション状態・公開件数ゲート requireDisplayThreshold）で絞り込める。立場説明・会話ログは自由記述のため固有名詞等が含まれ得る。条件に合致しない／存在しないなら status=not_found。user_id・email・有識者登録情報は含まない。",
       inputSchema: {
         reportId: z
           .string()
           .uuid()
-          .describe("対象レポートID（list_public_respondents の id）"),
+          .describe("対象レポートID（list_respondents の id）"),
+        ...filterInput,
       },
     },
-    async ({ reportId }) => {
-      const detail = await getPublicRespondentDetail(reportId);
+    async ({ reportId, ...filter }) => {
+      const detail = await getRespondentDetail(reportId, filter);
       if (!detail) {
         return jsonResult({ status: "not_found", report_id: reportId });
       }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -44,6 +44,10 @@
       "types": "./src/report-publication/auto-publish.ts",
       "default": "./src/report-publication/auto-publish.ts"
     },
+    "./report-publication/count-public-reports": {
+      "types": "./src/report-publication/count-public-reports.ts",
+      "default": "./src/report-publication/count-public-reports.ts"
+    },
     "./interview-prompts/types": {
       "types": "./src/interview-prompts/types.ts",
       "default": "./src/interview-prompts/types.ts"

--- a/packages/shared/src/report-publication/count-public-reports.ts
+++ b/packages/shared/src/report-publication/count-public-reports.ts
@@ -1,0 +1,30 @@
+import "server-only";
+
+import { createAdminClient } from "@mirai-gikai/supabase";
+
+/**
+ * 議案の公開レポート件数を数える（公開 = is_public_by_admin × is_public_by_user）。
+ * k-匿名性しきい値（[[shouldDisplayPublicReports]]）の判定や公開ページの表示制御に使う共通関数。
+ *
+ * web の公開ページ・OG画像・リアクション、admin MCP の回答詳細ゲートが同一定義を共有する。
+ */
+export async function countPublicReportsByBillId(
+  billId: string
+): Promise<number> {
+  const supabase = createAdminClient();
+  const { count, error } = await supabase
+    .from("interview_report")
+    .select("id, interview_sessions!inner(interview_configs!inner(bill_id))", {
+      count: "exact",
+      head: true,
+    })
+    .eq("is_public_by_admin", true)
+    .eq("is_public_by_user", true)
+    .eq("interview_sessions.interview_configs.bill_id", billId);
+
+  if (error) {
+    throw new Error(`Failed to count public interview reports: ${error.message}`);
+  }
+
+  return count ?? 0;
+}

--- a/packages/topic-analysis-core/package.json
+++ b/packages/topic-analysis-core/package.json
@@ -45,7 +45,8 @@
   "dependencies": {
     "@mirai-gikai/shared": "workspace:*",
     "@mirai-gikai/supabase": "workspace:*",
-    "ai": "^6.0.3"
+    "ai": "^6.0.3",
+    "server-only": "^0.0.1"
   },
   "peerDependencies": {
     "zod": "^4.0.0"

--- a/packages/topic-analysis-core/package.json
+++ b/packages/topic-analysis-core/package.json
@@ -25,6 +25,14 @@
       "types": "./src/repositories/repository.ts",
       "default": "./src/repositories/repository.ts"
     },
+    "./public": {
+      "types": "./src/public/public.ts",
+      "default": "./src/public/public.ts"
+    },
+    "./public-server": {
+      "types": "./src/public/public-server.ts",
+      "default": "./src/public/public-server.ts"
+    },
     "./constants": {
       "types": "./src/shared/constants.ts",
       "default": "./src/shared/constants.ts"

--- a/packages/topic-analysis-core/package.json
+++ b/packages/topic-analysis-core/package.json
@@ -33,6 +33,10 @@
       "types": "./src/public/public-server.ts",
       "default": "./src/public/public-server.ts"
     },
+    "./internal-server": {
+      "types": "./src/internal/internal-server.ts",
+      "default": "./src/internal/internal-server.ts"
+    },
     "./constants": {
       "types": "./src/shared/constants.ts",
       "default": "./src/shared/constants.ts"

--- a/packages/topic-analysis-core/src/internal/internal-server.ts
+++ b/packages/topic-analysis-core/src/internal/internal-server.ts
@@ -1,0 +1,12 @@
+import "server-only";
+
+// 内部用途（admin MCP）の**サーバ専用**読み取りエントリポイント。
+// デフォルトで公開・非公開・モデレーション状態を問わず取得し、ReadFilter で任意に絞り込む。
+// web 公開ページの「公開（§8 固定）」経路（@mirai-gikai/topic-analysis-core/public-server）とは別物。
+// 直接識別子（user_id・email・expert_registrations）は返却型に含めない。
+export {
+  type ReadFilter,
+  getRespondentDetail,
+  getTopicAnalysis,
+  listRespondents,
+} from "./loaders";

--- a/packages/topic-analysis-core/src/internal/loaders.ts
+++ b/packages/topic-analysis-core/src/internal/loaders.ts
@@ -1,0 +1,130 @@
+import "server-only";
+
+import { shouldDisplayPublicReports } from "@mirai-gikai/shared/report-publication/auto-publish";
+import { countPublicReportsByBillId } from "@mirai-gikai/shared/report-publication/count-public-reports";
+import { buildPublicBillRespondents } from "../public/build-public-bill-respondents";
+import { buildPublicRespondentDetail } from "../public/build-public-respondent-detail";
+import { buildPublicTopicAnalysis } from "../public/build-public-topic-analysis";
+import {
+  findLatestAnalysis,
+  findRespondentDetail,
+  findRespondentRows,
+  type ModerationStatus,
+  type ReportRowFilter,
+  type RespondentDetailFilter,
+} from "../public/public-read-repository";
+import type {
+  PublicRespondent,
+  PublicRespondentDetail,
+  PublicTopicAnalysis,
+  RawOpinionRow,
+} from "../public/public-types";
+
+/**
+ * 内部用途（admin MCP）の取得条件。**未指定の項目は制約しない**（＝全件対象）。
+ * デフォルト（空）では公開・非公開・モデレーション状態を問わず全件返す。
+ * プロンプト等から条件を指定したときのみ、その条件でクエリを絞り込む。
+ *
+ * 注意: これは「公開（PII セーフ）」経路ではない。web 公開ページは別途
+ * `getPublicTopicAnalysis` / `getPublicBillRespondents`（§8 固定）を使う。
+ * ただし本経路でも user_id・email・有識者登録情報等の直接識別子は返却型に含めない。
+ */
+export type ReadFilter = {
+  isPublicByAdmin?: boolean;
+  isPublicByUser?: boolean;
+  moderationStatus?: ModerationStatus;
+  /** true のとき web と同じ k-匿名性ゲート（公開レポート >= 20 件）を適用。 */
+  requireDisplayThreshold?: boolean;
+};
+
+/** ReadFilter から、トピック分析の意見述語を組み立てる（未指定なら全件通す）。 */
+function opinionPredicate(filter: ReadFilter): (o: RawOpinionRow) => boolean {
+  return (o) => {
+    if (
+      filter.isPublicByAdmin !== undefined &&
+      o.is_public_by_admin !== filter.isPublicByAdmin
+    ) {
+      return false;
+    }
+    if (
+      filter.isPublicByUser !== undefined &&
+      o.is_public_by_user !== filter.isPublicByUser
+    ) {
+      return false;
+    }
+    if (
+      filter.moderationStatus !== undefined &&
+      o.moderation_status !== filter.moderationStatus
+    ) {
+      return false;
+    }
+    return true;
+  };
+}
+
+/** requireDisplayThreshold 指定時、公開レポートが k-匿名性しきい値未満なら true（＝隠す）。 */
+async function blockedByThreshold(
+  billId: string,
+  filter: ReadFilter
+): Promise<boolean> {
+  if (!filter.requireDisplayThreshold) return false;
+  const count = await countPublicReportsByBillId(billId);
+  return !shouldDisplayPublicReports(count);
+}
+
+/**
+ * 議案の最新トピック分析を取得する（公開・非公開を問わず最新版）。
+ * filter で意見を絞り込み、件数・内訳・期待/懸念はフィルタ後の集合から再計算する。
+ * version が無い／件数ゲートで隠す場合は null。
+ */
+export async function getTopicAnalysis(
+  billId: string,
+  filter: ReadFilter = {}
+): Promise<PublicTopicAnalysis | null> {
+  if (await blockedByThreshold(billId, filter)) return null;
+  const data = await findLatestAnalysis(billId);
+  if (!data) return null;
+  return buildPublicTopicAnalysis(
+    data.meta,
+    data.rawTopics,
+    opinionPredicate(filter)
+  );
+}
+
+/**
+ * 議案の回答者一覧を取得する（回答者1人=1件、新しい順）。
+ * filter 未指定なら公開・非公開を問わず全件。件数ゲートで隠す場合は null。
+ */
+export async function listRespondents(
+  billId: string,
+  filter: ReadFilter = {}
+): Promise<PublicRespondent[] | null> {
+  if (await blockedByThreshold(billId, filter)) return null;
+  const rowFilter: ReportRowFilter = {
+    isPublicByAdmin: filter.isPublicByAdmin,
+    isPublicByUser: filter.isPublicByUser,
+    moderationStatus: filter.moderationStatus,
+  };
+  const rows = await findRespondentRows(billId, rowFilter);
+  return buildPublicBillRespondents(rows);
+}
+
+/**
+ * レポート1件の詳細（立場説明＋会話ログ）を取得する。
+ * filter で公開フラグ・モデレーション・件数ゲート（requireDisplayThreshold）を任意に適用。
+ * 条件に合致しない／存在しない場合は null（呼び出し側で not_found 扱い）。
+ */
+export async function getRespondentDetail(
+  reportId: string,
+  filter: ReadFilter = {}
+): Promise<PublicRespondentDetail | null> {
+  const detailFilter: RespondentDetailFilter = {
+    isPublicByAdmin: filter.isPublicByAdmin,
+    isPublicByUser: filter.isPublicByUser,
+    moderationStatus: filter.moderationStatus,
+    requireDisplayThreshold: filter.requireDisplayThreshold,
+  };
+  const data = await findRespondentDetail(reportId, detailFilter);
+  if (!data) return null;
+  return buildPublicRespondentDetail(data.report, data.messages);
+}

--- a/packages/topic-analysis-core/src/public/build-public-bill-respondents.test.ts
+++ b/packages/topic-analysis-core/src/public/build-public-bill-respondents.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { RawRespondentRow } from "../types";
+import type { RawRespondentRow } from "./public-types";
 import { buildPublicBillRespondents } from "./build-public-bill-respondents";
 
 function row(overrides: Partial<RawRespondentRow> = {}): RawRespondentRow {

--- a/packages/topic-analysis-core/src/public/build-public-bill-respondents.ts
+++ b/packages/topic-analysis-core/src/public/build-public-bill-respondents.ts
@@ -1,9 +1,11 @@
-import type { PublicRespondent, RawRespondentRow } from "../types";
 import { mapRoleToCategory } from "./build-public-topic-analysis";
-import { normalizeRoleTitle } from "./topic-category";
+import { normalizeRoleTitle } from "./normalize-role-title";
+import type { PublicRespondent, RawRespondentRow } from "./public-types";
 
-/** interview_report.stance を 期待/懸念 に正規化（neutral 等は null）。 */
-function toBillSentiment(stance: string | null): "期待" | "懸念" | null {
+/** interview_report.stance（for/against）を 期待/懸念 に正規化（neutral 等は null）。 */
+function normalizeStanceToSentiment(
+  stance: string | null
+): "期待" | "懸念" | null {
   if (stance === "for") return "期待";
   if (stance === "against") return "懸念";
   return null;
@@ -20,7 +22,7 @@ export function buildPublicBillRespondents(
     id: r.id,
     user_category: mapRoleToCategory(r.role),
     role_title: normalizeRoleTitle(r.role_title),
-    bill_sentiment: toBillSentiment(r.stance),
+    bill_sentiment: normalizeStanceToSentiment(r.stance),
     summary: r.summary,
     created_at: r.created_at,
   }));

--- a/packages/topic-analysis-core/src/public/build-public-bill-respondents.ts
+++ b/packages/topic-analysis-core/src/public/build-public-bill-respondents.ts
@@ -1,15 +1,7 @@
 import { mapRoleToCategory } from "./build-public-topic-analysis";
 import { normalizeRoleTitle } from "./normalize-role-title";
+import { normalizeStanceToSentiment } from "./normalize-stance";
 import type { PublicRespondent, RawRespondentRow } from "./public-types";
-
-/** interview_report.stance（for/against）を 期待/懸念 に正規化（neutral 等は null）。 */
-function normalizeStanceToSentiment(
-  stance: string | null
-): "期待" | "懸念" | null {
-  if (stance === "for") return "期待";
-  if (stance === "against") return "懸念";
-  return null;
-}
 
 /**
  * 公開レポートの生行から、回答一覧カード用の表示データを構築する純粋関数。

--- a/packages/topic-analysis-core/src/public/build-public-respondent-detail.test.ts
+++ b/packages/topic-analysis-core/src/public/build-public-respondent-detail.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { buildPublicRespondentDetail } from "./build-public-respondent-detail";
+import type {
+  RawRespondentDetailRow,
+  RawTranscriptMessageRow,
+} from "./public-types";
+
+const baseReport: RawRespondentDetailRow = {
+  id: "report-1",
+  role: "work_related",
+  role_title: "運送業の経営者",
+  stance: "against",
+  summary: "要約テキスト",
+  role_description: "運送会社を経営しています",
+  created_at: "2026-06-01T00:00:00Z",
+};
+
+describe("buildPublicRespondentDetail", () => {
+  it("role→カテゴリ・stance→懸念に正規化し、role_description と会話ログを返す", () => {
+    const messages: RawTranscriptMessageRow[] = [
+      {
+        id: "m1",
+        role: "assistant",
+        content: "この法案についてどう思いますか？",
+        created_at: "2026-06-01T00:00:01Z",
+      },
+      {
+        id: "m2",
+        role: "user",
+        content: "燃料費が下がるのはありがたいです",
+        created_at: "2026-06-01T00:00:02Z",
+      },
+    ];
+
+    const result = buildPublicRespondentDetail(baseReport, messages);
+
+    expect(result.id).toBe("report-1");
+    expect(result.user_category).toBe("industry");
+    expect(result.role_title).toBe("運送業の経営者");
+    expect(result.role_description).toBe("運送会社を経営しています");
+    expect(result.bill_sentiment).toBe("懸念");
+    expect(result.messages).toEqual([
+      {
+        id: "m1",
+        speaker: "assistant",
+        content: "この法案についてどう思いますか？",
+        created_at: "2026-06-01T00:00:01Z",
+      },
+      {
+        id: "m2",
+        speaker: "user",
+        content: "燃料費が下がるのはありがたいです",
+        created_at: "2026-06-01T00:00:02Z",
+      },
+    ]);
+  });
+
+  it("assistant/user 以外のメッセージ（system 等）は会話ログから除外する", () => {
+    const messages: RawTranscriptMessageRow[] = [
+      { id: "s1", role: "system", content: "システム指示", created_at: null },
+      { id: "u1", role: "user", content: "回答", created_at: null },
+    ];
+
+    const result = buildPublicRespondentDetail(baseReport, messages);
+
+    expect(result.messages.map((m) => m.id)).toEqual(["u1"]);
+  });
+
+  it("会話ログが空でも詳細を返す", () => {
+    const result = buildPublicRespondentDetail(baseReport, []);
+    expect(result.messages).toEqual([]);
+  });
+});

--- a/packages/topic-analysis-core/src/public/build-public-respondent-detail.ts
+++ b/packages/topic-analysis-core/src/public/build-public-respondent-detail.ts
@@ -1,0 +1,48 @@
+import { mapRoleToCategory } from "./build-public-topic-analysis";
+import { normalizeRoleTitle } from "./normalize-role-title";
+import { normalizeStanceToSentiment } from "./normalize-stance";
+import type {
+  PublicRespondentDetail,
+  RawRespondentDetailRow,
+  RawTranscriptMessageRow,
+  TranscriptMessage,
+} from "./public-types";
+
+/** interview_messages.role を会話ログの speaker に正規化（assistant/user 以外は除外）。 */
+function toSpeaker(role: string | null): TranscriptMessage["speaker"] | null {
+  if (role === "assistant" || role === "user") return role;
+  return null;
+}
+
+/**
+ * 公開レポートの生行＋会話メッセージから、回答者詳細の表示データを構築する純粋関数。
+ * role→カテゴリ・stance→期待/懸念に正規化し、会話ログは assistant/user のみ残す。
+ * フィルタ（管理者公開×ユーザー公開）は取得側で適用済み。
+ */
+export function buildPublicRespondentDetail(
+  report: RawRespondentDetailRow,
+  messages: RawTranscriptMessageRow[]
+): PublicRespondentDetail {
+  const transcript: TranscriptMessage[] = [];
+  for (const m of messages) {
+    const speaker = toSpeaker(m.role);
+    if (!speaker) continue;
+    transcript.push({
+      id: m.id,
+      speaker,
+      content: m.content,
+      created_at: m.created_at,
+    });
+  }
+
+  return {
+    id: report.id,
+    user_category: mapRoleToCategory(report.role),
+    role_title: normalizeRoleTitle(report.role_title),
+    role_description: report.role_description,
+    bill_sentiment: normalizeStanceToSentiment(report.stance),
+    summary: report.summary,
+    created_at: report.created_at,
+    messages: transcript,
+  };
+}

--- a/packages/topic-analysis-core/src/public/build-public-topic-analysis.test.ts
+++ b/packages/topic-analysis-core/src/public/build-public-topic-analysis.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { RawOpinionRow, RawTopicRow } from "../types";
+import type { RawOpinionRow, RawTopicRow } from "./public-types";
 import {
   buildPublicTopicAnalysis,
   mapRoleToCategory,

--- a/packages/topic-analysis-core/src/public/build-public-topic-analysis.ts
+++ b/packages/topic-analysis-core/src/public/build-public-topic-analysis.ts
@@ -1,3 +1,4 @@
+import { normalizeRoleTitle } from "./normalize-role-title";
 import type {
   PublicOpinion,
   PublicTopic,
@@ -6,8 +7,7 @@ import type {
   RawOpinionRow,
   RawTopicRow,
   UserCategory,
-} from "../types";
-import { normalizeRoleTitle } from "./topic-category";
+} from "./public-types";
 
 /** interview_report.role → §9 の4区分。未知/null は一般市民に倒す。 */
 export function mapRoleToCategory(role: string | null): UserCategory {

--- a/packages/topic-analysis-core/src/public/build-public-topic-analysis.ts
+++ b/packages/topic-analysis-core/src/public/build-public-topic-analysis.ts
@@ -27,8 +27,9 @@ export function mapRoleToCategory(role: string | null): UserCategory {
 /**
  * §8 表示時フィルタの最終ゲート: 管理者公開 × ユーザー公開 × モデレーションOK のみ通す。
  * 分析後に管理者が非公開化・ユーザーが同意撤回した意見は即座に除外される。
+ * web 公開ページのデフォルト述語。内部用途では別の述語を渡して上書きできる。
  */
-function isDisplayable(o: RawOpinionRow): boolean {
+export function isDisplayable(o: RawOpinionRow): boolean {
   return (
     o.is_public_by_admin === true &&
     o.is_public_by_user === true &&
@@ -51,18 +52,21 @@ function toBillSentiment(value: string | null): "期待" | "懸念" | null {
  */
 export function buildPublicTopicAnalysis(
   meta: PublishedVersionMeta,
-  rawTopics: RawTopicRow[]
+  rawTopics: RawTopicRow[],
+  // 含める意見の述語。デフォルトは web 公開ページの §8 フィルタ。
+  // 内部用途（admin MCP）では任意の述語を渡して取得条件を変えられる。
+  includeOpinion: (o: RawOpinionRow) => boolean = isDisplayable
 ): PublicTopicAnalysis {
   const topics: PublicTopic[] = [];
   let totalOpinions = 0;
 
   for (const rawTopic of rawTopics) {
-    // §8 フィルタ後、richness（情報充実度）降順で並べる。
+    // フィルタ後、richness（情報充実度）降順で並べる。
     // 充実した引用が先頭になり、カード・詳細ともに優先表示される。
     // null（旧データ・未生成）は最後尾。同点は元順序（report_id, opinion_index）を保つ
     // ＝ V8 の安定ソートに依存。集計（件数・内訳・sentiment）は順序の影響を受けない。
     const displayable = rawTopic.opinions
-      .filter(isDisplayable)
+      .filter(includeOpinion)
       .slice()
       .sort((a, b) => (b.richness ?? -1) - (a.richness ?? -1));
     if (displayable.length === 0) {

--- a/packages/topic-analysis-core/src/public/loaders.ts
+++ b/packages/topic-analysis-core/src/public/loaders.ts
@@ -1,16 +1,10 @@
 import "server-only";
 
 import { buildPublicBillRespondents } from "./build-public-bill-respondents";
-import { buildPublicRespondentDetail } from "./build-public-respondent-detail";
 import { buildPublicTopicAnalysis } from "./build-public-topic-analysis";
-import type {
-  PublicRespondent,
-  PublicRespondentDetail,
-  PublicTopicAnalysis,
-} from "./public-types";
+import type { PublicRespondent, PublicTopicAnalysis } from "./public-types";
 import {
   findPublicBillRespondentRows,
-  findPublicRespondentDetail,
   findPublishedAnalysis,
 } from "./public-read-repository";
 
@@ -18,7 +12,7 @@ import {
  * 議案の公開中トピック分析を、§8 の表示時フィルタ適用後の表示用データで取得する。
  * 公開版が無ければ null（呼び出し側で「分析準備中」扱いにする）。
  *
- * web の Server Components / 公開 API と admin MCP が同一の PII セーフな経路を共有する。
+ * web の Server Components / 公開 API が使用する公開（PII セーフ）経路。
  */
 export async function getPublicTopicAnalysis(
   billId: string
@@ -37,17 +31,4 @@ export async function getPublicBillRespondents(
 ): Promise<PublicRespondent[]> {
   const rows = await findPublicBillRespondentRows(billId);
   return buildPublicBillRespondents(rows);
-}
-
-/**
- * 公開レポート1件の詳細（立場説明＋会話ログ）を取得する。
- * 回答一覧と同一基準（管理者公開×ユーザー公開）でフィルタ。
- * 非公開・存在しない場合は null（呼び出し側で not_found 扱い）。
- */
-export async function getPublicRespondentDetail(
-  reportId: string
-): Promise<PublicRespondentDetail | null> {
-  const data = await findPublicRespondentDetail(reportId);
-  if (!data) return null;
-  return buildPublicRespondentDetail(data.report, data.messages);
 }

--- a/packages/topic-analysis-core/src/public/loaders.ts
+++ b/packages/topic-analysis-core/src/public/loaders.ts
@@ -1,0 +1,32 @@
+import { buildPublicBillRespondents } from "./build-public-bill-respondents";
+import { buildPublicTopicAnalysis } from "./build-public-topic-analysis";
+import type { PublicRespondent, PublicTopicAnalysis } from "./public-types";
+import {
+  findPublicBillRespondentRows,
+  findPublishedAnalysis,
+} from "./public-read-repository";
+
+/**
+ * 議案の公開中トピック分析を、§8 の表示時フィルタ適用後の表示用データで取得する。
+ * 公開版が無ければ null（呼び出し側で「分析準備中」扱いにする）。
+ *
+ * web の Server Components / 公開 API と admin MCP が同一の PII セーフな経路を共有する。
+ */
+export async function getPublicTopicAnalysis(
+  billId: string
+): Promise<PublicTopicAnalysis | null> {
+  const data = await findPublishedAnalysis(billId);
+  if (!data) return null;
+  return buildPublicTopicAnalysis(data.meta, data.rawTopics);
+}
+
+/**
+ * 議案の公開レポート（回答者）を全件取得する。
+ * AIインタビュー回答一覧（回答者1人=1カード）で使用する。
+ */
+export async function getPublicBillRespondents(
+  billId: string
+): Promise<PublicRespondent[]> {
+  const rows = await findPublicBillRespondentRows(billId);
+  return buildPublicBillRespondents(rows);
+}

--- a/packages/topic-analysis-core/src/public/loaders.ts
+++ b/packages/topic-analysis-core/src/public/loaders.ts
@@ -1,8 +1,16 @@
+import "server-only";
+
 import { buildPublicBillRespondents } from "./build-public-bill-respondents";
+import { buildPublicRespondentDetail } from "./build-public-respondent-detail";
 import { buildPublicTopicAnalysis } from "./build-public-topic-analysis";
-import type { PublicRespondent, PublicTopicAnalysis } from "./public-types";
+import type {
+  PublicRespondent,
+  PublicRespondentDetail,
+  PublicTopicAnalysis,
+} from "./public-types";
 import {
   findPublicBillRespondentRows,
+  findPublicRespondentDetail,
   findPublishedAnalysis,
 } from "./public-read-repository";
 
@@ -29,4 +37,17 @@ export async function getPublicBillRespondents(
 ): Promise<PublicRespondent[]> {
   const rows = await findPublicBillRespondentRows(billId);
   return buildPublicBillRespondents(rows);
+}
+
+/**
+ * 公開レポート1件の詳細（立場説明＋会話ログ）を取得する。
+ * 回答一覧と同一基準（管理者公開×ユーザー公開）でフィルタ。
+ * 非公開・存在しない場合は null（呼び出し側で not_found 扱い）。
+ */
+export async function getPublicRespondentDetail(
+  reportId: string
+): Promise<PublicRespondentDetail | null> {
+  const data = await findPublicRespondentDetail(reportId);
+  if (!data) return null;
+  return buildPublicRespondentDetail(data.report, data.messages);
 }

--- a/packages/topic-analysis-core/src/public/normalize-role-title.test.ts
+++ b/packages/topic-analysis-core/src/public/normalize-role-title.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { normalizeRoleTitle } from "./normalize-role-title";
+
+describe("normalizeRoleTitle", () => {
+  it("固有の肩書はそのまま返す", () => {
+    expect(normalizeRoleTitle("育休経験者")).toBe("育休経験者");
+  });
+  it("前後の空白はトリムする", () => {
+    expect(normalizeRoleTitle("  育休経験者  ")).toBe("育休経験者");
+  });
+  it("null・空白は null", () => {
+    expect(normalizeRoleTitle(null)).toBeNull();
+    expect(normalizeRoleTitle("  ")).toBeNull();
+  });
+  it("汎用的な「市民」相当（一般市民/市民/一般）は null", () => {
+    expect(normalizeRoleTitle("一般市民")).toBeNull();
+    expect(normalizeRoleTitle("市民")).toBeNull();
+    expect(normalizeRoleTitle("一般")).toBeNull();
+  });
+});

--- a/packages/topic-analysis-core/src/public/normalize-role-title.ts
+++ b/packages/topic-analysis-core/src/public/normalize-role-title.ts
@@ -1,0 +1,15 @@
+/**
+ * 「市民」相当の汎用的な肩書。固有の肩書とは見なさず、カテゴリラベルに委ねる。
+ * （role_title データに「一般市民」等が入っていても UI 上は「市民」に統一するため。）
+ */
+const GENERIC_CITIZEN_TITLES = new Set(["一般市民", "市民", "一般"]);
+
+/**
+ * 表示用の肩書を返す。固有の肩書のみを返し、空文字や汎用的な「市民」相当は null。
+ * 呼び出し側はこれが null のときカテゴリラベルにフォールバックする。
+ */
+export function normalizeRoleTitle(roleTitle: string | null): string | null {
+  const trimmed = roleTitle?.trim();
+  if (!trimmed || GENERIC_CITIZEN_TITLES.has(trimmed)) return null;
+  return trimmed;
+}

--- a/packages/topic-analysis-core/src/public/normalize-stance.test.ts
+++ b/packages/topic-analysis-core/src/public/normalize-stance.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { normalizeStanceToSentiment } from "./normalize-stance";
+
+describe("normalizeStanceToSentiment", () => {
+  it("for を 期待 に正規化する", () => {
+    expect(normalizeStanceToSentiment("for")).toBe("期待");
+  });
+
+  it("against を 懸念 に正規化する", () => {
+    expect(normalizeStanceToSentiment("against")).toBe("懸念");
+  });
+
+  it("neutral・未知の値・null は null を返す", () => {
+    expect(normalizeStanceToSentiment("neutral")).toBeNull();
+    expect(normalizeStanceToSentiment("unknown")).toBeNull();
+    expect(normalizeStanceToSentiment(null)).toBeNull();
+  });
+});

--- a/packages/topic-analysis-core/src/public/normalize-stance.ts
+++ b/packages/topic-analysis-core/src/public/normalize-stance.ts
@@ -1,0 +1,8 @@
+/** interview_report.stance（for/against）を 期待/懸念 に正規化（neutral 等は null）。 */
+export function normalizeStanceToSentiment(
+  stance: string | null
+): "期待" | "懸念" | null {
+  if (stance === "for") return "期待";
+  if (stance === "against") return "懸念";
+  return null;
+}

--- a/packages/topic-analysis-core/src/public/public-read-repository.ts
+++ b/packages/topic-analysis-core/src/public/public-read-repository.ts
@@ -1,12 +1,10 @@
-import "server-only";
-
 import { createAdminClient } from "@mirai-gikai/supabase";
 import type {
   PublishedVersionMeta,
   RawOpinionRow,
   RawRespondentRow,
   RawTopicRow,
-} from "../../shared/types";
+} from "./public-types";
 
 export type PublishedAnalysisData = {
   meta: PublishedVersionMeta;
@@ -108,6 +106,7 @@ export async function findPublishedAnalysis(
     rawTopics,
   };
 }
+
 /**
  * 議案に紐づく公開レポート（回答者）を全件取得する。
  * 公開レポート（管理者公開 × ユーザー公開）と同一基準でフィルタし、

--- a/packages/topic-analysis-core/src/public/public-read-repository.ts
+++ b/packages/topic-analysis-core/src/public/public-read-repository.ts
@@ -1,5 +1,6 @@
 import "server-only";
 
+import { shouldDisplayPublicReports } from "@mirai-gikai/shared/report-publication/auto-publish";
 import { createAdminClient } from "@mirai-gikai/supabase";
 import type {
   PublishedVersionMeta,
@@ -150,9 +151,32 @@ export type RespondentDetailData = {
 };
 
 /**
+ * 議案の公開レポート件数を数える（web の countPublicReportsByBillId と同一定義）。
+ * k-匿名性しきい値（shouldDisplayPublicReports）の判定に使う。
+ */
+async function countPublicReportsByBillId(billId: string): Promise<number> {
+  const supabase = createAdminClient();
+  const { count, error } = await supabase
+    .from("interview_report")
+    .select("id, interview_sessions!inner(interview_configs!inner(bill_id))", {
+      count: "exact",
+      head: true,
+    })
+    .eq("is_public_by_admin", true)
+    .eq("is_public_by_user", true)
+    .eq("interview_sessions.interview_configs.bill_id", billId);
+  if (error) {
+    throw new Error(`Failed to count public reports: ${error.message}`);
+  }
+  return count ?? 0;
+}
+
+/**
  * 公開レポート1件の詳細（立場説明＋会話ログ）を生データで取得する。
- * 回答一覧と同一基準（管理者公開×ユーザー公開）でフィルタし、
- * 非公開・存在しない場合は null（呼び出し側で not_found 扱い）。
+ * 回答一覧と同一基準（管理者公開×ユーザー公開）でフィルタし、加えて
+ * **web の個別レポート詳細（getPublicReportById）と同じ k-匿名性ゲート**
+ * （公開レポートが `shouldDisplayPublicReports` を満たす＝20件以上）を適用する。
+ * 件数未満・非公開・存在しない場合は null（呼び出し側で not_found 扱い）。
  * 会話メッセージは作成日時昇順。
  */
 export async function findPublicRespondentDetail(
@@ -163,7 +187,7 @@ export async function findPublicRespondentDetail(
   const { data: report, error } = await supabase
     .from("interview_report")
     .select(
-      "id, role, role_title, stance, summary, role_description, created_at, interview_session_id"
+      "id, role, role_title, stance, summary, role_description, created_at, interview_session_id, interview_sessions!inner(interview_configs!inner(bill_id))"
     )
     .eq("id", reportId)
     .eq("is_public_by_admin", true)
@@ -173,6 +197,16 @@ export async function findPublicRespondentDetail(
     throw new Error(`Failed to fetch respondent detail: ${error.message}`);
   }
   if (!report) return null;
+
+  // k-匿名性ゲート: 公開レポートが少数の議案では会話ログを返さない（web と統一）。
+  // これにより get_public_topic_analysis(interview_report_id) → detail のピボットも塞ぐ。
+  const session = report.interview_sessions as unknown as {
+    interview_configs: { bill_id: string } | null;
+  } | null;
+  const billId = session?.interview_configs?.bill_id ?? null;
+  if (!billId) return null;
+  const publicReportCount = await countPublicReportsByBillId(billId);
+  if (!shouldDisplayPublicReports(publicReportCount)) return null;
 
   const { data: messages, error: messagesError } = await supabase
     .from("interview_messages")

--- a/packages/topic-analysis-core/src/public/public-read-repository.ts
+++ b/packages/topic-analysis-core/src/public/public-read-repository.ts
@@ -18,31 +18,14 @@ export type PublishedAnalysisData = {
 };
 
 /**
- * 議案の「公開中（is_published=true）」のトピック分析を生データで取得する。
- * §8 の表示時フィルタに必要な interview_report 属性（公開同意・モデレーション・role）も
- * 相乗して返す。フィルタ・集計は純粋関数 buildPublicTopicAnalysis 側で行う。
- *
- * 公開中 version が無ければ null（呼び出し側で「準備中」扱い）。
+ * 指定 version のトピック＋意見（§8 判定に必要な interview_report 属性込み）を生データで取得する。
+ * version の選び方（公開中 / 最新）に依存しない共通処理。フィルタ・集計は純粋関数側で行う。
  */
-export async function findPublishedAnalysis(
+async function fetchAnalysisData(
+  version: { id: string; version: number; completed_at: string | null },
   billId: string
-): Promise<PublishedAnalysisData | null> {
+): Promise<PublishedAnalysisData> {
   const supabase = createAdminClient();
-
-  // bill ごと公開は最大1版（one_published_per_bill）。
-  const { data: version, error: versionError } = await supabase
-    .from("topic_analysis_version")
-    .select("id, version, completed_at")
-    .eq("bill_id", billId)
-    .eq("is_published", true)
-    .maybeSingle();
-  if (versionError) {
-    throw new Error(
-      `Failed to fetch published version: ${versionError.message}`
-    );
-  }
-  if (!version) return null;
-
   const { data: topics, error: topicsError } = await supabase
     .from("topic")
     .select(
@@ -114,24 +97,91 @@ export async function findPublishedAnalysis(
 }
 
 /**
- * 議案に紐づく公開レポート（回答者）を全件取得する。
- * 公開レポート（管理者公開 × ユーザー公開）と同一基準でフィルタし、
- * 回答一覧（回答者1人=1カード）で使用する。新しい回答が上に来るよう降順。
+ * 議案の「公開中（is_published=true）」のトピック分析を生データで取得する（web 公開ページ用）。
+ * 公開中 version が無ければ null（呼び出し側で「準備中」扱い）。
  */
-export async function findPublicBillRespondentRows(
+export async function findPublishedAnalysis(
   billId: string
+): Promise<PublishedAnalysisData | null> {
+  const supabase = createAdminClient();
+  // bill ごと公開は最大1版（one_published_per_bill）。
+  const { data: version, error } = await supabase
+    .from("topic_analysis_version")
+    .select("id, version, completed_at")
+    .eq("bill_id", billId)
+    .eq("is_published", true)
+    .maybeSingle();
+  if (error) {
+    throw new Error(`Failed to fetch published version: ${error.message}`);
+  }
+  if (!version) return null;
+  return fetchAnalysisData(version, billId);
+}
+
+/**
+ * 議案の最新トピック分析を生データで取得する（公開・非公開を問わず最大 version を返す）。
+ * 内部用途（admin MCP）向け。version が無ければ null。
+ */
+export async function findLatestAnalysis(
+  billId: string
+): Promise<PublishedAnalysisData | null> {
+  const supabase = createAdminClient();
+  const { data: version, error } = await supabase
+    .from("topic_analysis_version")
+    .select("id, version, completed_at")
+    .eq("bill_id", billId)
+    .order("version", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  if (error) {
+    throw new Error(`Failed to fetch latest version: ${error.message}`);
+  }
+  if (!version) return null;
+  return fetchAnalysisData(version, billId);
+}
+
+/** モデレーション状態（interview_report.moderation_status の列挙）。 */
+export type ModerationStatus = "ok" | "warning" | "ng";
+
+/** レポート行に対する取得条件。未指定の項目は制約しない（＝全件対象）。 */
+export type ReportRowFilter = {
+  isPublicByAdmin?: boolean;
+  isPublicByUser?: boolean;
+  moderationStatus?: ModerationStatus;
+};
+
+/** web 公開ページのプリセット（管理者公開 × ユーザー公開）。 */
+const PUBLIC_REPORT_FILTER: ReportRowFilter = {
+  isPublicByAdmin: true,
+  isPublicByUser: true,
+};
+
+/**
+ * 議案に紐づく回答者レポート行を取得する（回答一覧用・新しい順）。
+ * filter で公開フラグ・モデレーション状態を任意に絞り込む（未指定なら制約しない＝全件）。
+ */
+export async function findRespondentRows(
+  billId: string,
+  filter: ReportRowFilter = {}
 ): Promise<RawRespondentRow[]> {
   const supabase = createAdminClient();
-  const { data, error } = await supabase
+  let query = supabase
     .from("interview_report")
     .select(
       `id, role, role_title, stance, summary, created_at,
        interview_sessions!inner(interview_configs!inner(bill_id))`
     )
-    .eq("interview_sessions.interview_configs.bill_id", billId)
-    .eq("is_public_by_admin", true)
-    .eq("is_public_by_user", true)
-    .order("created_at", { ascending: false });
+    .eq("interview_sessions.interview_configs.bill_id", billId);
+  if (filter.isPublicByAdmin !== undefined) {
+    query = query.eq("is_public_by_admin", filter.isPublicByAdmin);
+  }
+  if (filter.isPublicByUser !== undefined) {
+    query = query.eq("is_public_by_user", filter.isPublicByUser);
+  }
+  if (filter.moderationStatus !== undefined) {
+    query = query.eq("moderation_status", filter.moderationStatus);
+  }
+  const { data, error } = await query.order("created_at", { ascending: false });
   if (error) {
     throw new Error(`Failed to fetch bill respondents: ${error.message}`);
   }
@@ -146,47 +196,74 @@ export async function findPublicBillRespondentRows(
   }));
 }
 
+/**
+ * web 公開ページ用: 公開（管理者公開 × ユーザー公開）のレポートのみ取得する。
+ * 挙動は従来どおり（PUBLIC_REPORT_FILTER 固定）。
+ */
+export async function findPublicBillRespondentRows(
+  billId: string
+): Promise<RawRespondentRow[]> {
+  return findRespondentRows(billId, PUBLIC_REPORT_FILTER);
+}
+
 export type RespondentDetailData = {
   report: RawRespondentDetailRow;
   messages: RawTranscriptMessageRow[];
 };
 
+/** 回答者詳細の取得条件。未指定の公開フラグ／モデレーションは制約しない。 */
+export type RespondentDetailFilter = {
+  isPublicByAdmin?: boolean;
+  isPublicByUser?: boolean;
+  moderationStatus?: ModerationStatus;
+  /** true のとき web と同じ k-匿名性ゲート（公開レポート >= 20 件）を適用。 */
+  requireDisplayThreshold?: boolean;
+};
+
 /**
- * 公開レポート1件の詳細（立場説明＋会話ログ）を生データで取得する。
- * 回答一覧と同一基準（管理者公開×ユーザー公開）でフィルタし、加えて
- * **web の個別レポート詳細（getPublicReportById）と同じ k-匿名性ゲート**
+ * レポート1件の詳細（立場説明＋会話ログ）を生データで取得する（内部用途）。
+ * filter で公開フラグ・モデレーション状態を任意に絞り込み、`requireDisplayThreshold` を
+ * 指定したときのみ web 個別レポート詳細（getPublicReportById）と同じ k-匿名性ゲート
  * （公開レポートが `shouldDisplayPublicReports` を満たす＝20件以上）を適用する。
- * 件数未満・非公開・存在しない場合は null（呼び出し側で not_found 扱い）。
- * 会話メッセージは作成日時昇順。
+ * 条件に合致しない・存在しない場合は null（呼び出し側で not_found 扱い）。会話メッセージは作成日時昇順。
  */
-export async function findPublicRespondentDetail(
-  reportId: string
+export async function findRespondentDetail(
+  reportId: string,
+  filter: RespondentDetailFilter = {}
 ): Promise<RespondentDetailData | null> {
   const supabase = createAdminClient();
 
-  const { data: report, error } = await supabase
+  let query = supabase
     .from("interview_report")
     .select(
       "id, role, role_title, stance, summary, role_description, created_at, interview_session_id, interview_sessions!inner(interview_configs!inner(bill_id))"
     )
-    .eq("id", reportId)
-    .eq("is_public_by_admin", true)
-    .eq("is_public_by_user", true)
-    .maybeSingle();
+    .eq("id", reportId);
+  if (filter.isPublicByAdmin !== undefined) {
+    query = query.eq("is_public_by_admin", filter.isPublicByAdmin);
+  }
+  if (filter.isPublicByUser !== undefined) {
+    query = query.eq("is_public_by_user", filter.isPublicByUser);
+  }
+  if (filter.moderationStatus !== undefined) {
+    query = query.eq("moderation_status", filter.moderationStatus);
+  }
+  const { data: report, error } = await query.maybeSingle();
   if (error) {
     throw new Error(`Failed to fetch respondent detail: ${error.message}`);
   }
   if (!report) return null;
 
-  // k-匿名性ゲート: 公開レポートが少数の議案では会話ログを返さない（web と統一）。
-  // これにより get_public_topic_analysis(interview_report_id) → detail のピボットも塞ぐ。
-  const session = report.interview_sessions as unknown as {
-    interview_configs: { bill_id: string } | null;
-  } | null;
-  const billId = session?.interview_configs?.bill_id ?? null;
-  if (!billId) return null;
-  const publicReportCount = await countPublicReportsByBillId(billId);
-  if (!shouldDisplayPublicReports(publicReportCount)) return null;
+  // k-匿名性ゲート（任意）: 公開レポートが少数の議案では会話ログを返さない（web と統一）。
+  if (filter.requireDisplayThreshold) {
+    const session = report.interview_sessions as unknown as {
+      interview_configs: { bill_id: string } | null;
+    } | null;
+    const billId = session?.interview_configs?.bill_id ?? null;
+    if (!billId) return null;
+    const publicReportCount = await countPublicReportsByBillId(billId);
+    if (!shouldDisplayPublicReports(publicReportCount)) return null;
+  }
 
   const { data: messages, error: messagesError } = await supabase
     .from("interview_messages")

--- a/packages/topic-analysis-core/src/public/public-read-repository.ts
+++ b/packages/topic-analysis-core/src/public/public-read-repository.ts
@@ -1,6 +1,7 @@
 import "server-only";
 
 import { shouldDisplayPublicReports } from "@mirai-gikai/shared/report-publication/auto-publish";
+import { countPublicReportsByBillId } from "@mirai-gikai/shared/report-publication/count-public-reports";
 import { createAdminClient } from "@mirai-gikai/supabase";
 import type {
   PublishedVersionMeta,
@@ -149,27 +150,6 @@ export type RespondentDetailData = {
   report: RawRespondentDetailRow;
   messages: RawTranscriptMessageRow[];
 };
-
-/**
- * 議案の公開レポート件数を数える（web の countPublicReportsByBillId と同一定義）。
- * k-匿名性しきい値（shouldDisplayPublicReports）の判定に使う。
- */
-async function countPublicReportsByBillId(billId: string): Promise<number> {
-  const supabase = createAdminClient();
-  const { count, error } = await supabase
-    .from("interview_report")
-    .select("id, interview_sessions!inner(interview_configs!inner(bill_id))", {
-      count: "exact",
-      head: true,
-    })
-    .eq("is_public_by_admin", true)
-    .eq("is_public_by_user", true)
-    .eq("interview_sessions.interview_configs.bill_id", billId);
-  if (error) {
-    throw new Error(`Failed to count public reports: ${error.message}`);
-  }
-  return count ?? 0;
-}
 
 /**
  * 公開レポート1件の詳細（立場説明＋会話ログ）を生データで取得する。

--- a/packages/topic-analysis-core/src/public/public-read-repository.ts
+++ b/packages/topic-analysis-core/src/public/public-read-repository.ts
@@ -1,9 +1,13 @@
+import "server-only";
+
 import { createAdminClient } from "@mirai-gikai/supabase";
 import type {
   PublishedVersionMeta,
   RawOpinionRow,
+  RawRespondentDetailRow,
   RawRespondentRow,
   RawTopicRow,
+  RawTranscriptMessageRow,
 } from "./public-types";
 
 export type PublishedAnalysisData = {
@@ -138,4 +142,58 @@ export async function findPublicBillRespondentRows(
     summary: r.summary,
     created_at: r.created_at,
   }));
+}
+
+export type RespondentDetailData = {
+  report: RawRespondentDetailRow;
+  messages: RawTranscriptMessageRow[];
+};
+
+/**
+ * 公開レポート1件の詳細（立場説明＋会話ログ）を生データで取得する。
+ * 回答一覧と同一基準（管理者公開×ユーザー公開）でフィルタし、
+ * 非公開・存在しない場合は null（呼び出し側で not_found 扱い）。
+ * 会話メッセージは作成日時昇順。
+ */
+export async function findPublicRespondentDetail(
+  reportId: string
+): Promise<RespondentDetailData | null> {
+  const supabase = createAdminClient();
+
+  const { data: report, error } = await supabase
+    .from("interview_report")
+    .select(
+      "id, role, role_title, stance, summary, role_description, created_at, interview_session_id"
+    )
+    .eq("id", reportId)
+    .eq("is_public_by_admin", true)
+    .eq("is_public_by_user", true)
+    .maybeSingle();
+  if (error) {
+    throw new Error(`Failed to fetch respondent detail: ${error.message}`);
+  }
+  if (!report) return null;
+
+  const { data: messages, error: messagesError } = await supabase
+    .from("interview_messages")
+    .select("id, role, content, created_at")
+    .eq("interview_session_id", report.interview_session_id)
+    .order("created_at", { ascending: true });
+  if (messagesError) {
+    throw new Error(`Failed to fetch transcript: ${messagesError.message}`);
+  }
+
+  return {
+    report: {
+      id: report.id,
+      role: report.role,
+      role_title: report.role_title,
+      stance: report.stance,
+      summary: report.summary,
+      role_description: report.role_description,
+      created_at: report.created_at,
+    },
+    // select 列が RawTranscriptMessageRow と一致するためそのまま渡す。
+    messages: messages ?? [],
+  };
 }

--- a/packages/topic-analysis-core/src/public/public-server.ts
+++ b/packages/topic-analysis-core/src/public/public-server.ts
@@ -1,0 +1,14 @@
+// 公開（PII セーフ）読み取りの**サーバ専用**エントリポイント。
+// Supabase（createAdminClient / SUPABASE_SECRET_KEY）に触れる repository / loaders を
+// ここに集約し、ブラウザ安全な純粋ロジック（./public）と分離する。
+// サーバ（web の loaders / Server Components / admin MCP）からのみ import すること。
+export * from "./public";
+export {
+  type PublishedAnalysisData,
+  findPublicBillRespondentRows,
+  findPublishedAnalysis,
+} from "./public-read-repository";
+export {
+  getPublicBillRespondents,
+  getPublicTopicAnalysis,
+} from "./loaders";

--- a/packages/topic-analysis-core/src/public/public-server.ts
+++ b/packages/topic-analysis-core/src/public/public-server.ts
@@ -1,3 +1,5 @@
+import "server-only";
+
 // 公開（PII セーフ）読み取りの**サーバ専用**エントリポイント。
 // Supabase（createAdminClient / SUPABASE_SECRET_KEY）に触れる repository / loaders を
 // ここに集約し、ブラウザ安全な純粋ロジック（./public）と分離する。

--- a/packages/topic-analysis-core/src/public/public-server.ts
+++ b/packages/topic-analysis-core/src/public/public-server.ts
@@ -7,10 +7,13 @@ import "server-only";
 export * from "./public";
 export {
   type PublishedAnalysisData,
+  type RespondentDetailData,
   findPublicBillRespondentRows,
+  findPublicRespondentDetail,
   findPublishedAnalysis,
 } from "./public-read-repository";
 export {
   getPublicBillRespondents,
+  getPublicRespondentDetail,
   getPublicTopicAnalysis,
 } from "./loaders";

--- a/packages/topic-analysis-core/src/public/public-server.ts
+++ b/packages/topic-analysis-core/src/public/public-server.ts
@@ -1,19 +1,18 @@
 import "server-only";
 
-// 公開（PII セーフ）読み取りの**サーバ専用**エントリポイント。
-// Supabase（createAdminClient / SUPABASE_SECRET_KEY）に触れる repository / loaders を
-// ここに集約し、ブラウザ安全な純粋ロジック（./public）と分離する。
-// サーバ（web の loaders / Server Components / admin MCP）からのみ import すること。
+// 公開（PII セーフ・§8 固定）読み取りの**サーバ専用**エントリポイント。
+// web の公開ページ / 公開 API が使う。Supabase（createAdminClient）に触れる
+// repository / loaders をここに集約し、ブラウザ安全な純粋ロジック（./public）と分離する。
+//
+// 内部用途（admin MCP）の「全件＋任意フィルタ」経路は
+// `@mirai-gikai/topic-analysis-core/internal-server` に分離している。
 export * from "./public";
 export {
   type PublishedAnalysisData,
-  type RespondentDetailData,
   findPublicBillRespondentRows,
-  findPublicRespondentDetail,
   findPublishedAnalysis,
 } from "./public-read-repository";
 export {
   getPublicBillRespondents,
-  getPublicRespondentDetail,
   getPublicTopicAnalysis,
 } from "./loaders";

--- a/packages/topic-analysis-core/src/public/public-types.ts
+++ b/packages/topic-analysis-core/src/public/public-types.ts
@@ -1,0 +1,126 @@
+// ユーザー向けトピック分析の読み取り（公開）API のデータ契約（設計 §13 付録 A.4）。
+// web の表示と admin MCP の連携が同一の PII セーフな契約を共有する。
+// 個人を特定する識別子（user_id・email・電話等）は含めない。
+
+/** §9 の4区分。interview_report.role を 1:1 でマップする。 */
+export type UserCategory = "affected" | "industry" | "expert" | "citizen";
+
+/** 公開 API が返す意見カード（§8 フィルタ後のもののみ）。 */
+export type PublicOpinion = {
+  id: string;
+  /** この意見の出典インタビューレポートID（レポート詳細への遷移に使う）。 */
+  interview_report_id: string;
+  /**
+   * 出典レポートが管理者公開済みか（is_public_by_admin）。
+   * レポート詳細ページは管理者公開かつ公開件数しきい値を満たす場合のみ表示されるため、
+   * リンク表示の出し分けに使う（§8 表示判定は user 同意・モデレーションのみ）。
+   */
+  report_public: boolean;
+  /** 出典レポートの作成日時（相対表示・日付表示に使う）。 */
+  created_at: string | null;
+  title: string;
+  content: string;
+  user_category: UserCategory;
+  /** 発言者の立場の短縮タイトル（interview_report.role_title）。引用の属性表示に使う。 */
+  role_title: string | null;
+  bill_sentiment: "期待" | "懸念" | null;
+  contextual_quote: string | null;
+  /**
+   * 意見単位の情報充実度（0-100）。引用の優先表示・並べ替えに使う（集計には使わない）。
+   * 旧データ・未生成は null。
+   */
+  richness: number | null;
+  /** 引用の出典メッセージID。レポート詳細の該当メッセージ（#message-<id>）へ遷移するのに使う。 */
+  source_message_id: string | null;
+  /**
+   * 発言を引き出した質問文（source_message_id から導出）。
+   * 導出は Q&A 表示を行う Step 4b で実装するため、4a では null 固定。
+   */
+  question_snippet: string | null;
+};
+
+/** 公開 API が返すトピック（件数・内訳は §8 フィルタ後に再計算）。 */
+export type PublicTopic = {
+  id: string;
+  title: string;
+  description: string;
+  opinion_count: number;
+  affected_count: number;
+  industry_count: number;
+  expert_count: number;
+  citizen_count: number;
+  sentiment: { 期待: number; 懸念: number };
+  opinions: PublicOpinion[];
+};
+
+/** 公開 API レスポンス全体（§13 A.4）。 */
+export type PublicTopicAnalysis = {
+  bill_id: string;
+  version: number;
+  generated_at: string | null;
+  total_opinions: number;
+  topics: PublicTopic[];
+};
+
+// ── リポジトリが返す生データ（pure 関数の入力） ──
+
+/** §8 判定に必要なレポート属性を相乗した、生の意見行。 */
+export type RawOpinionRow = {
+  id: string;
+  interview_report_id: string;
+  created_at: string | null;
+  title: string;
+  content: string;
+  contextual_quote: string | null;
+  source_message_id: string | null;
+  bill_sentiment: string | null;
+  /** 意見単位の情報充実度（0-100・nullable）。引用の優先表示・並べ替えに使う。 */
+  richness: number | null;
+  is_public_by_user: boolean;
+  is_public_by_admin: boolean;
+  moderation_status: string | null;
+  role: string | null;
+  role_title: string | null;
+};
+
+/** version 配下の生トピック行（sort_order 昇順）。 */
+export type RawTopicRow = {
+  id: string;
+  title: string;
+  description: string;
+  opinions: RawOpinionRow[];
+};
+
+/** 公開中 version のメタ情報。 */
+export type PublishedVersionMeta = {
+  bill_id: string;
+  version: number;
+  generated_at: string | null;
+};
+
+// ── 回答一覧（回答者1人=1カード）の表示データ ──
+
+/** 回答一覧カード1件（公開レポート＝回答者1人）。 */
+export type PublicRespondent = {
+  /** 出典インタビューレポートID（レポート詳細への遷移に使う）。 */
+  id: string;
+  user_category: UserCategory;
+  /** 発言者の立場の短縮タイトル（interview_report.role_title）。 */
+  role_title: string | null;
+  /** 賛否（for=期待 / against=懸念 / それ以外=null）。 */
+  bill_sentiment: "期待" | "懸念" | null;
+  /** レポートの要約テキスト（カード本文に表示）。 */
+  summary: string | null;
+  /** 出典レポートの作成日時（相対表示・日付表示に使う）。 */
+  created_at: string | null;
+};
+
+/** リポジトリが返す生のレポート行（回答一覧用・pure 関数の入力）。 */
+export type RawRespondentRow = {
+  id: string;
+  role: string | null;
+  role_title: string | null;
+  stance: string | null;
+  summary: string | null;
+  created_at: string | null;
+};

--- a/packages/topic-analysis-core/src/public/public-types.ts
+++ b/packages/topic-analysis-core/src/public/public-types.ts
@@ -124,3 +124,51 @@ export type RawRespondentRow = {
   summary: string | null;
   created_at: string | null;
 };
+
+// ── 回答者詳細（立場説明＋会話ログ／分析用） ──
+//
+// 注意: role_description と messages.content は回答者の**自由記述**であり、
+// LLM で構造化・要約されたものではない。§8 のレポート公開判定
+// （管理者公開×ユーザー公開）は通すが、自由記述ゆえ固有名詞等が含まれ得る。
+// それでも user_id・email・有識者登録情報（expert_registrations）等の
+// 識別子は含めない。
+
+/** 会話ログ1メッセージ。speaker="assistant"=AIの質問 / "user"=回答者の発言。 */
+export type TranscriptMessage = {
+  id: string;
+  speaker: "assistant" | "user";
+  content: string;
+  created_at: string | null;
+};
+
+/** 公開レポート1件の詳細（立場説明と会話ログを含む）。 */
+export type PublicRespondentDetail = {
+  /** 出典インタビューレポートID。 */
+  id: string;
+  user_category: UserCategory;
+  /** 発言者の立場の短縮タイトル（interview_report.role_title）。 */
+  role_title: string | null;
+  /** 回答者が自由記述した立場説明（interview_report.role_description）。 */
+  role_description: string | null;
+  /** 賛否（for=期待 / against=懸念 / それ以外=null）。 */
+  bill_sentiment: "期待" | "懸念" | null;
+  /** レポートの要約テキスト。 */
+  summary: string | null;
+  /** 出典レポートの作成日時。 */
+  created_at: string | null;
+  /** AIとの会話ログ（質問と回答のやり取り、作成日時昇順）。 */
+  messages: TranscriptMessage[];
+};
+
+/** 詳細取得の生レポート行（pure 関数の入力）。回答一覧の行に立場説明を加えたもの。 */
+export type RawRespondentDetailRow = RawRespondentRow & {
+  role_description: string | null;
+};
+
+/** 生の会話メッセージ行（pure 関数の入力）。 */
+export type RawTranscriptMessageRow = {
+  id: string;
+  role: string | null;
+  content: string;
+  created_at: string | null;
+};

--- a/packages/topic-analysis-core/src/public/public.ts
+++ b/packages/topic-analysis-core/src/public/public.ts
@@ -1,0 +1,23 @@
+// ユーザー向けトピック分析・公開インタビュー回答の「公開（PII セーフ）」データ契約と
+// 純粋ロジック。**ブラウザ安全**（DB クライアント等のサーバ専用依存を持たない）なので、
+// Client Components からも安全に import できる。
+//
+// Supabase へアクセスする repository / loaders はサーバ専用のため
+// `@mirai-gikai/topic-analysis-core/public-server` に分離している。
+export type {
+  PublicOpinion,
+  PublicRespondent,
+  PublicTopic,
+  PublicTopicAnalysis,
+  PublishedVersionMeta,
+  RawOpinionRow,
+  RawRespondentRow,
+  RawTopicRow,
+  UserCategory,
+} from "./public-types";
+export { normalizeRoleTitle } from "./normalize-role-title";
+export {
+  buildPublicTopicAnalysis,
+  mapRoleToCategory,
+} from "./build-public-topic-analysis";
+export { buildPublicBillRespondents } from "./build-public-bill-respondents";

--- a/packages/topic-analysis-core/src/public/public.ts
+++ b/packages/topic-analysis-core/src/public/public.ts
@@ -1,23 +1,33 @@
-// ユーザー向けトピック分析・公開インタビュー回答の「公開（PII セーフ）」データ契約と
-// 純粋ロジック。**ブラウザ安全**（DB クライアント等のサーバ専用依存を持たない）なので、
+// ユーザー向けトピック分析・公開インタビュー回答の公開データ契約と純粋ロジック。
+// **ブラウザ安全**（DB クライアント等のサーバ専用依存を持たない）なので、
 // Client Components からも安全に import できる。
+//
+// 契約として user_id・email 等の直接的な識別子は含めない。ただし
+// PublicRespondentDetail の role_description・会話ログは回答者の自由記述であり、
+// 固有名詞等が含まれ得る（「識別子フリー」であって「内容PIIフリー」ではない）。
 //
 // Supabase へアクセスする repository / loaders はサーバ専用のため
 // `@mirai-gikai/topic-analysis-core/public-server` に分離している。
 export type {
   PublicOpinion,
   PublicRespondent,
+  PublicRespondentDetail,
   PublicTopic,
   PublicTopicAnalysis,
   PublishedVersionMeta,
   RawOpinionRow,
+  RawRespondentDetailRow,
   RawRespondentRow,
   RawTopicRow,
+  RawTranscriptMessageRow,
+  TranscriptMessage,
   UserCategory,
 } from "./public-types";
 export { normalizeRoleTitle } from "./normalize-role-title";
+export { normalizeStanceToSentiment } from "./normalize-stance";
 export {
   buildPublicTopicAnalysis,
   mapRoleToCategory,
 } from "./build-public-topic-analysis";
 export { buildPublicBillRespondents } from "./build-public-bill-respondents";
+export { buildPublicRespondentDetail } from "./build-public-respondent-detail";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -231,6 +231,9 @@ importers:
       ai:
         specifier: ^6.0.3
         version: 6.0.3(zod@4.1.12)
+      server-only:
+        specifier: ^0.0.1
+        version: 0.0.1
     devDependencies:
       typescript:
         specifier: ^5.6.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -256,6 +256,9 @@ importers:
       '@mirai-gikai/supabase':
         specifier: workspace:*
         version: link:../packages/supabase
+      '@mirai-gikai/topic-analysis-core':
+        specifier: workspace:*
+        version: link:../packages/topic-analysis-core
       '@opentelemetry/sdk-node':
         specifier: ^0.206.0
         version: 0.206.0(@opentelemetry/api@1.9.0)

--- a/tests/mcp/topic-analysis-tools.test.ts
+++ b/tests/mcp/topic-analysis-tools.test.ts
@@ -1,0 +1,240 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { registerTopicAnalysisTools } from "../../admin/src/features/mcp/server/tools/register-topic-analysis-tools";
+import {
+  adminClient,
+  cleanupTestBill,
+  cleanupTestUser,
+  createTestBill,
+  createTestUser,
+  type TestUser,
+} from "../supabase/utils";
+import { createTestRegistry, type TestMcpRegistry } from "./utils";
+
+/** session + report + interview_opinion を1件作り、{ reportId, opinionId } を返す。 */
+async function createReportWithOpinion(opts: {
+  configId: string;
+  userId: string;
+  isPublicByUser: boolean;
+  isPublicByAdmin: boolean;
+  role: string;
+  stance?: string;
+  title: string;
+  billSentiment?: string;
+}): Promise<{ reportId: string; opinionId: string }> {
+  const { data: session } = await adminClient
+    .from("interview_sessions")
+    .insert({
+      interview_config_id: opts.configId,
+      user_id: opts.userId,
+      started_at: new Date().toISOString(),
+      completed_at: new Date().toISOString(),
+    })
+    .select()
+    .single();
+  if (!session) throw new Error("session insert failed");
+
+  const { data: report } = await adminClient
+    .from("interview_report")
+    .insert({
+      interview_session_id: session.id,
+      is_public_by_user: opts.isPublicByUser,
+      is_public_by_admin: opts.isPublicByAdmin,
+      moderation_score: 5,
+      role: opts.role,
+      role_title: "育休経験者",
+      stance: opts.stance ?? null,
+      summary: `${opts.title}の要約`,
+    })
+    .select()
+    .single();
+  if (!report) throw new Error("report insert failed");
+
+  const { data: opinion } = await adminClient
+    .from("interview_opinion")
+    .insert({
+      interview_report_id: report.id,
+      opinion_index: 0,
+      title: opts.title,
+      content: `${opts.title}の本文`,
+      bill_sentiment: opts.billSentiment ?? null,
+    })
+    .select("id")
+    .single();
+  if (!opinion) throw new Error("opinion insert failed");
+  return { reportId: report.id, opinionId: opinion.id };
+}
+
+describe("MCP topic-analysis tools（公開・PIIセーフ読み取り）", () => {
+  let registry: TestMcpRegistry;
+  let testUser: TestUser;
+  let billWithAnalysis: string;
+  let billWithout: string;
+  let publicReportId: string;
+  let privateReportId: string;
+
+  beforeAll(async () => {
+    registry = createTestRegistry();
+    registerTopicAnalysisTools(registry.asMcpServer());
+
+    testUser = await createTestUser();
+
+    const bill = await createTestBill();
+    billWithAnalysis = bill.id;
+    const { data: config } = await adminClient
+      .from("interview_configs")
+      .insert({ bill_id: billWithAnalysis, status: "public", name: "mcp-ta" })
+      .select()
+      .single();
+    if (!config) throw new Error("config insert failed");
+
+    // §8 を通る公開意見 / ユーザー非公開 / 管理者非公開 の3件
+    const ok = await createReportWithOpinion({
+      configId: config.id,
+      userId: testUser.id,
+      isPublicByUser: true,
+      isPublicByAdmin: true,
+      role: "daily_life_affected",
+      stance: "for",
+      title: "公開OK",
+      billSentiment: "期待",
+    });
+    publicReportId = ok.reportId;
+    const userPrivate = await createReportWithOpinion({
+      configId: config.id,
+      userId: testUser.id,
+      isPublicByUser: false,
+      isPublicByAdmin: true,
+      role: "general_citizen",
+      title: "ユーザー非公開",
+    });
+    privateReportId = userPrivate.reportId;
+    const adminPrivate = await createReportWithOpinion({
+      configId: config.id,
+      userId: testUser.id,
+      isPublicByUser: true,
+      isPublicByAdmin: false,
+      role: "general_citizen",
+      title: "管理者非公開",
+    });
+
+    const { data: version } = await adminClient
+      .from("topic_analysis_version")
+      .insert({
+        bill_id: billWithAnalysis,
+        version: 1,
+        status: "completed",
+        trigger: "manual",
+        is_published: true,
+        completed_at: new Date().toISOString(),
+      })
+      .select()
+      .single();
+    if (!version) throw new Error("version insert failed");
+
+    const { data: topic } = await adminClient
+      .from("topic")
+      .insert({
+        version_id: version.id,
+        title: "論点A",
+        description: "desc",
+        sort_order: 0,
+      })
+      .select()
+      .single();
+    if (!topic) throw new Error("topic insert failed");
+
+    await adminClient.from("topic_opinion").insert([
+      { version_id: version.id, topic_id: topic.id, opinion_id: ok.opinionId },
+      {
+        version_id: version.id,
+        topic_id: topic.id,
+        opinion_id: userPrivate.opinionId,
+      },
+      {
+        version_id: version.id,
+        topic_id: topic.id,
+        opinion_id: adminPrivate.opinionId,
+      },
+    ]);
+
+    const bill2 = await createTestBill();
+    billWithout = bill2.id;
+  });
+
+  afterAll(async () => {
+    if (billWithAnalysis) await cleanupTestBill(billWithAnalysis);
+    if (billWithout) await cleanupTestBill(billWithout);
+    if (testUser?.id) await cleanupTestUser(testUser.id);
+  });
+
+  it("登録されているツール名が想定通り", () => {
+    expect(registry.toolNames().sort()).toEqual(
+      ["get_public_topic_analysis", "list_public_respondents"].sort()
+    );
+  });
+
+  describe("get_public_topic_analysis", () => {
+    it("§8 を通る公開意見のみ返し、件数も再計算する", async () => {
+      const result = await registry.callTool<{
+        topics: Array<{
+          opinion_count: number;
+          affected_count: number;
+          sentiment: { 期待: number; 懸念: number };
+          opinions: Array<{ title: string }>;
+        }>;
+        total_opinions: number;
+      }>("get_public_topic_analysis", { billId: billWithAnalysis });
+
+      expect(result.total_opinions).toBe(1);
+      expect(result.topics).toHaveLength(1);
+      expect(result.topics[0].opinion_count).toBe(1);
+      expect(result.topics[0].affected_count).toBe(1);
+      expect(result.topics[0].sentiment).toEqual({ 期待: 1, 懸念: 0 });
+      expect(result.topics[0].opinions[0].title).toBe("公開OK");
+    });
+
+    it("個人情報（user_id・email・session）を返さない", async () => {
+      const result = await registry.callTool("get_public_topic_analysis", {
+        billId: billWithAnalysis,
+      });
+      const serialized = JSON.stringify(result);
+      expect(serialized).not.toContain("user_id");
+      expect(serialized).not.toContain("email");
+      expect(serialized).not.toContain("interview_session");
+      expect(serialized).not.toContain(testUser.id);
+    });
+
+    it("公開版が無ければ status=not_ready を返す", async () => {
+      const result = await registry.callTool<{ status: string }>(
+        "get_public_topic_analysis",
+        { billId: billWithout }
+      );
+      expect(result.status).toBe("not_ready");
+    });
+  });
+
+  describe("list_public_respondents", () => {
+    it("公開（管理者公開×ユーザー公開）のレポートのみ返す", async () => {
+      const result = await registry.callTool<
+        Array<{ id: string; summary: string | null; bill_sentiment: unknown }>
+      >("list_public_respondents", { billId: billWithAnalysis });
+
+      const ids = result.map((r) => r.id);
+      expect(ids).toContain(publicReportId);
+      expect(ids).not.toContain(privateReportId);
+      const pub = result.find((r) => r.id === publicReportId);
+      expect(pub?.summary).toBe("公開OKの要約");
+      expect(pub?.bill_sentiment).toBe("期待");
+    });
+
+    it("個人情報（user_id・email）を返さない", async () => {
+      const result = await registry.callTool("list_public_respondents", {
+        billId: billWithAnalysis,
+      });
+      const serialized = JSON.stringify(result);
+      expect(serialized).not.toContain("user_id");
+      expect(serialized).not.toContain("email");
+      expect(serialized).not.toContain(testUser.id);
+    });
+  });
+});

--- a/tests/mcp/topic-analysis-tools.test.ts
+++ b/tests/mcp/topic-analysis-tools.test.ts
@@ -83,6 +83,42 @@ async function createReportWithOpinion(opts: {
   return { reportId: report.id, opinionId: opinion.id };
 }
 
+/**
+ * 件数ゲート用に、最小構成の公開レポート（session + report）を n 件まとめて作る。
+ * k-匿名性しきい値（公開レポート >= 20 件）を満たすための水増しに使う。
+ */
+async function createPublicReports(
+  configId: string,
+  userId: string,
+  n: number
+): Promise<void> {
+  const now = new Date().toISOString();
+  const { data: sessions } = await adminClient
+    .from("interview_sessions")
+    .insert(
+      Array.from({ length: n }, () => ({
+        interview_config_id: configId,
+        user_id: userId,
+        started_at: now,
+        completed_at: now,
+      }))
+    )
+    .select("id");
+  if (!sessions) throw new Error("sessions insert failed");
+
+  const { error } = await adminClient.from("interview_report").insert(
+    sessions.map((s) => ({
+      interview_session_id: s.id,
+      is_public_by_user: true,
+      is_public_by_admin: true,
+      moderation_score: 5,
+      role: "general_citizen",
+      summary: "件数ゲート用",
+    }))
+  );
+  if (error) throw new Error("reports insert failed");
+}
+
 describe("MCP topic-analysis tools（公開・PIIセーフ読み取り）", () => {
   let registry: TestMcpRegistry;
   let testUser: TestUser;
@@ -90,6 +126,9 @@ describe("MCP topic-analysis tools（公開・PIIセーフ読み取り）", () =
   let billWithout: string;
   let publicReportId: string;
   let privateReportId: string;
+  // 公開レポート >= 20 件で k-匿名性ゲートを通過する議案と、その詳細対象レポート
+  let billDisplayable: string;
+  let detailReportId: string;
 
   beforeAll(async () => {
     registry = createTestRegistry();
@@ -183,11 +222,45 @@ describe("MCP topic-analysis tools（公開・PIIセーフ読み取り）", () =
 
     const bill2 = await createTestBill();
     billWithout = bill2.id;
+
+    // k-匿名性ゲートを通過する議案（公開レポート 20 件）。
+    // 詳細対象 1 件（立場説明＋会話ログ）＋ 件数水増し 19 件 = 20 件。
+    const bill3 = await createTestBill();
+    billDisplayable = bill3.id;
+    const { data: config3 } = await adminClient
+      .from("interview_configs")
+      .insert({
+        bill_id: billDisplayable,
+        status: "public",
+        name: "mcp-detail",
+      })
+      .select()
+      .single();
+    if (!config3) throw new Error("config3 insert failed");
+
+    const detail = await createReportWithOpinion({
+      configId: config3.id,
+      userId: testUser.id,
+      isPublicByUser: true,
+      isPublicByAdmin: true,
+      role: "daily_life_affected",
+      stance: "for",
+      title: "詳細対象",
+      billSentiment: "期待",
+      roleDescription: "育休を取得した当事者です",
+      messages: [
+        { role: "assistant", content: "この法案についてどう思いますか？" },
+        { role: "user", content: "賛成です。負担が軽くなります" },
+      ],
+    });
+    detailReportId = detail.reportId;
+    await createPublicReports(config3.id, testUser.id, 19);
   });
 
   afterAll(async () => {
     if (billWithAnalysis) await cleanupTestBill(billWithAnalysis);
     if (billWithout) await cleanupTestBill(billWithout);
+    if (billDisplayable) await cleanupTestBill(billDisplayable);
     if (testUser?.id) await cleanupTestUser(testUser.id);
   });
 
@@ -255,28 +328,29 @@ describe("MCP topic-analysis tools（公開・PIIセーフ読み取り）", () =
       expect(pub?.bill_sentiment).toBe("期待");
     });
 
-    it("個人情報（user_id・email）を返さない", async () => {
+    it("個人情報（user_id・email・session）を返さない", async () => {
       const result = await registry.callTool("list_public_respondents", {
         billId: billWithAnalysis,
       });
       const serialized = JSON.stringify(result);
       expect(serialized).not.toContain("user_id");
       expect(serialized).not.toContain("email");
+      expect(serialized).not.toContain("interview_session");
       expect(serialized).not.toContain(testUser.id);
     });
   });
 
   describe("get_respondent_detail", () => {
-    it("公開レポートの立場説明と会話ログを返す", async () => {
+    it("公開件数が十分な議案では立場説明と会話ログを返す", async () => {
       const result = await registry.callTool<{
         id: string;
         user_category: string;
         role_description: string | null;
         bill_sentiment: unknown;
         messages: Array<{ speaker: string; content: string }>;
-      }>("get_respondent_detail", { reportId: publicReportId });
+      }>("get_respondent_detail", { reportId: detailReportId });
 
-      expect(result.id).toBe(publicReportId);
+      expect(result.id).toBe(detailReportId);
       expect(result.user_category).toBe("affected");
       expect(result.role_description).toBe("育休を取得した当事者です");
       expect(result.bill_sentiment).toBe("期待");
@@ -286,6 +360,15 @@ describe("MCP topic-analysis tools（公開・PIIセーフ読み取り）", () =
         { speaker: "assistant", content: "この法案についてどう思いますか？" },
         { speaker: "user", content: "賛成です。負担が軽くなります" },
       ]);
+    });
+
+    it("公開レポートが20件未満の議案は status=not_found（k-匿名性ゲート）", async () => {
+      // billWithAnalysis の公開レポートは publicReportId の1件のみ（< 20）。
+      const result = await registry.callTool<{ status: string }>(
+        "get_respondent_detail",
+        { reportId: publicReportId }
+      );
+      expect(result.status).toBe("not_found");
     });
 
     it("非公開レポートは status=not_found を返す", async () => {
@@ -298,7 +381,7 @@ describe("MCP topic-analysis tools（公開・PIIセーフ読み取り）", () =
 
     it("個人情報（user_id・email・session）を返さない", async () => {
       const result = await registry.callTool("get_respondent_detail", {
-        reportId: publicReportId,
+        reportId: detailReportId,
       });
       const serialized = JSON.stringify(result);
       expect(serialized).not.toContain("user_id");

--- a/tests/mcp/topic-analysis-tools.test.ts
+++ b/tests/mcp/topic-analysis-tools.test.ts
@@ -10,7 +10,10 @@ import {
 } from "../supabase/utils";
 import { createTestRegistry, type TestMcpRegistry } from "./utils";
 
-/** session + report + interview_opinion を1件作り、{ reportId, opinionId } を返す。 */
+/**
+ * session + report + interview_opinion を1件作り、{ reportId, opinionId } を返す。
+ * roleDescription / messages を渡すと立場説明・会話ログも投入する。
+ */
 async function createReportWithOpinion(opts: {
   configId: string;
   userId: string;
@@ -20,6 +23,8 @@ async function createReportWithOpinion(opts: {
   stance?: string;
   title: string;
   billSentiment?: string;
+  roleDescription?: string;
+  messages?: Array<{ role: "assistant" | "user"; content: string }>;
 }): Promise<{ reportId: string; opinionId: string }> {
   const { data: session } = await adminClient
     .from("interview_sessions")
@@ -42,12 +47,26 @@ async function createReportWithOpinion(opts: {
       moderation_score: 5,
       role: opts.role,
       role_title: "育休経験者",
+      role_description: opts.roleDescription ?? null,
       stance: opts.stance ?? null,
       summary: `${opts.title}の要約`,
     })
     .select()
     .single();
   if (!report) throw new Error("report insert failed");
+
+  if (opts.messages?.length) {
+    const { error: messagesError } = await adminClient
+      .from("interview_messages")
+      .insert(
+        opts.messages.map((m) => ({
+          interview_session_id: session.id,
+          role: m.role,
+          content: m.content,
+        }))
+      );
+    if (messagesError) throw new Error("messages insert failed");
+  }
 
   const { data: opinion } = await adminClient
     .from("interview_opinion")
@@ -97,6 +116,11 @@ describe("MCP topic-analysis tools（公開・PIIセーフ読み取り）", () =
       stance: "for",
       title: "公開OK",
       billSentiment: "期待",
+      roleDescription: "育休を取得した当事者です",
+      messages: [
+        { role: "assistant", content: "この法案についてどう思いますか？" },
+        { role: "user", content: "賛成です。負担が軽くなります" },
+      ],
     });
     publicReportId = ok.reportId;
     const userPrivate = await createReportWithOpinion({
@@ -169,7 +193,11 @@ describe("MCP topic-analysis tools（公開・PIIセーフ読み取り）", () =
 
   it("登録されているツール名が想定通り", () => {
     expect(registry.toolNames().sort()).toEqual(
-      ["get_public_topic_analysis", "list_public_respondents"].sort()
+      [
+        "get_public_topic_analysis",
+        "list_public_respondents",
+        "get_respondent_detail",
+      ].sort()
     );
   });
 
@@ -234,6 +262,48 @@ describe("MCP topic-analysis tools（公開・PIIセーフ読み取り）", () =
       const serialized = JSON.stringify(result);
       expect(serialized).not.toContain("user_id");
       expect(serialized).not.toContain("email");
+      expect(serialized).not.toContain(testUser.id);
+    });
+  });
+
+  describe("get_respondent_detail", () => {
+    it("公開レポートの立場説明と会話ログを返す", async () => {
+      const result = await registry.callTool<{
+        id: string;
+        user_category: string;
+        role_description: string | null;
+        bill_sentiment: unknown;
+        messages: Array<{ speaker: string; content: string }>;
+      }>("get_respondent_detail", { reportId: publicReportId });
+
+      expect(result.id).toBe(publicReportId);
+      expect(result.user_category).toBe("affected");
+      expect(result.role_description).toBe("育休を取得した当事者です");
+      expect(result.bill_sentiment).toBe("期待");
+      expect(
+        result.messages.map((m) => ({ speaker: m.speaker, content: m.content }))
+      ).toEqual([
+        { speaker: "assistant", content: "この法案についてどう思いますか？" },
+        { speaker: "user", content: "賛成です。負担が軽くなります" },
+      ]);
+    });
+
+    it("非公開レポートは status=not_found を返す", async () => {
+      const result = await registry.callTool<{ status: string }>(
+        "get_respondent_detail",
+        { reportId: privateReportId }
+      );
+      expect(result.status).toBe("not_found");
+    });
+
+    it("個人情報（user_id・email・session）を返さない", async () => {
+      const result = await registry.callTool("get_respondent_detail", {
+        reportId: publicReportId,
+      });
+      const serialized = JSON.stringify(result);
+      expect(serialized).not.toContain("user_id");
+      expect(serialized).not.toContain("email");
+      expect(serialized).not.toContain("interview_session");
       expect(serialized).not.toContain(testUser.id);
     });
   });

--- a/tests/mcp/topic-analysis-tools.test.ts
+++ b/tests/mcp/topic-analysis-tools.test.ts
@@ -119,7 +119,7 @@ async function createPublicReports(
   if (error) throw new Error("reports insert failed");
 }
 
-describe("MCP topic-analysis tools（公開・PIIセーフ読み取り）", () => {
+describe("MCP topic-analysis tools（内部向け・識別子フリー読み取り）", () => {
   let registry: TestMcpRegistry;
   let testUser: TestUser;
   let billWithAnalysis: string;
@@ -266,36 +266,60 @@ describe("MCP topic-analysis tools（公開・PIIセーフ読み取り）", () =
 
   it("登録されているツール名が想定通り", () => {
     expect(registry.toolNames().sort()).toEqual(
-      [
-        "get_public_topic_analysis",
-        "list_public_respondents",
-        "get_respondent_detail",
-      ].sort()
+      ["get_topic_analysis", "list_respondents", "get_respondent_detail"].sort()
     );
   });
 
-  describe("get_public_topic_analysis", () => {
-    it("§8 を通る公開意見のみ返し、件数も再計算する", async () => {
+  describe("get_topic_analysis", () => {
+    it("既定（フィルタ無し）では公開・非公開を問わず全意見を返す", async () => {
       const result = await registry.callTool<{
         topics: Array<{
           opinion_count: number;
           affected_count: number;
+          citizen_count: number;
           sentiment: { 期待: number; 懸念: number };
+        }>;
+        total_opinions: number;
+      }>("get_topic_analysis", { billId: billWithAnalysis });
+
+      // ok（公開）/ ユーザー非公開 / 管理者非公開 の3意見すべて。
+      expect(result.total_opinions).toBe(3);
+      expect(result.topics).toHaveLength(1);
+      expect(result.topics[0].opinion_count).toBe(3);
+      expect(result.topics[0].affected_count).toBe(1);
+      expect(result.topics[0].citizen_count).toBe(2);
+      expect(result.topics[0].sentiment).toEqual({ 期待: 1, 懸念: 0 });
+    });
+
+    it("公開フラグ＋モデレーションOKで絞り込める", async () => {
+      const result = await registry.callTool<{
+        topics: Array<{
+          opinion_count: number;
           opinions: Array<{ title: string }>;
         }>;
         total_opinions: number;
-      }>("get_public_topic_analysis", { billId: billWithAnalysis });
+      }>("get_topic_analysis", {
+        billId: billWithAnalysis,
+        isPublicByAdmin: true,
+        isPublicByUser: true,
+        moderationStatus: "ok",
+      });
 
       expect(result.total_opinions).toBe(1);
-      expect(result.topics).toHaveLength(1);
       expect(result.topics[0].opinion_count).toBe(1);
-      expect(result.topics[0].affected_count).toBe(1);
-      expect(result.topics[0].sentiment).toEqual({ 期待: 1, 懸念: 0 });
       expect(result.topics[0].opinions[0].title).toBe("公開OK");
     });
 
+    it("requireDisplayThreshold 指定時、公開20件未満なら status=not_ready", async () => {
+      const result = await registry.callTool<{ status: string }>(
+        "get_topic_analysis",
+        { billId: billWithAnalysis, requireDisplayThreshold: true }
+      );
+      expect(result.status).toBe("not_ready");
+    });
+
     it("個人情報（user_id・email・session）を返さない", async () => {
-      const result = await registry.callTool("get_public_topic_analysis", {
+      const result = await registry.callTool("get_topic_analysis", {
         billId: billWithAnalysis,
       });
       const serialized = JSON.stringify(result);
@@ -305,20 +329,34 @@ describe("MCP topic-analysis tools（公開・PIIセーフ読み取り）", () =
       expect(serialized).not.toContain(testUser.id);
     });
 
-    it("公開版が無ければ status=not_ready を返す", async () => {
+    it("版が無ければ status=not_ready を返す", async () => {
       const result = await registry.callTool<{ status: string }>(
-        "get_public_topic_analysis",
+        "get_topic_analysis",
         { billId: billWithout }
       );
       expect(result.status).toBe("not_ready");
     });
   });
 
-  describe("list_public_respondents", () => {
-    it("公開（管理者公開×ユーザー公開）のレポートのみ返す", async () => {
+  describe("list_respondents", () => {
+    it("既定（フィルタ無し）では公開・非公開を問わず全件返す", async () => {
+      const result = await registry.callTool<Array<{ id: string }>>(
+        "list_respondents",
+        { billId: billWithAnalysis }
+      );
+      const ids = result.map((r) => r.id);
+      expect(ids).toContain(publicReportId);
+      expect(ids).toContain(privateReportId);
+    });
+
+    it("公開フラグで絞り込める", async () => {
       const result = await registry.callTool<
         Array<{ id: string; summary: string | null; bill_sentiment: unknown }>
-      >("list_public_respondents", { billId: billWithAnalysis });
+      >("list_respondents", {
+        billId: billWithAnalysis,
+        isPublicByAdmin: true,
+        isPublicByUser: true,
+      });
 
       const ids = result.map((r) => r.id);
       expect(ids).toContain(publicReportId);
@@ -328,8 +366,16 @@ describe("MCP topic-analysis tools（公開・PIIセーフ読み取り）", () =
       expect(pub?.bill_sentiment).toBe("期待");
     });
 
+    it("requireDisplayThreshold 指定時、公開20件未満なら status=below_threshold", async () => {
+      const result = await registry.callTool<{ status: string }>(
+        "list_respondents",
+        { billId: billWithAnalysis, requireDisplayThreshold: true }
+      );
+      expect(result.status).toBe("below_threshold");
+    });
+
     it("個人情報（user_id・email・session）を返さない", async () => {
-      const result = await registry.callTool("list_public_respondents", {
+      const result = await registry.callTool("list_respondents", {
         billId: billWithAnalysis,
       });
       const serialized = JSON.stringify(result);
@@ -341,16 +387,16 @@ describe("MCP topic-analysis tools（公開・PIIセーフ読み取り）", () =
   });
 
   describe("get_respondent_detail", () => {
-    it("公開件数が十分な議案では立場説明と会話ログを返す", async () => {
+    it("既定（フィルタ無し）では公開条件に関わらず立場説明と会話ログを返す", async () => {
       const result = await registry.callTool<{
         id: string;
         user_category: string;
         role_description: string | null;
         bill_sentiment: unknown;
         messages: Array<{ speaker: string; content: string }>;
-      }>("get_respondent_detail", { reportId: detailReportId });
+      }>("get_respondent_detail", { reportId: publicReportId });
 
-      expect(result.id).toBe(detailReportId);
+      expect(result.id).toBe(publicReportId);
       expect(result.user_category).toBe("affected");
       expect(result.role_description).toBe("育休を取得した当事者です");
       expect(result.bill_sentiment).toBe("期待");
@@ -362,21 +408,38 @@ describe("MCP topic-analysis tools（公開・PIIセーフ読み取り）", () =
       ]);
     });
 
-    it("公開レポートが20件未満の議案は status=not_found（k-匿名性ゲート）", async () => {
-      // billWithAnalysis の公開レポートは publicReportId の1件のみ（< 20）。
+    it("既定では非公開レポートも返す（内部向け）", async () => {
+      const result = await registry.callTool<{ id?: string; status?: string }>(
+        "get_respondent_detail",
+        { reportId: privateReportId }
+      );
+      expect(result.id).toBe(privateReportId);
+      expect(result.status).toBeUndefined();
+    });
+
+    it("公開フラグフィルタで非公開レポートを除外できる（status=not_found）", async () => {
       const result = await registry.callTool<{ status: string }>(
         "get_respondent_detail",
-        { reportId: publicReportId }
+        { reportId: privateReportId, isPublicByUser: true }
       );
       expect(result.status).toBe("not_found");
     });
 
-    it("非公開レポートは status=not_found を返す", async () => {
+    it("requireDisplayThreshold 指定時、公開20件未満は status=not_found", async () => {
       const result = await registry.callTool<{ status: string }>(
         "get_respondent_detail",
-        { reportId: privateReportId }
+        { reportId: publicReportId, requireDisplayThreshold: true }
       );
       expect(result.status).toBe("not_found");
+    });
+
+    it("requireDisplayThreshold 指定でも公開20件以上の議案は詳細を返す", async () => {
+      const result = await registry.callTool<{ id?: string; status?: string }>(
+        "get_respondent_detail",
+        { reportId: detailReportId, requireDisplayThreshold: true }
+      );
+      expect(result.id).toBe(detailReportId);
+      expect(result.status).toBeUndefined();
     });
 
     it("個人情報（user_id・email・session）を返さない", async () => {

--- a/tests/mcp/vitest.config.mts
+++ b/tests/mcp/vitest.config.mts
@@ -26,6 +26,10 @@ export default defineConfig({
         repoRoot,
         "packages/topic-analysis-core/src/public/public-server.ts"
       ),
+      "@mirai-gikai/topic-analysis-core/internal-server": path.resolve(
+        repoRoot,
+        "packages/topic-analysis-core/src/internal/internal-server.ts"
+      ),
       // server-only は非 react-server 環境で throw するため空 stub に差し替える
       // （tests/supabase と同方式。alias は deep import 経由でも確実に効く）。
       "server-only": path.resolve(

--- a/tests/mcp/vitest.config.mts
+++ b/tests/mcp/vitest.config.mts
@@ -22,6 +22,10 @@ export default defineConfig({
   resolve: {
     alias: {
       "@mirai-gikai/supabase": path.resolve(repoRoot, "packages/supabase/src"),
+      "@mirai-gikai/topic-analysis-core/public-server": path.resolve(
+        repoRoot,
+        "packages/topic-analysis-core/src/public/public-server.ts"
+      ),
       "@": path.resolve(repoRoot, "admin/src"),
       // ルート node_modules には zod / MCP SDK が無いため、
       // admin の node_modules（pnpm の symlink）経由で解決する。

--- a/tests/mcp/vitest.config.mts
+++ b/tests/mcp/vitest.config.mts
@@ -26,6 +26,12 @@ export default defineConfig({
         repoRoot,
         "packages/topic-analysis-core/src/public/public-server.ts"
       ),
+      // server-only は非 react-server 環境で throw するため空 stub に差し替える
+      // （tests/supabase と同方式。alias は deep import 経由でも確実に効く）。
+      "server-only": path.resolve(
+        repoRoot,
+        "tests/supabase/server-only-stub.ts"
+      ),
       "@": path.resolve(repoRoot, "admin/src"),
       // ルート node_modules には zod / MCP SDK が無いため、
       // admin の node_modules（pnpm の symlink）経由で解決する。

--- a/tests/supabase/topic-analysis-publish-and-read.test.ts
+++ b/tests/supabase/topic-analysis-publish-and-read.test.ts
@@ -1,4 +1,7 @@
-import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  buildPublicTopicAnalysis,
+  findPublishedAnalysis,
+} from "@mirai-gikai/topic-analysis-core/public-server";
 import {
   createVersion,
   finalizeVersion,
@@ -6,8 +9,7 @@ import {
   saveTopicsAndAssignments,
   setVersionPublished,
 } from "@mirai-gikai/topic-analysis-core/repository";
-import { findPublishedAnalysis } from "../../web/src/features/user-topic-analysis/server/repositories/topic-analysis-read-repository";
-import { buildPublicTopicAnalysis } from "../../web/src/features/user-topic-analysis/shared/utils/build-public-topic-analysis";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
 import {
   adminClient,
   cleanupTestBill,

--- a/tests/supabase/vitest.config.mts
+++ b/tests/supabase/vitest.config.mts
@@ -28,6 +28,10 @@ export default defineConfig({
         __dirname,
         "../../packages/topic-analysis-core/src/repositories/repository.ts"
       ),
+      "@mirai-gikai/topic-analysis-core/public-server": path.resolve(
+        __dirname,
+        "../../packages/topic-analysis-core/src/public/public-server.ts"
+      ),
       "server-only": path.resolve(__dirname, "server-only-stub.ts"),
     },
   },

--- a/web/package.json
+++ b/web/package.json
@@ -19,6 +19,7 @@
     "@ai-sdk/react": "^3.0.3",
     "@mirai-gikai/shared": "workspace:*",
     "@mirai-gikai/supabase": "workspace:*",
+    "@mirai-gikai/topic-analysis-core": "workspace:*",
     "@opentelemetry/sdk-node": "^0.206.0",
     "@radix-ui/react-avatar": "^1.1.10",
     "@radix-ui/react-collapsible": "^1.1.12",

--- a/web/src/app/api/bills/[billId]/topic-analysis/route.integration.test.ts
+++ b/web/src/app/api/bills/[billId]/topic-analysis/route.integration.test.ts
@@ -1,4 +1,8 @@
 import {
+  buildPublicTopicAnalysis,
+  findPublishedAnalysis,
+} from "@mirai-gikai/topic-analysis-core/public-server";
+import {
   adminClient,
   cleanupTestBill,
   cleanupTestUser,
@@ -7,8 +11,6 @@ import {
   type TestUser,
 } from "@test-utils/utils";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { findPublishedAnalysis } from "@/features/user-topic-analysis/server/repositories/topic-analysis-read-repository";
-import { buildPublicTopicAnalysis } from "@/features/user-topic-analysis/shared/utils/build-public-topic-analysis";
 import { GET } from "./route";
 
 /** report + interview_opinion を1件作り、opinionId を返す。 */

--- a/web/src/app/api/bills/[billId]/topic-analysis/route.ts
+++ b/web/src/app/api/bills/[billId]/topic-analysis/route.ts
@@ -1,5 +1,4 @@
-import { findPublishedAnalysis } from "@/features/user-topic-analysis/server/repositories/topic-analysis-read-repository";
-import { buildPublicTopicAnalysis } from "@/features/user-topic-analysis/shared/utils/build-public-topic-analysis";
+import { getPublicTopicAnalysis } from "@mirai-gikai/topic-analysis-core/public-server";
 
 const json = (body: unknown, status = 200) =>
   new Response(JSON.stringify(body), {
@@ -26,11 +25,11 @@ export async function GET(
   }
 
   try {
-    const data = await findPublishedAnalysis(billId);
-    if (!data) {
+    const analysis = await getPublicTopicAnalysis(billId);
+    if (!analysis) {
       return json({ error: "no published analysis" }, 404);
     }
-    return json(buildPublicTopicAnalysis(data.meta, data.rawTopics));
+    return json(analysis);
   } catch (error) {
     console.error("[TopicAnalysis] public read failed:", error);
     return json(

--- a/web/src/features/interview-report/server/repositories/interview-report-repository.ts
+++ b/web/src/features/interview-report/server/repositories/interview-report-repository.ts
@@ -133,26 +133,9 @@ export async function countPublicReportsByStance(billId: string) {
 /**
  * 議案IDの公開インタビューレポート件数を取得
  */
-export async function countPublicReportsByBillId(billId: string) {
-  const supabase = createAdminClient();
-  const { count, error } = await supabase
-    .from("interview_report")
-    .select("id, interview_sessions!inner(interview_configs!inner(bill_id))", {
-      count: "exact",
-      head: true,
-    })
-    .eq("is_public_by_admin", true)
-    .eq("is_public_by_user", true)
-    .eq("interview_sessions.interview_configs.bill_id", billId);
-
-  if (error) {
-    throw new Error(
-      `Failed to count public interview reports: ${error.message}`
-    );
-  }
-
-  return count ?? 0;
-}
+// 公開レポート件数のカウントは web・admin MCP で共有するため
+// @mirai-gikai/shared に集約。既存の呼び出し元はこの re-export 経由で参照する。
+export { countPublicReportsByBillId } from "@mirai-gikai/shared/report-publication/count-public-reports";
 
 /**
  * 公開レポートをIDから取得（認証不要）

--- a/web/src/features/interview-report/shared/components/report-interviewee-card.tsx
+++ b/web/src/features/interview-report/shared/components/report-interviewee-card.tsx
@@ -1,5 +1,5 @@
+import { mapRoleToCategory } from "@mirai-gikai/topic-analysis-core/public";
 import { CalendarDays, NotebookText, UserRound } from "lucide-react";
-import { mapRoleToCategory } from "@/features/user-topic-analysis/shared/utils/build-public-topic-analysis";
 import {
   userCategoryColorClass,
   userCategoryLabels,

--- a/web/src/features/user-topic-analysis/server/loaders/get-public-bill-respondents.ts
+++ b/web/src/features/user-topic-analysis/server/loaders/get-public-bill-respondents.ts
@@ -1,16 +1,6 @@
 import "server-only";
 
-import type { PublicRespondent } from "../../shared/types";
-import { buildPublicBillRespondents } from "../../shared/utils/build-public-bill-respondents";
-import { findPublicBillRespondentRows } from "../repositories/topic-analysis-read-repository";
-
-/**
- * 議案の公開レポート（回答者）を全件取得する。
- * AIインタビュー回答一覧（回答者1人=1カード）で使用する。
- */
-export async function getPublicBillRespondents(
-  billId: string
-): Promise<PublicRespondent[]> {
-  const rows = await findPublicBillRespondentRows(billId);
-  return buildPublicBillRespondents(rows);
-}
+export {
+  getPublicBillRespondents,
+  type PublicRespondent,
+} from "@mirai-gikai/topic-analysis-core/public-server";

--- a/web/src/features/user-topic-analysis/server/loaders/get-public-topic-analysis.ts
+++ b/web/src/features/user-topic-analysis/server/loaders/get-public-topic-analysis.ts
@@ -1,22 +1,21 @@
 import "server-only";
 
+import {
+  getPublicTopicAnalysis as fetchPublicTopicAnalysis,
+  type PublicTopicAnalysis,
+} from "@mirai-gikai/topic-analysis-core/public-server";
 import { cache } from "react";
-import type { PublicTopicAnalysis } from "../../shared/types";
-import { buildPublicTopicAnalysis } from "../../shared/utils/build-public-topic-analysis";
-import { findPublishedAnalysis } from "../repositories/topic-analysis-read-repository";
 
 /**
  * 議案の公開中トピック分析を、§8 の表示時フィルタ適用後の表示用データで取得する。
  * Server Components から直接呼ぶ（公開 API と同じデータ契約）。
  * 公開版が無ければ null（呼び出し側で「分析準備中」扱いにする）。
  *
+ * 取得・フィルタの本体は @mirai-gikai/topic-analysis-core/public に集約（web/admin 共有）。
  * React cache() でリクエスト内のDB呼び出しを重複排除する
  * （generateMetadata とページ本体で同じ billId を取得しても1回のクエリで済む）。
  */
 export const getPublicTopicAnalysis = cache(
-  async (billId: string): Promise<PublicTopicAnalysis | null> => {
-    const data = await findPublishedAnalysis(billId);
-    if (!data) return null;
-    return buildPublicTopicAnalysis(data.meta, data.rawTopics);
-  }
+  (billId: string): Promise<PublicTopicAnalysis | null> =>
+    fetchPublicTopicAnalysis(billId)
 );

--- a/web/src/features/user-topic-analysis/shared/types.ts
+++ b/web/src/features/user-topic-analysis/shared/types.ts
@@ -1,124 +1,14 @@
-// ユーザー向けトピック分析の読み取り（公開）API のデータ契約（設計 §13 付録 A.4）。
-
-/** §9 の4区分。interview_report.role を 1:1 でマップする。 */
-export type UserCategory = "affected" | "industry" | "expert" | "citizen";
-
-/** 公開 API が返す意見カード（§8 フィルタ後のもののみ）。 */
-export type PublicOpinion = {
-  id: string;
-  /** この意見の出典インタビューレポートID（レポート詳細への遷移に使う）。 */
-  interview_report_id: string;
-  /**
-   * 出典レポートが管理者公開済みか（is_public_by_admin）。
-   * レポート詳細ページは管理者公開かつ公開件数しきい値を満たす場合のみ表示されるため、
-   * リンク表示の出し分けに使う（§8 表示判定は user 同意・モデレーションのみ）。
-   */
-  report_public: boolean;
-  /** 出典レポートの作成日時（相対表示・日付表示に使う）。 */
-  created_at: string | null;
-  title: string;
-  content: string;
-  user_category: UserCategory;
-  /** 発言者の立場の短縮タイトル（interview_report.role_title）。引用の属性表示に使う。 */
-  role_title: string | null;
-  bill_sentiment: "期待" | "懸念" | null;
-  contextual_quote: string | null;
-  /**
-   * 意見単位の情報充実度（0-100）。引用の優先表示・並べ替えに使う（集計には使わない）。
-   * 旧データ・未生成は null。
-   */
-  richness: number | null;
-  /** 引用の出典メッセージID。レポート詳細の該当メッセージ（#message-<id>）へ遷移するのに使う。 */
-  source_message_id: string | null;
-  /**
-   * 発言を引き出した質問文（source_message_id から導出）。
-   * 導出は Q&A 表示を行う Step 4b で実装するため、4a では null 固定。
-   */
-  question_snippet: string | null;
-};
-
-/** 公開 API が返すトピック（件数・内訳は §8 フィルタ後に再計算）。 */
-export type PublicTopic = {
-  id: string;
-  title: string;
-  description: string;
-  opinion_count: number;
-  affected_count: number;
-  industry_count: number;
-  expert_count: number;
-  citizen_count: number;
-  sentiment: { 期待: number; 懸念: number };
-  opinions: PublicOpinion[];
-};
-
-/** 公開 API レスポンス全体（§13 A.4）。 */
-export type PublicTopicAnalysis = {
-  bill_id: string;
-  version: number;
-  generated_at: string | null;
-  total_opinions: number;
-  topics: PublicTopic[];
-};
-
-// ── リポジトリが返す生データ（pure 関数の入力） ──
-
-/** §8 判定に必要なレポート属性を相乗した、生の意見行。 */
-export type RawOpinionRow = {
-  id: string;
-  interview_report_id: string;
-  created_at: string | null;
-  title: string;
-  content: string;
-  contextual_quote: string | null;
-  source_message_id: string | null;
-  bill_sentiment: string | null;
-  /** 意見単位の情報充実度（0-100・nullable）。引用の優先表示・並べ替えに使う。 */
-  richness: number | null;
-  is_public_by_user: boolean;
-  is_public_by_admin: boolean;
-  moderation_status: string | null;
-  role: string | null;
-  role_title: string | null;
-};
-
-/** version 配下の生トピック行（sort_order 昇順）。 */
-export type RawTopicRow = {
-  id: string;
-  title: string;
-  description: string;
-  opinions: RawOpinionRow[];
-};
-
-/** 公開中 version のメタ情報。 */
-export type PublishedVersionMeta = {
-  bill_id: string;
-  version: number;
-  generated_at: string | null;
-};
-
-// ── 回答一覧（回答者1人=1カード）の表示データ ──
-
-/** 回答一覧カード1件（公開レポート＝回答者1人）。 */
-export type PublicRespondent = {
-  /** 出典インタビューレポートID（レポート詳細への遷移に使う）。 */
-  id: string;
-  user_category: UserCategory;
-  /** 発言者の立場の短縮タイトル（interview_report.role_title）。 */
-  role_title: string | null;
-  /** 賛否（for=期待 / against=懸念 / それ以外=null）。 */
-  bill_sentiment: "期待" | "懸念" | null;
-  /** レポートの要約テキスト（カード本文に表示）。 */
-  summary: string | null;
-  /** 出典レポートの作成日時（相対表示・日付表示に使う）。 */
-  created_at: string | null;
-};
-
-/** リポジトリが返す生のレポート行（回答一覧用・pure 関数の入力）。 */
-export type RawRespondentRow = {
-  id: string;
-  role: string | null;
-  role_title: string | null;
-  stance: string | null;
-  summary: string | null;
-  created_at: string | null;
-};
+// ユーザー向けトピック分析の公開データ契約（設計 §13 付録 A.4）は
+// @mirai-gikai/topic-analysis-core/public に集約し、web 表示と admin MCP 連携で
+// 同一の PII セーフな型を共有する（CLAUDE.md: web/admin 共有ロジックは packages へ）。
+export type {
+  PublicOpinion,
+  PublicRespondent,
+  PublicTopic,
+  PublicTopicAnalysis,
+  PublishedVersionMeta,
+  RawOpinionRow,
+  RawRespondentRow,
+  RawTopicRow,
+  UserCategory,
+} from "@mirai-gikai/topic-analysis-core/public";

--- a/web/src/features/user-topic-analysis/shared/utils/topic-category.ts
+++ b/web/src/features/user-topic-analysis/shared/utils/topic-category.ts
@@ -1,4 +1,8 @@
+import { normalizeRoleTitle } from "@mirai-gikai/topic-analysis-core/public";
 import type { PublicOpinion, UserCategory } from "../types";
+
+// 純粋ロジックの正準はパッケージ側。web 既存 import 互換のため再エクスポートする。
+export { normalizeRoleTitle };
 
 /** §9 の4区分の表示ラベル。 */
 export const userCategoryLabels: Record<UserCategory, string> = {
@@ -18,22 +22,6 @@ export const userCategoryColorClass: Record<UserCategory, string> = {
   expert: "text-topic-expert",
   citizen: "text-topic-citizen",
 };
-
-/**
- * 「市民」相当の汎用的な肩書。固有の肩書とは見なさず、カテゴリラベルに委ねる。
- * （role_title データに「一般市民」等が入っていても UI 上は「市民」に統一するため。）
- */
-const GENERIC_CITIZEN_TITLES = new Set(["一般市民", "市民", "一般"]);
-
-/**
- * 表示用の肩書を返す。固有の肩書のみを返し、空文字や汎用的な「市民」相当は null。
- * 呼び出し側はこれが null のときカテゴリラベルにフォールバックする。
- */
-export function normalizeRoleTitle(roleTitle: string | null): string | null {
-  const trimmed = roleTitle?.trim();
-  if (!trimmed || GENERIC_CITIZEN_TITLES.has(trimmed)) return null;
-  return trimmed;
-}
 
 /**
  * 引用の属性表示ラベル。固有の肩書があればそれを、無ければカテゴリラベルにフォールバックする。


### PR DESCRIPTION
## 🎯 これは何？

AIインタビューの内容（要約・意見・引用・会話ログ）とトピック分析を、**内部の管理者用エージェント**から MCP 経由で取得する**内部向けツール**です。

> [!IMPORTANT]
> このツールは `ADMIN_MCP_TOKEN`（管理者トークン）で到達する**内部向け**機能で、**既定では公開・非公開・モデレーション状態を問わず全件取得**します。取得条件は任意のクエリパラメータで指定でき、プロンプトから「モデレーションOKのみ」等を指示すればクエリに反映されます。
>
> ⚠️ レビュー途中で方針変更しています（当初の「公開連携・PIIセーフ」→ **内部向け・全件＋任意フィルタ**）。`ADMIN_MCP_TOKEN` の内部限定が前提です。

**設計上のポイント:**
- ✅ **新規サーバーは作らない** — 既存の管理用 MCP サーバー（`admin/api/mcp`）に読み取りツールを追加。
- ✅ **web 公開ページの挙動は一切変更なし** — §8 固定の公開経路（`getPublicTopicAnalysis` / `getPublicBillRespondents`）はそのまま。`build-public-topic-analysis`(14件)・`supabase publish-and-read` 等の既存テストが無改修で緑であることで不変を保証。
- ✅ 内部経路は別エントリ **`@mirai-gikai/topic-analysis-core/internal-server`** に分離。

## 追加した MCP ツール（3つ・内部向け・読み取り専用）

| ツール | 入力 | 返すもの |
|---|---|---|
| **`get_topic_analysis`** | `{ billId, ...filter }` | 最新トピック分析（公開・非公開問わず最新版）。トピックごとの件数・属性内訳・期待/懸念＋意見。版が無い/件数ゲートで隠す場合 `status: "not_ready"`。 |
| **`list_respondents`** | `{ billId, ...filter }` | インタビュー回答（回答者1人=1件、新しい順）。立場区分・肩書・賛否・要約。件数ゲートで隠す場合 `status: "below_threshold"`。 |
| **`get_respondent_detail`** | `{ reportId, ...filter }` | 回答詳細＝立場説明（role_description）＋会話ログ（質問と回答）。条件に合致しない/不在なら `status: "not_found"`。 |

## 🔎 任意フィルタ（`...filter`）

未指定なら**絞り込まない（＝全件）**。プロンプトから指定すればクエリに反映:

- `isPublicByAdmin?` / `isPublicByUser?` — 公開フラグで絞り込む
- `moderationStatus?` — `ok` / `warning` / `ng` で絞り込む（例: OK のみ）
- `requireDisplayThreshold?` — `true` で web と同じ k-匿名性ゲート（公開レポート≥20件の議案のみ）を適用

## 🔒 識別子の扱い

> [!WARNING]
> 内部向けのため、**非公開・未モデレーションのレポートや会話ログ（自由記述）も返り得ます**（自由記述には固有名詞が含まれ得る）。`ADMIN_MCP_TOKEN` を外部に出さない前提で運用してください。
>
> ただし `user_id`・email・`expert_registrations`（氏名/連絡先）等の**直接識別子は返却型に含めません**（型レベル）。3ツールとも統合テストで `user_id`/`email`/`session` 非混入をアサート。

## ♻️ web との分離（重複排除しつつ挙動を分離）

- **公開経路**（web 公開ページ）: `getPublicTopicAnalysis` / `getPublicBillRespondents` — §8 固定。**従来どおり**。
- **内部経路**（MCP）: `/internal-server` の `getTopicAnalysis` / `listRespondents` / `getRespondentDetail` — 全件＋任意フィルタ。
- 共有コアは引数で両対応: `buildPublicTopicAnalysis(meta, rawTopics, includeOpinion?)`（デフォルト述語＝§8 `isDisplayable`）、`findPublishedAnalysis`（公開版）/ `findLatestAnalysis`（最新版）は `fetchAnalysisData` を共有、`findRespondentRows(filter)` を web は public プリセットで委譲。

## ✅ テスト

- `pnpm --filter @mirai-gikai/topic-analysis-core test` … **77 passed**（`build-public-topic-analysis` 14件含む＝web ビルダー挙動不変）
- `tests/mcp`（実ローカルSupabase）… **55 passed**（topic-analysis 16: 全件/フィルタ/件数ゲート/識別子非混入）
- `tests/supabase` の `topic-analysis-publish-and-read` … 緑（web `findPublishedAnalysis` 挙動不変）
- `pnpm typecheck` / `pnpm lint` / `pnpm build` … 全パッケージ成功

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MCP サーバ に公開トピック分析 と公開インタビュー回答 取得 ツール を追加。
  * 公開（PII セーフ）データ の取得 を共通API に統合し、画面 と API で同一 ルール を適用。
* **Bug Fixes**
  * 肩書 の 正規化 を改善し、汎用的な ラベル 表示 を抑制。
  * 回答者一覧 表示用 データ と 指標（賛否 など） の 正規化 を見直し、一貫性 を向上。
* **Tests**
  * 肩書正規化 の 期待動作 を確認する テスト を追加。
* **Refactor**
  * 公開データ 取得 を 共通API に委譲し、型定義 も整理。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
