### PR TITLE
admin: MCPに get_mirai_stance ツールを追加

### DIFF
--- a/admin/src/features/mcp/server/tools/register-mirai-stance-tools.ts
+++ b/admin/src/features/mcp/server/tools/register-mirai-stance-tools.ts
@@ -12,6 +12,25 @@ import { jsonResult } from "../utils/json-result";
 
 export function registerMiraiStanceTools(server: McpServer): void {
   server.registerTool(
+    "get_mirai_stance",
+    {
+      title: "チームみらいの賛否を取得",
+      description:
+        "指定議案に対するチームみらいの賛否スタンス(mirai_stances)を返す。未設定なら stance=null。差分反映（既に同じ賛否が設定済みなら再提案・再反映しない）の判定に使う。",
+      inputSchema: {
+        billId: z.string().uuid(),
+      },
+    },
+    async ({ billId }) => {
+      const stance = await findStanceByBillId(billId);
+      return jsonResult({
+        billId,
+        stance: stance ? { type: stance.type, comment: stance.comment } : null,
+      });
+    }
+  );
+
+  server.registerTool(
     "upsert_mirai_stance",
     {
       title: "チームみらいの賛否を設定",

--- a/tests/mcp/mirai-stance-tools.test.ts
+++ b/tests/mcp/mirai-stance-tools.test.ts
@@ -103,7 +103,39 @@ describe("MCP mirai-stance tools", () => {
     });
   });
 
+  describe("get_mirai_stance", () => {
+    it("スタンス未設定の議案は stance=null を返す", async () => {
+      const bill = await createTestBill();
+      billIds.push(bill.id);
+
+      const result = await registry.callTool<{
+        billId: string;
+        stance: { type: string; comment: string | null } | null;
+      }>("get_mirai_stance", { billId: bill.id });
+      expect(result.billId).toBe(bill.id);
+      expect(result.stance).toBeNull();
+    });
+
+    it("設定済みの議案は type / comment を返す", async () => {
+      const bill = await createTestBill();
+      billIds.push(bill.id);
+      await registry.callTool("upsert_mirai_stance", {
+        billId: bill.id,
+        type: "against",
+        comment: "反対の理由",
+      });
+
+      const result = await registry.callTool<{
+        stance: { type: string; comment: string | null } | null;
+      }>("get_mirai_stance", { billId: bill.id });
+      expect(result.stance).toEqual({ type: "against", comment: "反対の理由" });
+    });
+  });
+
   it("登録されているツール名が想定通り", () => {
-    expect(registry.toolNames().sort()).toEqual(["upsert_mirai_stance"]);
+    expect(registry.toolNames().sort()).toEqual([
+      "get_mirai_stance",
+      "upsert_mirai_stance",
+    ]);
   });
 });


### PR DESCRIPTION
## 概要
admin MCP に、議案に対するチームみらいの賛否(`mirai_stances`)を**読む** `get_mirai_stance` ツールを追加します。`upsert_mirai_stance`（#890）と対になる read ツールです。

## 背景
みらい議会の賛否を半自動反映する仕組み（`check-bill-stances` / Slack 承認フロー）で、検出のたびに **既に同じ賛否が設定済みの議案まで再提案・再反映**してしまい、Slack に大量の承認メッセージが出る問題がありました。差分反映（設定済みと同じならスキップ）を実現するには「現在の賛否を読む」手段が必要なため追加します。

## 変更
- `register-mirai-stance-tools.ts`: `get_mirai_stance(billId)` を追加。既存 `findStanceByBillId` を使い、`{ billId, stance: { type, comment } | null }` を返す（未設定なら `stance: null`）。
- `tests/mcp/mirai-stance-tools.test.ts`: 未設定→null / 設定済み→{type,comment} の2ケース追加。ツール名テストも更新。

## 動作確認
- `admin` `tsc --noEmit` 0 エラー
- `biome check`（変更ファイル）0 エラー
- MCP 統合テスト（ローカル Supabase）: **6 pass**（upsert 3 + get 2 + tool 名 1）

## 次のステップ
デプロイ後、`check-bill-stances` スキルがこのツールで現在の賛否を読み、検出した for/against と一致する議案は提案をスキップする（差分反映）よう更新します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)