### PR TITLE
インタビュー設定: 質問の順番をドラッグ&ドロップで入れ替え可能に

### DIFF
--- a/admin/package.json
+++ b/admin/package.json
@@ -12,6 +12,9 @@
   },
   "dependencies": {
     "@ai-sdk/react": "^3.0.3",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@hookform/resolvers": "^5.2.1",
     "@mirai-gikai/shared": "workspace:*",
     "@mirai-gikai/supabase": "workspace:*",

--- a/admin/src/features/interview-config/client/components/interview-question-list.tsx
+++ b/admin/src/features/interview-config/client/components/interview-question-list.tsx
@@ -1,15 +1,90 @@
 "use client";
 
-import { useCallback, useEffect, useState, useTransition } from "react";
+import {
+  closestCenter,
+  DndContext,
+  type DragEndEvent,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { GripVertical } from "lucide-react";
+import { useCallback, useEffect, useRef, useState, useTransition } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
 import { saveInterviewQuestions } from "../../server/actions/save-interview-questions";
 import type {
   InterviewQuestion,
   InterviewQuestionInput,
 } from "../../shared/types";
+import {
+  type SortableQuestion,
+  toInputs,
+  withUid,
+} from "../utils/sortable-question";
 import { InterviewQuestionForm } from "./interview-question-form";
+
+/**
+ * 並び替え可能な質問カードのラッパー。
+ * 編集中（disabled=true）はドラッグハンドルを表示せず、ドラッグも無効化する。
+ */
+function SortableQuestionItem({
+  id,
+  disabled,
+  children,
+}: {
+  id: string;
+  disabled?: boolean;
+  children: React.ReactNode;
+}) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id, disabled });
+
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={cn("flex items-start gap-2", isDragging && "relative z-10")}
+    >
+      {!disabled && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          aria-label="ドラッグして並び替え"
+          className="mt-1 h-8 w-6 cursor-grab touch-none text-gray-400 hover:text-gray-600 active:cursor-grabbing"
+          {...attributes}
+          {...listeners}
+        >
+          <GripVertical className="size-4" />
+        </Button>
+      )}
+      <div className="flex-1">{children}</div>
+    </div>
+  );
+}
 
 interface InterviewQuestionListProps {
   interviewConfigId: string;
@@ -32,38 +107,56 @@ export function InterviewQuestionList({
   onAiQuestionsApplied,
   getQuestionsRef,
 }: InterviewQuestionListProps) {
-  const [questions, setQuestions] = useState<InterviewQuestionInput[]>(
-    initialQuestions.map((q) => ({
-      question: q.question,
-      follow_up_guide: q.follow_up_guide || undefined,
-      quick_replies: q.quick_replies || undefined,
-      target_audience: q.target_audience || undefined,
-    }))
+  const [questions, setQuestions] = useState<SortableQuestion[]>(() =>
+    initialQuestions.map((q) =>
+      withUid({
+        question: q.question,
+        follow_up_guide: q.follow_up_guide || undefined,
+        quick_replies: q.quick_replies || undefined,
+        target_audience: q.target_audience || undefined,
+      })
+    )
   );
   const [editingIndex, setEditingIndex] = useState<number | null>(null);
   const [isPending, startTransition] = useTransition();
 
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
+  );
+
   // 親コンポーネントから最新の questions を読めるようにする
   useEffect(() => {
     if (!getQuestionsRef) return;
-    getQuestionsRef.current = () => questions;
+    getQuestionsRef.current = () => toInputs(questions);
     return () => {
       // アンマウント後に stale な getter を親が読まないようクリア
       getQuestionsRef.current = null;
     };
   }, [questions, getQuestionsRef]);
 
-  const saveQuestions = useCallback(
-    (questionsToSave: InterviewQuestionInput[]) => {
-      startTransition(async () => {
-        const result = await saveInterviewQuestions(
-          interviewConfigId,
-          questionsToSave
-        );
+  // 保存はサーバー側で全件削除→再挿入するため、連続して呼ばれた場合に
+  // 古いリクエストが後着して最新の並び順を上書きしないよう、送信順に直列化する。
+  const saveChainRef = useRef<Promise<void>>(Promise.resolve());
 
-        if (!result.success) {
-          toast.error(result.error || "質問の保存に失敗しました");
-        }
+  const saveQuestions = useCallback(
+    (questionsToSave: SortableQuestion[]) => {
+      const inputs = toInputs(questionsToSave);
+      startTransition(async () => {
+        const run = saveChainRef.current.then(async () => {
+          const result = await saveInterviewQuestions(
+            interviewConfigId,
+            inputs
+          );
+          if (!result.success) {
+            toast.error(result.error || "質問の保存に失敗しました");
+          }
+        });
+        // チェーンが失敗で途切れないよう、エラーは握りつぶして次へ繋ぐ
+        saveChainRef.current = run.catch(() => {});
+        await saveChainRef.current;
       });
     },
     [interviewConfigId]
@@ -72,15 +165,16 @@ export function InterviewQuestionList({
   // AI生成質問の反映
   useEffect(() => {
     if (aiGeneratedQuestions && aiGeneratedQuestions.length > 0) {
-      setQuestions(aiGeneratedQuestions);
-      saveQuestions(aiGeneratedQuestions);
+      const newQuestions = aiGeneratedQuestions.map(withUid);
+      setQuestions(newQuestions);
+      saveQuestions(newQuestions);
       onAiQuestionsApplied?.();
       toast.success(`AIが${aiGeneratedQuestions.length}件の質問を生成しました`);
     }
   }, [aiGeneratedQuestions, saveQuestions, onAiQuestionsApplied]);
 
   const handleAdd = (newQuestion: InterviewQuestionInput) => {
-    const newQuestions = [...questions, newQuestion];
+    const newQuestions = [...questions, withUid(newQuestion)];
     setQuestions(newQuestions);
     saveQuestions(newQuestions);
     toast.success("質問を追加しました");
@@ -91,7 +185,7 @@ export function InterviewQuestionList({
     updatedQuestion: InterviewQuestionInput
   ) => {
     const newQuestions = [...questions];
-    newQuestions[index] = updatedQuestion;
+    newQuestions[index] = { ...updatedQuestion, _uid: questions[index]._uid };
     setQuestions(newQuestions);
     setEditingIndex(null);
     saveQuestions(newQuestions);
@@ -106,6 +200,22 @@ export function InterviewQuestionList({
       saveQuestions(newQuestions);
       toast.success("質問を削除しました");
     }
+  };
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+
+    const oldIndex = questions.findIndex((q) => q._uid === active.id);
+    const newIndex = questions.findIndex((q) => q._uid === over.id);
+    if (oldIndex === -1 || newIndex === -1) return;
+
+    const newQuestions = arrayMove(questions, oldIndex, newIndex);
+    setQuestions(newQuestions);
+    // 並び替えでインデックスがずれるため、編集中の状態は解除する
+    setEditingIndex(null);
+    saveQuestions(newQuestions);
+    toast.success("質問の順番を変更しました");
   };
 
   return (
@@ -124,84 +234,98 @@ export function InterviewQuestionList({
               質問が登録されていません。上記のフォームから質問を追加してください。
             </p>
           ) : (
-            <div className="space-y-4">
-              {questions.map((question, index) => {
-                const isEditing = editingIndex === index;
-                const questionKey = `question-${index}-${question.question}`;
-                return (
-                  <div key={questionKey}>
-                    {isEditing ? (
-                      <InterviewQuestionForm
-                        onSubmit={(updated) => handleUpdate(index, updated)}
-                        onCancel={() => setEditingIndex(null)}
-                        initialData={question}
-                        submitLabel="更新"
-                      />
-                    ) : (
-                      <Card>
-                        <CardContent>
-                          <div className="flex items-start justify-between gap-4">
-                            <div className="flex-1 space-y-2">
-                              <div className="flex items-center gap-2">
-                                <span className="text-sm font-medium text-gray-500">
-                                  Q{index + 1}
-                                </span>
-                                <div className="font-semibold text-gray-900">
-                                  {question.question}
+            <DndContext
+              sensors={sensors}
+              collisionDetection={closestCenter}
+              onDragEnd={handleDragEnd}
+            >
+              <SortableContext
+                items={questions.map((q) => q._uid)}
+                strategy={verticalListSortingStrategy}
+              >
+                <div className="space-y-4">
+                  {questions.map((question, index) => {
+                    const isEditing = editingIndex === index;
+                    return (
+                      <SortableQuestionItem
+                        key={question._uid}
+                        id={question._uid}
+                        disabled={isEditing}
+                      >
+                        {isEditing ? (
+                          <InterviewQuestionForm
+                            onSubmit={(updated) => handleUpdate(index, updated)}
+                            onCancel={() => setEditingIndex(null)}
+                            initialData={question}
+                            submitLabel="更新"
+                          />
+                        ) : (
+                          <Card>
+                            <CardContent>
+                              <div className="flex items-start justify-between gap-4">
+                                <div className="flex-1 space-y-2">
+                                  <div className="flex items-center gap-2">
+                                    <span className="text-sm font-medium text-gray-500">
+                                      Q{index + 1}
+                                    </span>
+                                    <div className="font-semibold text-gray-900">
+                                      {question.question}
+                                    </div>
+                                  </div>
+                                  {question.follow_up_guide && (
+                                    <div className="text-sm text-gray-600">
+                                      <span className="font-medium">
+                                        フォローアップ指針:
+                                      </span>{" "}
+                                      {question.follow_up_guide}
+                                    </div>
+                                  )}
+                                  {question.quick_replies &&
+                                    question.quick_replies.length > 0 && (
+                                      <div className="text-sm text-gray-600">
+                                        <span className="font-medium">
+                                          クイックリプライ:
+                                        </span>{" "}
+                                        {question.quick_replies.join(", ")}
+                                      </div>
+                                    )}
+                                  {question.target_audience && (
+                                    <div className="text-sm text-gray-600">
+                                      <span className="font-medium">
+                                        対象者条件:
+                                      </span>{" "}
+                                      {question.target_audience}
+                                    </div>
+                                  )}
+                                </div>
+                                <div className="flex gap-2 flex-shrink-0">
+                                  <Button
+                                    type="button"
+                                    variant="outline"
+                                    size="sm"
+                                    onClick={() => setEditingIndex(index)}
+                                  >
+                                    編集
+                                  </Button>
+                                  <Button
+                                    type="button"
+                                    variant="destructive"
+                                    size="sm"
+                                    onClick={() => handleDelete(index)}
+                                  >
+                                    削除
+                                  </Button>
                                 </div>
                               </div>
-                              {question.follow_up_guide && (
-                                <div className="text-sm text-gray-600">
-                                  <span className="font-medium">
-                                    フォローアップ指針:
-                                  </span>{" "}
-                                  {question.follow_up_guide}
-                                </div>
-                              )}
-                              {question.quick_replies &&
-                                question.quick_replies.length > 0 && (
-                                  <div className="text-sm text-gray-600">
-                                    <span className="font-medium">
-                                      クイックリプライ:
-                                    </span>{" "}
-                                    {question.quick_replies.join(", ")}
-                                  </div>
-                                )}
-                              {question.target_audience && (
-                                <div className="text-sm text-gray-600">
-                                  <span className="font-medium">
-                                    対象者条件:
-                                  </span>{" "}
-                                  {question.target_audience}
-                                </div>
-                              )}
-                            </div>
-                            <div className="flex gap-2 flex-shrink-0">
-                              <Button
-                                type="button"
-                                variant="outline"
-                                size="sm"
-                                onClick={() => setEditingIndex(index)}
-                              >
-                                編集
-                              </Button>
-                              <Button
-                                type="button"
-                                variant="destructive"
-                                size="sm"
-                                onClick={() => handleDelete(index)}
-                              >
-                                削除
-                              </Button>
-                            </div>
-                          </div>
-                        </CardContent>
-                      </Card>
-                    )}
-                  </div>
-                );
-              })}
-            </div>
+                            </CardContent>
+                          </Card>
+                        )}
+                      </SortableQuestionItem>
+                    );
+                  })}
+                </div>
+              </SortableContext>
+            </DndContext>
           )}
         </div>
 

--- a/admin/src/features/interview-config/client/components/interview-question-list.tsx
+++ b/admin/src/features/interview-config/client/components/interview-question-list.tsx
@@ -117,7 +117,8 @@ export function InterviewQuestionList({
       })
     )
   );
-  const [editingIndex, setEditingIndex] = useState<number | null>(null);
+  // 並び替えでインデックスがずれても編集中の行を見失わないよう _uid で管理する
+  const [editingUid, setEditingUid] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
 
   const sensors = useSensors(
@@ -181,22 +182,23 @@ export function InterviewQuestionList({
   };
 
   const handleUpdate = (
-    index: number,
+    uid: string,
     updatedQuestion: InterviewQuestionInput
   ) => {
-    const newQuestions = [...questions];
-    newQuestions[index] = { ...updatedQuestion, _uid: questions[index]._uid };
+    const newQuestions = questions.map((q) =>
+      q._uid === uid ? { ...updatedQuestion, _uid: uid } : q
+    );
     setQuestions(newQuestions);
-    setEditingIndex(null);
+    setEditingUid(null);
     saveQuestions(newQuestions);
     toast.success("質問を更新しました");
   };
 
-  const handleDelete = (index: number) => {
+  const handleDelete = (uid: string) => {
     if (confirm("この質問を削除してもよろしいですか？")) {
-      const newQuestions = questions.filter((_, i) => i !== index);
+      const newQuestions = questions.filter((q) => q._uid !== uid);
       setQuestions(newQuestions);
-      setEditingIndex(null);
+      if (editingUid === uid) setEditingUid(null);
       saveQuestions(newQuestions);
       toast.success("質問を削除しました");
     }
@@ -212,8 +214,6 @@ export function InterviewQuestionList({
 
     const newQuestions = arrayMove(questions, oldIndex, newIndex);
     setQuestions(newQuestions);
-    // 並び替えでインデックスがずれるため、編集中の状態は解除する
-    setEditingIndex(null);
     saveQuestions(newQuestions);
     toast.success("質問の順番を変更しました");
   };
@@ -245,7 +245,7 @@ export function InterviewQuestionList({
               >
                 <div className="space-y-4">
                   {questions.map((question, index) => {
-                    const isEditing = editingIndex === index;
+                    const isEditing = editingUid === question._uid;
                     return (
                       <SortableQuestionItem
                         key={question._uid}
@@ -254,8 +254,10 @@ export function InterviewQuestionList({
                       >
                         {isEditing ? (
                           <InterviewQuestionForm
-                            onSubmit={(updated) => handleUpdate(index, updated)}
-                            onCancel={() => setEditingIndex(null)}
+                            onSubmit={(updated) =>
+                              handleUpdate(question._uid, updated)
+                            }
+                            onCancel={() => setEditingUid(null)}
                             initialData={question}
                             submitLabel="更新"
                           />
@@ -303,7 +305,7 @@ export function InterviewQuestionList({
                                     type="button"
                                     variant="outline"
                                     size="sm"
-                                    onClick={() => setEditingIndex(index)}
+                                    onClick={() => setEditingUid(question._uid)}
                                   >
                                     編集
                                   </Button>
@@ -311,7 +313,7 @@ export function InterviewQuestionList({
                                     type="button"
                                     variant="destructive"
                                     size="sm"
-                                    onClick={() => handleDelete(index)}
+                                    onClick={() => handleDelete(question._uid)}
                                   >
                                     削除
                                   </Button>

--- a/admin/src/features/interview-config/client/utils/sortable-question.test.ts
+++ b/admin/src/features/interview-config/client/utils/sortable-question.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import type { InterviewQuestionInput } from "../../shared/types";
+import { type SortableQuestion, toInputs, withUid } from "./sortable-question";
+
+describe("withUid", () => {
+  it("元のフィールドを保持したまま _uid を付与する", () => {
+    const input: InterviewQuestionInput = {
+      question: "好きな色は？",
+      follow_up_guide: "理由も聞く",
+      quick_replies: ["赤", "青"],
+      target_audience: "全員",
+    };
+
+    const result = withUid(input);
+
+    expect(result._uid).toBeTruthy();
+    expect(result).toMatchObject(input);
+  });
+
+  it("呼び出しごとに異なる _uid を割り当てる", () => {
+    const input: InterviewQuestionInput = { question: "Q" };
+
+    expect(withUid(input)._uid).not.toBe(withUid(input)._uid);
+  });
+});
+
+describe("toInputs", () => {
+  it("_uid を取り除いて InterviewQuestionInput[] に戻す", () => {
+    const items: SortableQuestion[] = [
+      { _uid: "a", question: "Q1" },
+      { _uid: "b", question: "Q2", follow_up_guide: "g" },
+    ];
+
+    const result = toInputs(items);
+
+    expect(result).toEqual([
+      { question: "Q1" },
+      { question: "Q2", follow_up_guide: "g" },
+    ]);
+    expect(result.every((q) => !("_uid" in q))).toBe(true);
+  });
+
+  it("配列の順序を維持する", () => {
+    const items: SortableQuestion[] = [
+      { _uid: "a", question: "Q1" },
+      { _uid: "b", question: "Q2" },
+      { _uid: "c", question: "Q3" },
+    ];
+
+    expect(toInputs(items).map((q) => q.question)).toEqual(["Q1", "Q2", "Q3"]);
+  });
+
+  it("withUid とのラウンドトリップで元の入力に一致する", () => {
+    const inputs: InterviewQuestionInput[] = [
+      { question: "Q1", quick_replies: ["a"] },
+      { question: "Q2" },
+    ];
+
+    expect(toInputs(inputs.map(withUid))).toEqual(inputs);
+  });
+});

--- a/admin/src/features/interview-config/client/utils/sortable-question.ts
+++ b/admin/src/features/interview-config/client/utils/sortable-question.ts
@@ -1,0 +1,22 @@
+import type { InterviewQuestionInput } from "../../shared/types";
+
+/**
+ * ドラッグ並び替え用に、各質問へクライアント側で安定したIDを付与した内部表現。
+ * 保存時・親への受け渡し時は `_uid` を取り除いて {@link InterviewQuestionInput} に戻す。
+ */
+export type SortableQuestion = InterviewQuestionInput & { _uid: string };
+
+/**
+ * 質問に並び替え用の安定IDを付与する。
+ * `crypto.randomUUID()` を用いるため、呼び出しごとに新しいIDが割り振られる。
+ */
+export function withUid(question: InterviewQuestionInput): SortableQuestion {
+  return { ...question, _uid: crypto.randomUUID() };
+}
+
+/**
+ * 並び替え用の `_uid` を取り除き、保存・送信用の {@link InterviewQuestionInput} に戻す。
+ */
+export function toInputs(items: SortableQuestion[]): InterviewQuestionInput[] {
+  return items.map(({ _uid, ...rest }) => rest);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,15 @@ importers:
       '@ai-sdk/react':
         specifier: ^3.0.3
         version: 3.0.3(react@19.1.2)(zod@4.1.12)
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.1.2(react@19.1.2))(react@19.1.2))(react@19.1.2)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.1.2)
       '@hookform/resolvers':
         specifier: ^5.2.1
         version: 5.2.2(react-hook-form@7.64.0(react@19.1.2))
@@ -661,6 +670,28 @@ packages:
   '@csstools/css-tokenizer@4.0.0':
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@emnapi/runtime@1.5.0':
     resolution: {integrity: sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==}
@@ -5150,6 +5181,31 @@ snapshots:
   '@csstools/css-syntax-patches-for-csstree@1.0.28': {}
 
   '@csstools/css-tokenizer@4.0.0': {}
+
+  '@dnd-kit/accessibility@3.1.1(react@19.1.2)':
+    dependencies:
+      react: 19.1.2
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.1.2(react@19.1.2))(react@19.1.2)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.1.2)
+      '@dnd-kit/utilities': 3.2.2(react@19.1.2)
+      react: 19.1.2
+      react-dom: 19.1.2(react@19.1.2)
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.1.2(react@19.1.2))(react@19.1.2))(react@19.1.2)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
+      '@dnd-kit/utilities': 3.2.2(react@19.1.2)
+      react: 19.1.2
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.1.2)':
+    dependencies:
+      react: 19.1.2
+      tslib: 2.8.1
 
   '@emnapi/runtime@1.5.0':
     dependencies:


### PR DESCRIPTION
## 概要

インタビューコンフィグの設定画面（質問一覧）で、質問の順番をドラッグ&ドロップで入れ替えられるようにしました。

## 変更内容

- `@dnd-kit/core` / `@dnd-kit/sortable` / `@dnd-kit/utilities` を `admin` に追加
- 各質問カードにドラッグハンドル（`GripVertical`）を追加し、`@dnd-kit` で並び替え可能に
  - ポインタ操作・キーボード操作の両方に対応（アクセシビリティ）
  - 編集中の行はドラッグを無効化
- 並び替え結果は既存の `saveInterviewQuestions` Server Action で永続化（`question_order` を配列順で再採番）
- **保存の直列化**: サーバー側が全件削除→再挿入のため、連続並び替え時に古い保存リクエストが後着して最新の順番を上書きするレースを防止（add/update/delete の保存にも適用）
- `_uid` ライフサイクル（`withUid` / `toInputs` / `SortableQuestion` 型）を `client/utils/sortable-question.ts` に切り出し、ユニットテストを追加

## テスト

- `pnpm --filter admin typecheck` ✓
- `pnpm lint` ✓
- `pnpm --filter admin test` ✓（446 passed / うち新規 5）
- `pnpm --filter admin build` ✓

## 備考

- `admin/package.json` / `pnpm-lock.yaml` に依存追加あり

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 面接質問の一覧をドラッグ＆ドロップで並び替えできるようになりました。
  * 編集中はドラッグ操作を無効化し、誤操作を防ぎます。
* **バグ修正**
  * 連続した保存時も、並び替え結果が正しい順序で反映されるよう改善しました。
  * 追加・編集・削除後も、並び順が安定して保持されます。
* **テスト**
  * 並び替え用変換の挙動を検証するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->