### PR TITLE
admin: MCPに upsert_mirai_stance ツールを追加

### DIFF
--- a/admin/src/features/mcp/server/create-handler.ts
+++ b/admin/src/features/mcp/server/create-handler.ts
@@ -6,6 +6,7 @@ import {
 } from "mcp-handler";
 import { registerBillsTools } from "./tools/register-bills-tools";
 import { registerDietSessionsTools } from "./tools/register-diet-sessions-tools";
+import { registerMiraiStanceTools } from "./tools/register-mirai-stance-tools";
 import { registerPreviewTools } from "./tools/register-preview-tools";
 import { registerTagsTools } from "./tools/register-tags-tools";
 import { registerTopicAnalysisTools } from "./tools/register-topic-analysis-tools";
@@ -16,6 +17,7 @@ export function createAdminMcpHandler() {
     (server) => {
       registerBillsTools(server);
       registerDietSessionsTools(server);
+      registerMiraiStanceTools(server);
       registerPreviewTools(server);
       registerTagsTools(server);
       registerTopicAnalysisTools(server);

--- a/admin/src/features/mcp/server/tools/register-mirai-stance-tools.ts
+++ b/admin/src/features/mcp/server/tools/register-mirai-stance-tools.ts
@@ -25,8 +25,14 @@ export function registerMiraiStanceTools(server: McpServer): void {
     async ({ billId, type, comment }) => {
       // created は「新規か更新か」を呼び出し側（Slack bot）に伝えるための
       // best-effort な情報。実際の書き込みは upsertMiraiStance が
-      // onConflict(bill_id) で atomic に行うため、この事前 read は正しさに影響しない。
-      const existing = await findStanceByBillId(billId);
+      // onConflict(bill_id) で atomic に行う。事前 read が失敗しても created の
+      // 精度が落ちるだけで、書き込み自体はブロックしない。
+      let existing: Awaited<ReturnType<typeof findStanceByBillId>> = null;
+      try {
+        existing = await findStanceByBillId(billId);
+      } catch {
+        // best-effort: read 失敗時は created を判定できないため未知扱い
+      }
       await upsertMiraiStance(billId, { type, comment });
       await invalidateBillsCache();
       return jsonResult({ ok: true, created: existing === null, type });

--- a/admin/src/features/mcp/server/tools/register-mirai-stance-tools.ts
+++ b/admin/src/features/mcp/server/tools/register-mirai-stance-tools.ts
@@ -3,9 +3,8 @@ import "server-only";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import {
-  createMiraiStance,
   findStanceByBillId,
-  updateMiraiStance,
+  upsertMiraiStance,
 } from "@/features/mirai-stance/server/repositories/mirai-stance-repository";
 import { stanceInputSchema } from "@/features/mirai-stance/shared/types";
 import { invalidateBillsCache } from "../utils/invalidate-bills-cache";
@@ -24,13 +23,11 @@ export function registerMiraiStanceTools(server: McpServer): void {
       },
     },
     async ({ billId, type, comment }) => {
+      // created は「新規か更新か」を呼び出し側（Slack bot）に伝えるための
+      // best-effort な情報。実際の書き込みは upsertMiraiStance が
+      // onConflict(bill_id) で atomic に行うため、この事前 read は正しさに影響しない。
       const existing = await findStanceByBillId(billId);
-      const input = { type, comment };
-      if (existing) {
-        await updateMiraiStance(existing.id, input);
-      } else {
-        await createMiraiStance(billId, input);
-      }
+      await upsertMiraiStance(billId, { type, comment });
       await invalidateBillsCache();
       return jsonResult({ ok: true, created: existing === null, type });
     }

--- a/admin/src/features/mcp/server/tools/register-mirai-stance-tools.ts
+++ b/admin/src/features/mcp/server/tools/register-mirai-stance-tools.ts
@@ -1,0 +1,38 @@
+import "server-only";
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import {
+  createMiraiStance,
+  findStanceByBillId,
+  updateMiraiStance,
+} from "@/features/mirai-stance/server/repositories/mirai-stance-repository";
+import { stanceInputSchema } from "@/features/mirai-stance/shared/types";
+import { invalidateBillsCache } from "../utils/invalidate-bills-cache";
+import { jsonResult } from "../utils/json-result";
+
+export function registerMiraiStanceTools(server: McpServer): void {
+  server.registerTool(
+    "upsert_mirai_stance",
+    {
+      title: "チームみらいの賛否を設定",
+      description:
+        "指定議案に対するチームみらいの賛否スタンスをupsertする（1議案につき1件）。既存スタンスがあれば type / comment を更新し、なければ新規作成する。type は for / against / neutral / conditional_for / conditional_against / considering / continued_deliberation のいずれか。",
+      inputSchema: {
+        billId: z.string().uuid(),
+        ...stanceInputSchema.shape,
+      },
+    },
+    async ({ billId, type, comment }) => {
+      const existing = await findStanceByBillId(billId);
+      const input = { type, comment };
+      if (existing) {
+        await updateMiraiStance(existing.id, input);
+      } else {
+        await createMiraiStance(billId, input);
+      }
+      await invalidateBillsCache();
+      return jsonResult({ ok: true, created: existing === null, type });
+    }
+  );
+}

--- a/admin/src/features/mirai-stance/server/repositories/mirai-stance-repository.ts
+++ b/admin/src/features/mirai-stance/server/repositories/mirai-stance-repository.ts
@@ -50,6 +50,28 @@ export async function updateMiraiStance(stanceId: string, input: StanceInput) {
   }
 }
 
+/**
+ * bill_id をキーにスタンスを atomic に upsert する。
+ * mirai_stances.bill_id は UNIQUE 制約があるため、onConflict で
+ * 「あれば更新／なければ作成」を単一クエリで行い、check-then-act の競合を避ける。
+ */
+export async function upsertMiraiStance(billId: string, input: StanceInput) {
+  const supabase = createAdminClient();
+  const { error } = await supabase.from("mirai_stances").upsert(
+    {
+      bill_id: billId,
+      type: input.type,
+      comment: input.comment || null,
+      updated_at: new Date().toISOString(),
+    },
+    { onConflict: "bill_id" }
+  );
+
+  if (error) {
+    throw new Error(`Failed to upsert stance: ${error.message}`);
+  }
+}
+
 export async function deleteMiraiStance(stanceId: string) {
   const supabase = createAdminClient();
   const { error } = await supabase

--- a/tests/mcp/mirai-stance-tools.test.ts
+++ b/tests/mcp/mirai-stance-tools.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { registerMiraiStanceTools } from "../../admin/src/features/mcp/server/tools/register-mirai-stance-tools";
+import {
+  adminClient,
+  cleanupTestBill,
+  createTestBill,
+} from "../supabase/utils";
+import { createTestRegistry, type TestMcpRegistry } from "./utils";
+
+describe("MCP mirai-stance tools", () => {
+  let registry: TestMcpRegistry;
+  const billIds: string[] = [];
+
+  beforeEach(() => {
+    registry = createTestRegistry();
+    registerMiraiStanceTools(registry.asMcpServer());
+  });
+
+  afterEach(async () => {
+    // mirai_stances は bills への ON DELETE CASCADE なので bill 削除で一緒に消える
+    for (const id of billIds.splice(0)) await cleanupTestBill(id);
+  });
+
+  describe("upsert_mirai_stance", () => {
+    it("スタンスが無い議案には新規作成する（created: true）", async () => {
+      const bill = await createTestBill();
+      billIds.push(bill.id);
+
+      const result = await registry.callTool<{
+        ok: boolean;
+        created: boolean;
+        type: string;
+      }>("upsert_mirai_stance", {
+        billId: bill.id,
+        type: "for",
+        comment: "賛成コメント",
+      });
+      expect(result.ok).toBe(true);
+      expect(result.created).toBe(true);
+      expect(result.type).toBe("for");
+
+      const { data } = await adminClient
+        .from("mirai_stances")
+        .select("type, comment")
+        .eq("bill_id", bill.id)
+        .single();
+      expect(data?.type).toBe("for");
+      expect(data?.comment).toBe("賛成コメント");
+    });
+
+    it("既存スタンスがあれば type / comment を更新する（created: false、行IDは同一）", async () => {
+      const bill = await createTestBill();
+      billIds.push(bill.id);
+
+      await registry.callTool("upsert_mirai_stance", {
+        billId: bill.id,
+        type: "for",
+        comment: "最初のコメント",
+      });
+      const { data: before } = await adminClient
+        .from("mirai_stances")
+        .select("id")
+        .eq("bill_id", bill.id)
+        .single();
+
+      const result = await registry.callTool<{
+        created: boolean;
+        type: string;
+      }>("upsert_mirai_stance", {
+        billId: bill.id,
+        type: "against",
+        comment: "変更後のコメント",
+      });
+      expect(result.created).toBe(false);
+      expect(result.type).toBe("against");
+
+      const { data: after } = await adminClient
+        .from("mirai_stances")
+        .select("id, type, comment")
+        .eq("bill_id", bill.id)
+        .single();
+      // UNIQUE(bill_id) なので行は増えず、同じ行が更新される
+      expect(after?.id).toBe(before?.id);
+      expect(after?.type).toBe("against");
+      expect(after?.comment).toBe("変更後のコメント");
+    });
+
+    it("comment を省略すると null で保存する", async () => {
+      const bill = await createTestBill();
+      billIds.push(bill.id);
+
+      await registry.callTool("upsert_mirai_stance", {
+        billId: bill.id,
+        type: "neutral",
+      });
+
+      const { data } = await adminClient
+        .from("mirai_stances")
+        .select("comment")
+        .eq("bill_id", bill.id)
+        .single();
+      expect(data?.comment).toBeNull();
+    });
+  });
+
+  it("登録されているツール名が想定通り", () => {
+    expect(registry.toolNames().sort()).toEqual(["upsert_mirai_stance"]);
+  });
+});


### PR DESCRIPTION
## 概要

みらい議会 admin の MCP サーバーに、議案に対する**チームみらいの賛否スタンス**（`mirai_stances`）を upsert する `upsert_mirai_stance` ツールを追加します。

## 背景

衆議院サイトの「議案審議経過情報」ページには `衆議院審議時賛成会派 / 反対会派`（参議院側も同様）が記載されており、ここに「チームみらい」が含まれるかで賛否を判定できます。これを **Slack bot が承認フロー（古川さんのみ承認可）付きでみらい議会へ反映する** 機能を計画しており、その前提として「MCP から賛否を書き込む口」が必要でした。

現状の admin MCP には `mirai_stances` を更新するツールが無く（管理画面は server action 経由）、この PR でその口を追加します。DB モデル・enum・公開表示（`MiraiStanceCard`）は既存のものをそのまま利用します。

## 変更内容

- `admin/src/features/mcp/server/tools/register-mirai-stance-tools.ts` を新規追加
  - `upsert_mirai_stance(billId, type, comment?)`
  - 既存 `mirai-stance-repository`（`findStanceByBillId` / `createMiraiStance` / `updateMiraiStance`）を再利用し、`bill_id` に紐づくスタンスがあれば更新、なければ新規作成（1議案1件、`bill_id` は UNIQUE）
  - `type` は `stanceInputSchema` の enum（`for` / `against` / `neutral` / `conditional_for` / `conditional_against` / `considering` / `continued_deliberation`）
  - 既存 bills ツールと同様に `invalidateBillsCache()` を呼ぶ
- `create-handler.ts` に `registerMiraiStanceTools` を登録
- `tests/mcp/mirai-stance-tools.test.ts` を追加（新規作成 / 更新で行ID不変 / comment 省略時 null / ツール名）

## 動作確認

- `pnpm --filter admin typecheck` ✅
- `biome check`（format + lint）✅
- MCP 統合テスト（ローカル Supabase） `tests/mcp/mirai-stance-tools.test.ts` 4件 pass ✅
- ※ `topic-analysis-tools.test.ts` はローカルの GCP 環境変数未設定による**既存の failure**で、本 PR の変更（stashしても再現）とは無関係です

## 次のステップ（別 PR / 別リポジトリ）

1. mirai-gikai-content 側: 議案審議経過情報ページから チームみらいの賛否（`for` / `against`）を抽出
2. slack-bot 側: 既存の速報版/正式版リリースと同型の承認ボタンフロー（古川さんのみの strict allowlist）で本ツールを呼ぶ

🤖 by Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * MCPサーバーにMirai stance関連ツールを追加し、利用できるようになりました。
  * billId（UUID）と type／comment を指定して、スタンスを新規作成または更新できます。
  * 更新後は関連する議案情報のキャッシュが最新状態に反映されます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->