### PR TITLE
fix(deploy): supabase db push を --yes で非対話化（CIハング解消）

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,10 +26,13 @@ jobs:
           SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
 
       # マイグレーション適用（idempotent）
+      # --yes: CI(非TTY)で確認プロンプト待ちハングを防ぐ（prod に未適用マイグレーションが
+      # あると supabase db push が [Y/n] を出して stdin 待ちで停止するため。実際に本番デプロイが
+      # db push で数時間ハングした）
       - name: Supabase db push
         run: |
-          supabase db push --include-all
-          supabase config push
+          supabase db push --include-all --yes
+          supabase config push --yes
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
           SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID: ${{ secrets.SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID }}


### PR DESCRIPTION
## 概要
`Migrate DB then Deploy`（deploy.yml）の `supabase db push` に `--yes` を付け、CI での確認プロンプト待ちハングを解消します。`supabase config push` にも付与。

## 事象
- 本番（main）デプロイ run が **`Supabase db push` で約5時間ハング**（`e004d332`）。後続の新デプロイ（`bb79fb92`、#892含む）も同ステップで停止し、**Vercel Deploy Hook が発火せず本番が更新されない**状態に（prod admin が古いまま=stanceツール未反映）。
- 原因: `supabase db push --include-all` は **prod に未適用マイグレーションがあると確認プロンプト `[Y/n]` を出す**。CI は非TTYで stdin 待ちのまま永久停止する。staging は既に適用済みでプロンプトが出ず1分で完了していたため、prod だけで顕在化した。

## 修正
- `supabase db push --include-all --yes`（`--yes` = "Answer yes to all prompts." CLI help で確認済み）
- `supabase config push --yes`（同様に念のため）

## 反映の流れ / 注意
- deploy.yml は `main` / `develop` 両方の push で走る。**本fixが main に届いた時点の main push run から**非対話で通る（GH Actions は push されたコミットの workflow を使うため、fix を含む develop→main マージの run が新workflowで実行される）。
- **`--yes` で自動確認になるため、次の本番デプロイは prod に溜まっていた未適用マイグレーションを一括適用する**（本パイプライン本来の意図どおり）。件数が多い場合は把握のうえマージを。

## 対応済み
- ハング中の run 2本（`28508177659` 5h / `28524729870`）は cancel 済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)