### PR TITLE
法案スタンスの選択肢に「自由投票」を追加

### DIFF
--- a/admin/src/features/mirai-stance/shared/types/index.ts
+++ b/admin/src/features/mirai-stance/shared/types/index.ts
@@ -15,6 +15,7 @@ export const stanceInputSchema = z.object({
       "conditional_against",
       "considering",
       "continued_deliberation",
+      "free_vote",
     ] as const)
     .refine((val) => val !== undefined, {
       message: "スタンスを選択してください",
@@ -33,4 +34,5 @@ export const STANCE_TYPE_LABELS: Record<StanceTypeEnum, string> = {
   conditional_against: "条件付き反対",
   considering: "検討中",
   continued_deliberation: "継続審査中",
+  free_vote: "自由投票",
 };

--- a/packages/supabase/types/supabase.types.ts
+++ b/packages/supabase/types/supabase.types.ts
@@ -1294,6 +1294,7 @@ export type Database = {
         | "conditional_against"
         | "considering"
         | "continued_deliberation"
+        | "free_vote"
       topic_analysis_status: "pending" | "running" | "completed" | "failed"
     }
     CompositeTypes: {
@@ -1462,9 +1463,9 @@ export const Constants = {
         "conditional_against",
         "considering",
         "continued_deliberation",
+        "free_vote",
       ],
       topic_analysis_status: ["pending", "running", "completed", "failed"],
     },
   },
 } as const
-

--- a/supabase/migrations/20260630090000_add_free_vote_to_stance_type.sql
+++ b/supabase/migrations/20260630090000_add_free_vote_to_stance_type.sql
@@ -1,0 +1,1 @@
+ALTER TYPE stance_type_enum ADD VALUE 'free_vote';

--- a/web/src/features/bills/shared/types/index.ts
+++ b/web/src/features/bills/shared/types/index.ts
@@ -114,4 +114,5 @@ export const STANCE_LABELS: Record<StanceTypeEnum, string> = {
   conditional_against: "条件付き反対",
   considering: "検討中",
   continued_deliberation: "継続審査中",
+  free_vote: "自由投票",
 };


### PR DESCRIPTION
## 概要

みらい議会の「チームみらいのスタンス」(`stance_type_enum`) の選択肢に **`free_vote`（自由投票）** を追加します。

党議拘束を外して各議員の判断に委ねる「自由投票」を、賛成/反対などと並ぶスタンスとして Admin から設定できるようにするための変更です。

## 背景

政調会長の古川あおいさんから「みらい議会の法案スタンスの選択肢に『自由投票』がないので追加してほしい」という依頼がありました（@k.murai @角野為耶 宛て）。
- 依頼スレッド: https://team-mirai-staff.slack.com/archives/C0AFPQKSKS7/p1782811311186799?thread_ts=1782811311.186799

## 変更内容

既存スタンス追加の前例（#135「継続審査中スタンスを追加」）と同じ構成で、`enum` 値 `free_vote` / 表示ラベル「自由投票」を追加しています。

- `supabase/migrations/20260630090000_add_free_vote_to_stance_type.sql`（新規）
  - `ALTER TYPE stance_type_enum ADD VALUE 'free_vote';`
- `packages/supabase/types/supabase.types.ts`
  - 生成型の `stance_type_enum` ユニオン と `Constants` 配列に `free_vote` を追加（`supabase gen types` 相当の手当て）
- `admin/src/features/mirai-stance/shared/types/index.ts`
  - 入力スキーマ(zod enum)と `STANCE_TYPE_LABELS` に `free_vote: "自由投票"` を追加
  - Admin のスタンス選択フォームは `STANCE_TYPE_LABELS` を列挙しているので、自動で選択肢に表示されます
- `web/src/features/bills/shared/types/index.ts`
  - 公開側 `STANCE_LABELS` に `free_vote: "自由投票"` を追加

## 表示について

- 公開側のスタンスバッジ（`stance-styles.ts`）は `for/conditional_for` と `against/conditional_against` 以外を `default`（中立寄りのグレー背景）で表示します。`free_vote` は賛成でも反対でもないため、この `default` 表示（ラベル「自由投票」）になります。専用配色が必要であれば別途指定ください。
- Admin ドロップダウンでは末尾に「自由投票」が追加されます（既存の並び順は維持）。

## 補足・確認したい点

- マイグレーションは PR #135 と同じく `ALTER TYPE ... ADD VALUE` のみです。
- 「党の賛否の正本は政調の法案管理シート、みらい議会はその同期先」という設計の議論が同チャンネルで進んでいますが、本 PR は選択肢（enum）の追加に限定しています。同期側で `free_vote` を扱う必要が出た場合は別途対応が必要です。

<!-- mirai-inu-session: sesn_01VZkWxFWmNQszy7cuogejBJ -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 立場の選択肢に「自由投票」を追加し、フォームや表示で選べるようになりました。
  * 立場ラベルの表示に「自由投票」が対応し、画面上でも正しく表示されます。
  * データ定義も更新され、新しい立場種別を一貫して扱えるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->