### PR TITLE
fix: db:types:genにおいて確認プロンプトがファイルに出力される問題を修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "db:types:gen": "npx supabase gen types typescript --local > packages/supabase/types/supabase.types.ts",
+    "db:types:gen": "npx --yes supabase gen types typescript --local > packages/supabase/types/supabase.types.ts",
     "db:migrate": "npx supabase migration up --include-all && pnpm run db:types:gen",
     "db:reset": "dotenv -e .env -- npx supabase db reset && pnpm db:types:gen && pnpm seed",
     "dev": "dotenv -e .env -- pnpm -r --stream --parallel run dev",


### PR DESCRIPTION
## Overview

`db:types:gen`において、supabase cliをインストールするかどうかの確認プロンプトが出力される。 しかし、出力は.tsファイルに入るため、yesも打てず失敗する(ファイルが壊れる)問題を修正。