### PR TITLE
本番デプロイ 07/01 23:24

### DIFF
--- a/admin/src/features/mcp/server/tools/register-mirai-stance-tools.ts
+++ b/admin/src/features/mcp/server/tools/register-mirai-stance-tools.ts
@@ -12,6 +12,25 @@ import { jsonResult } from "../utils/json-result";
 
 export function registerMiraiStanceTools(server: McpServer): void {
   server.registerTool(
+    "get_mirai_stance",
+    {
+      title: "チームみらいの賛否を取得",
+      description:
+        "指定議案に対するチームみらいの賛否スタンス(mirai_stances)を返す。未設定なら stance=null。差分反映（既に同じ賛否が設定済みなら再提案・再反映しない）の判定に使う。",
+      inputSchema: {
+        billId: z.string().uuid(),
+      },
+    },
+    async ({ billId }) => {
+      const stance = await findStanceByBillId(billId);
+      return jsonResult({
+        billId,
+        stance: stance ? { type: stance.type, comment: stance.comment } : null,
+      });
+    }
+  );
+
+  server.registerTool(
     "upsert_mirai_stance",
     {
       title: "チームみらいの賛否を設定",

--- a/tests/mcp/mirai-stance-tools.test.ts
+++ b/tests/mcp/mirai-stance-tools.test.ts
@@ -103,7 +103,39 @@ describe("MCP mirai-stance tools", () => {
     });
   });
 
+  describe("get_mirai_stance", () => {
+    it("スタンス未設定の議案は stance=null を返す", async () => {
+      const bill = await createTestBill();
+      billIds.push(bill.id);
+
+      const result = await registry.callTool<{
+        billId: string;
+        stance: { type: string; comment: string | null } | null;
+      }>("get_mirai_stance", { billId: bill.id });
+      expect(result.billId).toBe(bill.id);
+      expect(result.stance).toBeNull();
+    });
+
+    it("設定済みの議案は type / comment を返す", async () => {
+      const bill = await createTestBill();
+      billIds.push(bill.id);
+      await registry.callTool("upsert_mirai_stance", {
+        billId: bill.id,
+        type: "against",
+        comment: "反対の理由",
+      });
+
+      const result = await registry.callTool<{
+        stance: { type: string; comment: string | null } | null;
+      }>("get_mirai_stance", { billId: bill.id });
+      expect(result.stance).toEqual({ type: "against", comment: "反対の理由" });
+    });
+  });
+
   it("登録されているツール名が想定通り", () => {
-    expect(registry.toolNames().sort()).toEqual(["upsert_mirai_stance"]);
+    expect(registry.toolNames().sort()).toEqual([
+      "get_mirai_stance",
+      "upsert_mirai_stance",
+    ]);
   });
 });


### PR DESCRIPTION
指定議案のチームみらいの賛否(mirai_stances)を返す read ツール。未設定なら stance=null。 差分反映（既に同じ賛否が設定済みなら再提案・再反映しない）の判定に使う。既存の
findStanceByBillId を再利用。upsert_mirai_stance と対の read として統合テストを追加。