### PR TITLE
test: 自由投票スタンスのラベル表示の回帰テストを追加

### DIFF
--- a/web/src/features/bills/shared/utils/stance-styles.test.ts
+++ b/web/src/features/bills/shared/utils/stance-styles.test.ts
@@ -96,6 +96,15 @@ describe("getStanceStyles", () => {
     });
   });
 
+  it("free_vote スタンスでデフォルトスタイルを返す", () => {
+    const result = getStanceStyles(makeStance("free_vote"), false);
+    expect(result).toEqual({
+      bg: "bg-mirai-surface-muted",
+      textColor: "text-black",
+      label: "自由投票",
+    });
+  });
+
   it("stance=undefined, isPreparing=false のとき中立ラベルを返す", () => {
     const result = getStanceStyles(undefined, false);
     expect(result).toEqual({


### PR DESCRIPTION
## 概要

法案スタンスの表示スタイルを返す `getStanceStyles` のテストに、**`free_vote`（自由投票）** のケースを追加します。既存テストは全スタンスを網羅していましたが `free_vote` だけ未カバーだったため、回帰テストとして固定します。

## 背景（角野さんからの指摘）

[#886](https://github.com/team-mirai/mirai-gikai/pull/886) で `free_vote`（自由投票）スタンスを追加後、「ユーザー向け画面の賛否セクションのバッジに自由投票のときテキストが出ない」という指摘がありました。

### 調査結果：ランタイムのコードは既に正しい

ユーザー向けの賛否バッジを描画しているのは `mirai-stance-card.tsx` → `getStanceStyles()` の1経路だけで、`free_vote` は `継続審査中` などと同じ `default` 分岐を通り、`STANCE_LABELS["free_vote"]`（= 「自由投票」）を返します。#886 でこのラベルは追加済みで、`develop` にも入っています。

- 賛否を画像化する別経路（法案ページの OG 画像など）は存在せず、`getStanceStyles` の利用箇所もこのカードのみ（確認済み）。
- `develop` が唯一のデプロイ対象ブランチ（`main` は無し）で、`free_vote` は反映済み。

つまり **`free_vote` と `continued_deliberation` を区別するコードは存在せず、両者は同じ描画になります**。スクショでバッジが空だったのは、#886 のフロントエンドビルドがデプロイされる前の状態、もしくは当該法案ページの Full Route Cache が古い描画でキャッシュされていたためと考えられます。

→ 解消には **#886 を含む `develop` のデプロイが反映済みであることの確認**と、当該法案ページのキャッシュの再生成（再デプロイ or 当該 bill の revalidate）で十分です。もし最新ビルドでも空のままなら、その法案の URL をいただければさらに調べます。

## この PR の変更

- `web/src/features/bills/shared/utils/stance-styles.test.ts`
  - `free_vote` → グレー背景（`bg-mirai-surface-muted` / `text-black`）＋ラベル「自由投票」を返すことを検証するテストを追加（`継続審査中` のテストと同型）。

挙動の変更はありません（テストの追加のみ）。今後ラベル定義の取りこぼしで再発しないようにするためのガードです。

<!-- mirai-inu-session: sesn_01VZkWxFWmNQszy7cuogejBJ -->