### PR TITLE
本番デプロイ 07/01 23:51

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,10 +26,13 @@ jobs:
           SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
 
       # マイグレーション適用（idempotent）
+      # --yes: CI(非TTY)で確認プロンプト待ちハングを防ぐ（prod に未適用マイグレーションが
+      # あると supabase db push が [Y/n] を出して stdin 待ちで停止するため。実際に本番デプロイが
+      # db push で数時間ハングした）
       - name: Supabase db push
         run: |
-          supabase db push --include-all
-          supabase config push
+          supabase db push --include-all --yes
+          supabase config push --yes
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
           SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID: ${{ secrets.SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID }}


### PR DESCRIPTION
prod に未適用マイグレーションがあると supabase db push が確認プロンプト([Y/n])を出し、 CI(非TTY)では stdin 待ちのまま停止する（実際に本番デプロイが db push で約5時間ハングし、 後続の Vercel Deploy Hook が発火せず本番が更新されなかった）。--yes で自動確認する。 config push にも同フラグを付与。