### PR TITLE
admin: インタビューレポートにユーザー発言の検索ページを追加

### DIFF
--- a/admin/src/app/(protected)/bills/[id]/interview/[configId]/reports/[sessionId]/page.tsx
+++ b/admin/src/app/(protected)/bills/[id]/interview/[configId]/reports/[sessionId]/page.tsx
@@ -14,12 +14,18 @@ interface ReportDetailPageProps {
     configId: string;
     sessionId: string;
   }>;
+  searchParams: Promise<{
+    highlight?: string;
+  }>;
 }
 
 export default async function ReportDetailPage({
   params,
+  searchParams,
 }: ReportDetailPageProps) {
   const { id, configId, sessionId } = await params;
+  const { highlight } = await searchParams;
+  const highlightQuery = (highlight ?? "").trim();
   const [bill, session] = await Promise.all([
     getBillById(id),
     getInterviewSessionDetail(sessionId),
@@ -52,7 +58,11 @@ export default async function ReportDetailPage({
         </p>
       </div>
 
-      <SessionDetail session={session} billId={id} />
+      <SessionDetail
+        session={session}
+        billId={id}
+        highlightQuery={highlightQuery}
+      />
     </div>
   );
 }

--- a/admin/src/app/(protected)/bills/[id]/interview/[configId]/reports/page.tsx
+++ b/admin/src/app/(protected)/bills/[id]/interview/[configId]/reports/page.tsx
@@ -1,8 +1,9 @@
-import { ArrowLeft } from "lucide-react";
+import { ArrowLeft, Search } from "lucide-react";
 import type { Route } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
+import { Button } from "@/components/ui/button";
 import { getBillById } from "@/features/bills-edit/server/loaders/get-bill-by-id";
 import { BatchModerationButton } from "@/features/interview-reports/client/components/batch-moderation-button";
 import { BatchPublishButton } from "@/features/interview-reports/client/components/batch-publish-button";
@@ -83,6 +84,12 @@ export default async function ReportsPage({
           <p className="text-gray-600 mt-1">議案「{bill.name}」のレポート</p>
         </div>
         <div className="flex items-center gap-2">
+          <Button asChild variant="outline">
+            <Link href={routes.billReportsSearch(id, configId) as Route}>
+              <Search className="h-4 w-4" />
+              発言検索
+            </Link>
+          </Button>
           <CopyTsvButton billId={id} configId={configId} />
           <BatchPublishButton billId={id} configId={configId} />
           <BatchModerationButton />

--- a/admin/src/app/(protected)/bills/[id]/interview/[configId]/reports/search/page.tsx
+++ b/admin/src/app/(protected)/bills/[id]/interview/[configId]/reports/search/page.tsx
@@ -1,0 +1,79 @@
+import { ArrowLeft } from "lucide-react";
+import type { Route } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import { getBillById } from "@/features/bills-edit/server/loaders/get-bill-by-id";
+import { MessageSearchForm } from "@/features/interview-reports/client/components/message-search-form";
+import { MessageSearchResults } from "@/features/interview-reports/server/components/message-search-results";
+import { searchUserMessages } from "@/features/interview-reports/server/loaders/search-user-messages";
+import { routes } from "@/lib/routes";
+
+interface ReportsSearchPageProps {
+  params: Promise<{
+    id: string;
+    configId: string;
+  }>;
+  searchParams: Promise<{
+    q?: string;
+    page?: string;
+  }>;
+}
+
+export default async function ReportsSearchPage({
+  params,
+  searchParams,
+}: ReportsSearchPageProps) {
+  const { id, configId } = await params;
+  const { q, page } = await searchParams;
+  const query = (q ?? "").trim();
+  const currentPage = Math.max(1, Number(page) || 1);
+
+  const [bill, result] = await Promise.all([
+    getBillById(id),
+    query ? searchUserMessages(configId, query, currentPage) : null,
+  ]);
+
+  if (!bill) {
+    notFound();
+  }
+
+  return (
+    <div>
+      <div className="mb-6">
+        <Link
+          href={routes.billReports(id, configId) as Route}
+          className="inline-flex items-center gap-2 text-sm text-gray-600 hover:text-gray-900"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          レポート一覧に戻る
+        </Link>
+      </div>
+
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-gray-900">発言検索</h1>
+        <p className="text-gray-600 mt-1">
+          議案「{bill.name}」のインタビューでのユーザー発言を検索
+        </p>
+      </div>
+
+      <div className="mb-6">
+        <MessageSearchForm initialQuery={query} />
+      </div>
+
+      {result ? (
+        <MessageSearchResults
+          billId={id}
+          configId={configId}
+          query={query}
+          result={result}
+          currentPage={currentPage}
+        />
+      ) : (
+        <div className="rounded-lg border p-8 text-center text-gray-500">
+          キーワードを入力して検索してください
+        </div>
+      )}
+    </div>
+  );
+}

--- a/admin/src/features/interview-reports/client/components/message-search-form.tsx
+++ b/admin/src/features/interview-reports/client/components/message-search-form.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { Search } from "lucide-react";
+import type { Route } from "next";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+interface MessageSearchFormProps {
+  initialQuery: string;
+}
+
+export function MessageSearchForm({ initialQuery }: MessageSearchFormProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const [query, setQuery] = useState(initialQuery);
+
+  function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const params = new URLSearchParams(searchParams.toString());
+    const trimmed = query.trim();
+
+    if (trimmed) {
+      params.set("q", trimmed);
+    } else {
+      params.delete("q");
+    }
+
+    // 検索条件変更時はページを1にリセット
+    params.delete("page");
+
+    router.push(`${pathname}?${params.toString()}` as Route);
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex items-center gap-2">
+      <Input
+        value={query}
+        onChange={(event) => setQuery(event.target.value)}
+        placeholder="ユーザーの発言を検索"
+        aria-label="発言検索キーワード"
+        className="max-w-md"
+      />
+      <Button type="submit">
+        <Search className="h-4 w-4" />
+        検索
+      </Button>
+    </form>
+  );
+}

--- a/admin/src/features/interview-reports/server/components/highlighted-text.tsx
+++ b/admin/src/features/interview-reports/server/components/highlighted-text.tsx
@@ -1,0 +1,31 @@
+import { splitTextByQuery } from "../../shared/utils/split-text-by-query";
+
+interface HighlightedTextProps {
+  text: string;
+  query: string;
+}
+
+/**
+ * テキスト内の検索語一致箇所を <mark> でハイライト表示する。
+ */
+export function HighlightedText({ text, query }: HighlightedTextProps) {
+  const segments = splitTextByQuery(text, query);
+
+  // key には各セグメントのテキスト先頭位置（文字オフセット）を使う
+  let offset = 0;
+  return (
+    <>
+      {segments.map((segment) => {
+        const key = offset;
+        offset += segment.text.length;
+        return segment.isMatch ? (
+          <mark key={key} className="bg-yellow-200 rounded-sm px-0.5">
+            {segment.text}
+          </mark>
+        ) : (
+          <span key={key}>{segment.text}</span>
+        );
+      })}
+    </>
+  );
+}

--- a/admin/src/features/interview-reports/server/components/message-search-results.tsx
+++ b/admin/src/features/interview-reports/server/components/message-search-results.tsx
@@ -1,0 +1,170 @@
+import { Clock, MessageCircle } from "lucide-react";
+import type { Route } from "next";
+import Link from "next/link";
+import { Card, CardContent } from "@/components/ui/card";
+import { routes } from "@/lib/routes";
+import type { MessageSearchSession } from "../../shared/types";
+import { buildSnippet } from "../../shared/utils/build-snippet";
+import { formatJstDateTime } from "../../shared/utils/format-jst-date-time";
+import type { MessageSearchResult } from "../loaders/search-user-messages";
+import { SEARCH_SESSIONS_PER_PAGE } from "../loaders/search-user-messages";
+import { HighlightedText } from "./highlighted-text";
+import { PaginationNav } from "./pagination-nav";
+import { StanceBadge } from "./stance-badge";
+import { VisibilityBadge } from "./visibility-badge";
+
+const MAX_SNIPPETS_PER_SESSION = 3;
+
+interface MessageSearchResultsProps {
+  billId: string;
+  configId: string;
+  query: string;
+  result: MessageSearchResult;
+  currentPage: number;
+}
+
+function buildSearchPageUrl(
+  billId: string,
+  configId: string,
+  query: string,
+  page: number
+): Route {
+  const params = new URLSearchParams();
+  params.set("q", query);
+  if (page > 1) {
+    params.set("page", String(page));
+  }
+  return `${routes.billReportsSearch(billId, configId)}?${params.toString()}` as Route;
+}
+
+function buildDetailUrl(
+  billId: string,
+  configId: string,
+  sessionId: string,
+  query: string
+): Route {
+  const params = new URLSearchParams();
+  params.set("highlight", query);
+  return `${routes.billReportDetail(billId, configId, sessionId)}?${params.toString()}` as Route;
+}
+
+function SessionResultCard({
+  billId,
+  configId,
+  query,
+  session,
+}: {
+  billId: string;
+  configId: string;
+  query: string;
+  session: MessageSearchSession;
+}) {
+  const visibleMessages = session.matched_messages.slice(
+    0,
+    MAX_SNIPPETS_PER_SESSION
+  );
+  const hiddenCount = session.matched_messages.length - visibleMessages.length;
+  const report = session.interview_report;
+
+  return (
+    <Card>
+      <CardContent className="pt-6">
+        <div className="flex flex-wrap items-center gap-3 mb-3">
+          <Link
+            href={buildDetailUrl(billId, configId, session.id, query)}
+            className="font-mono text-sm text-blue-600 hover:underline"
+          >
+            {session.id.substring(0, 8)}...
+          </Link>
+          <StanceBadge stance={report?.stance || null} />
+          {report && (
+            <VisibilityBadge isPublic={report.is_public_by_admin ?? false} />
+          )}
+          {report?.role_title && (
+            <span className="text-sm text-gray-600">{report.role_title}</span>
+          )}
+          <span className="inline-flex items-center gap-1 text-sm text-gray-500">
+            <Clock className="h-4 w-4" />
+            {formatJstDateTime(session.started_at)}
+          </span>
+        </div>
+
+        <div className="space-y-2">
+          {visibleMessages.map((message) => (
+            <div
+              key={message.id}
+              className="flex items-start gap-2 rounded-lg bg-gray-50 px-3 py-2 text-sm text-gray-800"
+            >
+              <MessageCircle className="h-4 w-4 mt-0.5 shrink-0 text-gray-400" />
+              <span>
+                <HighlightedText
+                  text={buildSnippet(message.content, query)}
+                  query={query}
+                />
+              </span>
+            </div>
+          ))}
+        </div>
+
+        {hiddenCount > 0 && (
+          <div className="mt-2 text-sm text-gray-500">
+            他 {hiddenCount} 件の発言がヒット
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export function MessageSearchResults({
+  billId,
+  configId,
+  query,
+  result,
+  currentPage,
+}: MessageSearchResultsProps) {
+  const { sessions, totalSessionCount, matchedMessageCount, isTruncated } =
+    result;
+  const totalPages = Math.ceil(totalSessionCount / SEARCH_SESSIONS_PER_PAGE);
+
+  if (totalSessionCount === 0) {
+    return (
+      <div className="rounded-lg border p-8 text-center text-gray-500">
+        「{query}」に一致する発言はありません
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="mb-4 text-sm text-gray-600">
+        {totalSessionCount} セッション / {matchedMessageCount} 件の発言がヒット
+        {isTruncated && (
+          <span className="ml-2 text-amber-600">
+            （結果が多いため最新 {matchedMessageCount}
+            件の発言のみを対象にしています。キーワードを絞り込んでください）
+          </span>
+        )}
+      </div>
+
+      <div className="space-y-4">
+        {sessions.map((session) => (
+          <SessionResultCard
+            key={session.id}
+            billId={billId}
+            configId={configId}
+            query={query}
+            session={session}
+          />
+        ))}
+      </div>
+
+      <PaginationNav
+        className="mt-6"
+        totalPages={totalPages}
+        currentPage={currentPage}
+        buildHref={(page) => buildSearchPageUrl(billId, configId, query, page)}
+      />
+    </div>
+  );
+}

--- a/admin/src/features/interview-reports/server/components/pagination-nav.tsx
+++ b/admin/src/features/interview-reports/server/components/pagination-nav.tsx
@@ -1,0 +1,93 @@
+import type { Route } from "next";
+import {
+  Pagination,
+  PaginationContent,
+  PaginationEllipsis,
+  PaginationFirst,
+  PaginationItem,
+  PaginationLast,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from "@/components/ui/pagination";
+import { generatePageNumbers } from "../../shared/utils/pagination-utils";
+
+interface PaginationNavProps {
+  totalPages: number;
+  currentPage: number;
+  buildHref: (page: number) => Route;
+  className?: string;
+}
+
+/**
+ * ページ番号リンク付きのページネーションナビゲーション。
+ * totalPages が 1 以下の場合は何も表示しない。
+ */
+export function PaginationNav({
+  totalPages,
+  currentPage,
+  buildHref,
+  className,
+}: PaginationNavProps) {
+  if (totalPages <= 1) return null;
+
+  const prevDisabledClass =
+    currentPage <= 1 ? "pointer-events-none opacity-50" : "";
+  const nextDisabledClass =
+    currentPage >= totalPages ? "pointer-events-none opacity-50" : "";
+
+  return (
+    <Pagination className={className}>
+      <PaginationContent>
+        <PaginationItem>
+          <PaginationFirst
+            href={buildHref(1)}
+            aria-disabled={currentPage <= 1}
+            className={prevDisabledClass}
+          />
+        </PaginationItem>
+
+        <PaginationItem>
+          <PaginationPrevious
+            href={buildHref(Math.max(1, currentPage - 1))}
+            aria-disabled={currentPage <= 1}
+            className={prevDisabledClass}
+          />
+        </PaginationItem>
+
+        {generatePageNumbers(totalPages, currentPage).map((page) =>
+          typeof page === "string" ? (
+            <PaginationItem key={page}>
+              <PaginationEllipsis />
+            </PaginationItem>
+          ) : (
+            <PaginationItem key={page}>
+              <PaginationLink
+                href={buildHref(page)}
+                isActive={page === currentPage}
+              >
+                {page}
+              </PaginationLink>
+            </PaginationItem>
+          )
+        )}
+
+        <PaginationItem>
+          <PaginationNext
+            href={buildHref(Math.min(totalPages, currentPage + 1))}
+            aria-disabled={currentPage >= totalPages}
+            className={nextDisabledClass}
+          />
+        </PaginationItem>
+
+        <PaginationItem>
+          <PaginationLast
+            href={buildHref(totalPages)}
+            aria-disabled={currentPage >= totalPages}
+            className={nextDisabledClass}
+          />
+        </PaginationItem>
+      </PaginationContent>
+    </Pagination>
+  );
+}

--- a/admin/src/features/interview-reports/server/components/session-detail.tsx
+++ b/admin/src/features/interview-reports/server/components/session-detail.tsx
@@ -11,6 +11,7 @@ import type { InterviewSessionDetail } from "../../shared/types";
 import { formatDuration, getSessionStatus } from "../../shared/types";
 import { getMessageDisplayText } from "../../shared/utils/get-message-display-text";
 import { parseOpinions } from "../../shared/utils/parse-opinions";
+import { HighlightedText } from "./highlighted-text";
 import { ModerationBadge } from "./moderation-badge";
 import { RatingStars } from "./rating-stars";
 import { SessionStatusBadge } from "./session-status-badge";
@@ -19,6 +20,7 @@ import { StanceBadge } from "./stance-badge";
 interface SessionDetailProps {
   session: InterviewSessionDetail;
   billId: string;
+  highlightQuery?: string;
 }
 
 const contentRichnessLabels: Record<string, string> = {
@@ -50,7 +52,11 @@ function ContentRichnessBar({
   );
 }
 
-export function SessionDetail({ session, billId }: SessionDetailProps) {
+export function SessionDetail({
+  session,
+  billId,
+  highlightQuery = "",
+}: SessionDetailProps) {
   const status = getSessionStatus(session);
   const duration = formatDuration(session.started_at, session.completed_at);
   const report = session.interview_report;
@@ -384,7 +390,14 @@ export function SessionDetail({ session, billId }: SessionDetailProps) {
                             : "bg-gray-100 text-gray-800 rounded-tr-sm"
                         }`}
                       >
-                        {getMessageDisplayText(message.content)}
+                        {highlightQuery ? (
+                          <HighlightedText
+                            text={getMessageDisplayText(message.content)}
+                            query={highlightQuery}
+                          />
+                        ) : (
+                          getMessageDisplayText(message.content)
+                        )}
                       </div>
                       <div className="text-xs text-gray-400 mt-1 px-1">
                         {new Date(message.created_at).toLocaleString("ja-JP", {

--- a/admin/src/features/interview-reports/server/components/session-list.tsx
+++ b/admin/src/features/interview-reports/server/components/session-list.tsx
@@ -1,17 +1,6 @@
 import { CheckCircle2, Clock, Lightbulb, XCircle } from "lucide-react";
 import type { Route } from "next";
 import Link from "next/link";
-import {
-  Pagination,
-  PaginationContent,
-  PaginationEllipsis,
-  PaginationFirst,
-  PaginationItem,
-  PaginationLast,
-  PaginationLink,
-  PaginationNext,
-  PaginationPrevious,
-} from "@/components/ui/pagination";
 import { SortableTableHead } from "@/components/ui/sortable-table-head";
 import {
   Table,
@@ -35,9 +24,10 @@ import {
   formatDuration,
   getSessionStatus,
 } from "../../shared/types";
-import { generatePageNumbers } from "../../shared/utils/pagination-utils";
+import { formatJstDateTime } from "../../shared/utils/format-jst-date-time";
 import { SESSIONS_PER_PAGE } from "../loaders/get-interview-sessions";
 import { ModerationBadge } from "./moderation-badge";
+import { PaginationNav } from "./pagination-nav";
 import { RatingStars } from "./rating-stars";
 import { SessionStatusBadge } from "./session-status-badge";
 import { StanceBadge } from "./stance-badge";
@@ -267,14 +257,7 @@ export function SessionList({
                     <TableCell className="text-gray-600">
                       <div className="flex items-center gap-1">
                         <Clock className="h-4 w-4" />
-                        {new Date(session.started_at).toLocaleString("ja-JP", {
-                          year: "numeric",
-                          month: "2-digit",
-                          day: "2-digit",
-                          hour: "2-digit",
-                          minute: "2-digit",
-                          timeZone: "Asia/Tokyo",
-                        })}
+                        {formatJstDateTime(session.started_at)}
                       </div>
                     </TableCell>
                     <TableCell className="text-gray-600">{duration}</TableCell>
@@ -305,84 +288,14 @@ export function SessionList({
       )}
 
       {/* ページネーション */}
-      {totalPages > 1 && (
-        <Pagination className="mt-4">
-          <PaginationContent>
-            <PaginationItem>
-              <PaginationFirst
-                href={buildPageUrl(billId, configId, 1, sort, filters)}
-                aria-disabled={currentPage <= 1}
-                className={
-                  currentPage <= 1 ? "pointer-events-none opacity-50" : ""
-                }
-              />
-            </PaginationItem>
-
-            <PaginationItem>
-              <PaginationPrevious
-                href={buildPageUrl(
-                  billId,
-                  configId,
-                  currentPage > 1 ? currentPage - 1 : 1,
-                  sort,
-                  filters
-                )}
-                aria-disabled={currentPage <= 1}
-                className={
-                  currentPage <= 1 ? "pointer-events-none opacity-50" : ""
-                }
-              />
-            </PaginationItem>
-
-            {generatePageNumbers(totalPages, currentPage).map((page) =>
-              typeof page === "string" ? (
-                <PaginationItem key={page}>
-                  <PaginationEllipsis />
-                </PaginationItem>
-              ) : (
-                <PaginationItem key={page}>
-                  <PaginationLink
-                    href={buildPageUrl(billId, configId, page, sort, filters)}
-                    isActive={page === currentPage}
-                  >
-                    {page}
-                  </PaginationLink>
-                </PaginationItem>
-              )
-            )}
-
-            <PaginationItem>
-              <PaginationNext
-                href={buildPageUrl(
-                  billId,
-                  configId,
-                  currentPage < totalPages ? currentPage + 1 : totalPages,
-                  sort,
-                  filters
-                )}
-                aria-disabled={currentPage >= totalPages}
-                className={
-                  currentPage >= totalPages
-                    ? "pointer-events-none opacity-50"
-                    : ""
-                }
-              />
-            </PaginationItem>
-
-            <PaginationItem>
-              <PaginationLast
-                href={buildPageUrl(billId, configId, totalPages, sort, filters)}
-                aria-disabled={currentPage >= totalPages}
-                className={
-                  currentPage >= totalPages
-                    ? "pointer-events-none opacity-50"
-                    : ""
-                }
-              />
-            </PaginationItem>
-          </PaginationContent>
-        </Pagination>
-      )}
+      <PaginationNav
+        className="mt-4"
+        totalPages={totalPages}
+        currentPage={currentPage}
+        buildHref={(page) =>
+          buildPageUrl(billId, configId, page, sort, filters)
+        }
+      />
     </div>
   );
 }

--- a/admin/src/features/interview-reports/server/loaders/get-interview-sessions-for-tsv.ts
+++ b/admin/src/features/interview-reports/server/loaders/get-interview-sessions-for-tsv.ts
@@ -7,6 +7,7 @@ import type {
   InterviewSession,
 } from "../../shared/types";
 import type { InterviewSessionForTsv } from "../../shared/utils/build-interview-tsv";
+import { normalizeInterviewReport } from "../../shared/utils/normalize-interview-report";
 
 const PAGE_SIZE = 1000;
 
@@ -86,16 +87,9 @@ export async function getInterviewSessionsForTsv(
     }
   }
 
-  return sessions.map((session) => {
-    // 1:1 リレーションでも Supabase の生成型では配列で返るケースがあるため正規化
-    const reportRelation = session.interview_report;
-    const report = Array.isArray(reportRelation)
-      ? (reportRelation[0] ?? null)
-      : reportRelation;
-    return {
-      ...session,
-      interview_report: report,
-      interview_messages: messagesBySessionId.get(session.id) ?? [],
-    };
-  });
+  return sessions.map((session) => ({
+    ...session,
+    interview_report: normalizeInterviewReport(session.interview_report),
+    interview_messages: messagesBySessionId.get(session.id) ?? [],
+  }));
 }

--- a/admin/src/features/interview-reports/server/loaders/get-interview-sessions.ts
+++ b/admin/src/features/interview-reports/server/loaders/get-interview-sessions.ts
@@ -9,6 +9,7 @@ import {
   DEFAULT_SESSION_FILTER,
   DEFAULT_SESSION_SORT,
 } from "../../shared/types";
+import { normalizeInterviewReport } from "../../shared/utils/normalize-interview-report";
 import { calculatePaginationRange } from "../../shared/utils/pagination-utils";
 import {
   countInterviewSessionsByConfigId,
@@ -86,14 +87,9 @@ export async function getInterviewSessions(
   // 全セッションのメッセージ数・リアクション数を一括取得
   const sessionIds = sessions.map((s) => s.id);
 
-  // interview_reportは配列で返ってくるので最初の要素を取得するヘルパー
-  const normalizeReport = (
-    report: (typeof sessions)[number]["interview_report"]
-  ) => (Array.isArray(report) ? report[0] || null : report);
-
   // レポートIDを収集
   const reportIds = sessions
-    .map((s) => normalizeReport(s.interview_report)?.id)
+    .map((s) => normalizeInterviewReport(s.interview_report)?.id)
     .filter((id): id is string => id != null);
 
   let messageCounts:
@@ -143,7 +139,7 @@ export async function getInterviewSessions(
   // セッションにメッセージ数・リアクション数を付与
   const sessionsWithDetails: InterviewSessionWithDetails[] = sessions.map(
     (session) => {
-      const report = normalizeReport(session.interview_report);
+      const report = normalizeInterviewReport(session.interview_report);
       const helpfulCount = report ? (helpfulCountsMap.get(report.id) ?? 0) : 0;
 
       return {

--- a/admin/src/features/interview-reports/server/loaders/search-user-messages.ts
+++ b/admin/src/features/interview-reports/server/loaders/search-user-messages.ts
@@ -1,0 +1,63 @@
+import "server-only";
+
+import type { MessageSearchSession } from "../../shared/types";
+import { groupMatchedMessagesBySession } from "../../shared/utils/group-matched-messages";
+import { normalizeInterviewReport } from "../../shared/utils/normalize-interview-report";
+import {
+  findInterviewSessionsWithReportByIds,
+  searchUserMessagesByConfigId,
+} from "../repositories/interview-report-repository";
+
+export const SEARCH_SESSIONS_PER_PAGE = 20;
+
+/**
+ * 検索対象とする一致メッセージ数の上限。
+ * これを超えた場合は最新のメッセージのみを対象とし、isTruncated で通知する。
+ */
+export const MAX_SEARCH_MESSAGES = 500;
+
+export interface MessageSearchResult {
+  sessions: MessageSearchSession[];
+  totalSessionCount: number;
+  matchedMessageCount: number;
+  isTruncated: boolean;
+}
+
+export async function searchUserMessages(
+  configId: string,
+  query: string,
+  page = 1
+): Promise<MessageSearchResult> {
+  const matchedMessages = await searchUserMessagesByConfigId(
+    configId,
+    query,
+    MAX_SEARCH_MESSAGES
+  );
+  const groups = groupMatchedMessagesBySession(matchedMessages);
+
+  const from = (page - 1) * SEARCH_SESSIONS_PER_PAGE;
+  const pageGroups = groups.slice(from, from + SEARCH_SESSIONS_PER_PAGE);
+
+  const sessions = await findInterviewSessionsWithReportByIds(
+    pageGroups.map((group) => group.sessionId)
+  );
+
+  const sessionMap = new Map(sessions.map((session) => [session.id, session]));
+  const sessionsWithMessages: MessageSearchSession[] = [];
+  for (const group of pageGroups) {
+    const session = sessionMap.get(group.sessionId);
+    if (!session) continue;
+    sessionsWithMessages.push({
+      ...session,
+      interview_report: normalizeInterviewReport(session.interview_report),
+      matched_messages: group.messages,
+    });
+  }
+
+  return {
+    sessions: sessionsWithMessages,
+    totalSessionCount: groups.length,
+    matchedMessageCount: matchedMessages.length,
+    isTruncated: matchedMessages.length >= MAX_SEARCH_MESSAGES,
+  };
+}

--- a/admin/src/features/interview-reports/server/repositories/interview-report-repository.ts
+++ b/admin/src/features/interview-reports/server/repositories/interview-report-repository.ts
@@ -1,9 +1,10 @@
 import "server-only";
 
-import { createAdminClient } from "@mirai-gikai/supabase";
 import { isReportAutoPublishEligible } from "@mirai-gikai/shared/report-publication/auto-publish";
+import { createAdminClient } from "@mirai-gikai/supabase";
 import type { SessionFilterConfig } from "../../shared/types";
 import { DEFAULT_SESSION_FILTER } from "../../shared/types";
+import { escapeIlikePattern } from "../../shared/utils/escape-ilike-pattern";
 
 function toRpcFilterParams(filters: SessionFilterConfig) {
   return {
@@ -438,6 +439,35 @@ export async function findInterviewMessagesBySessionId(sessionId: string) {
   }
 
   return data;
+}
+
+export async function searchUserMessagesByConfigId(
+  configId: string,
+  query: string,
+  limit: number
+) {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("interview_messages")
+    .select(
+      "id, interview_session_id, content, created_at, interview_sessions!inner(interview_config_id)"
+    )
+    .eq("role", "user")
+    .eq("interview_sessions.interview_config_id", configId)
+    .ilike("content", `%${escapeIlikePattern(query)}%`)
+    .order("created_at", { ascending: false })
+    .limit(limit);
+
+  if (error) {
+    throw new Error(`Failed to search user messages: ${error.message}`);
+  }
+
+  return (data || []).map((row) => ({
+    id: row.id,
+    interview_session_id: row.interview_session_id,
+    content: row.content,
+    created_at: row.created_at,
+  }));
 }
 
 export async function findReactionCountsByReportId(

--- a/admin/src/features/interview-reports/server/services/batch-moderation-scoring.ts
+++ b/admin/src/features/interview-reports/server/services/batch-moderation-scoring.ts
@@ -1,9 +1,9 @@
 import "server-only";
 
+import { buildModerationPrompt } from "@mirai-gikai/shared/moderation/build-prompt";
+import { moderationResultSchema } from "@mirai-gikai/shared/moderation/schemas";
 import { generateObject } from "ai";
 import { DEFAULT_INTERVIEW_CHAT_MODEL } from "@/lib/ai/models";
-import { moderationResultSchema } from "@mirai-gikai/shared/moderation/schemas";
-import { buildModerationPrompt } from "@mirai-gikai/shared/moderation/build-prompt";
 import { parseOpinions } from "../../shared/utils/parse-opinions";
 import {
   findInterviewMessagesBySessionId,

--- a/admin/src/features/interview-reports/server/services/content-richness-scoring.ts
+++ b/admin/src/features/interview-reports/server/services/content-richness-scoring.ts
@@ -1,9 +1,9 @@
 import "server-only";
 
+import { buildContentRichnessPrompt } from "@mirai-gikai/shared/content-richness/build-prompt";
+import { contentRichnessResultSchema } from "@mirai-gikai/shared/content-richness/schemas";
 import { generateObject } from "ai";
 import { DEFAULT_INTERVIEW_CHAT_MODEL } from "@/lib/ai/models";
-import { contentRichnessResultSchema } from "@mirai-gikai/shared/content-richness/schemas";
-import { buildContentRichnessPrompt } from "@mirai-gikai/shared/content-richness/build-prompt";
 import { parseOpinions } from "../../shared/utils/parse-opinions";
 import {
   findInterviewMessagesBySessionId,

--- a/admin/src/features/interview-reports/shared/types/index.ts
+++ b/admin/src/features/interview-reports/shared/types/index.ts
@@ -20,6 +20,23 @@ export type ReactionCounts = {
   helpful: number;
 };
 
+export interface MatchedUserMessage {
+  id: string;
+  interview_session_id: string;
+  content: string;
+  created_at: string;
+}
+
+export interface SessionMatchGroup {
+  sessionId: string;
+  messages: MatchedUserMessage[];
+}
+
+export type MessageSearchSession = InterviewSession & {
+  interview_report: InterviewReport | null;
+  matched_messages: MatchedUserMessage[];
+};
+
 export type InterviewSessionDetail = InterviewSession & {
   interview_report: InterviewReport | null;
   interview_messages: InterviewMessage[];

--- a/admin/src/features/interview-reports/shared/utils/build-snippet.test.ts
+++ b/admin/src/features/interview-reports/shared/utils/build-snippet.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { buildSnippet } from "./build-snippet";
+
+describe("buildSnippet", () => {
+  it("短いテキストは全体をそのまま返す", () => {
+    expect(buildSnippet("子育て支援に賛成です", "子育て")).toBe(
+      "子育て支援に賛成です"
+    );
+  });
+
+  it("一致箇所の前後を radius 文字で切り出し省略記号を付ける", () => {
+    const content = `${"あ".repeat(50)}子育て${"い".repeat(50)}`;
+    const snippet = buildSnippet(content, "子育て", 10);
+    expect(snippet).toBe(`…${"あ".repeat(10)}子育て${"い".repeat(10)}…`);
+  });
+
+  it("一致箇所が先頭付近の場合は前方の省略記号を付けない", () => {
+    const content = `子育て${"い".repeat(100)}`;
+    const snippet = buildSnippet(content, "子育て", 10);
+    expect(snippet).toBe(`子育て${"い".repeat(10)}…`);
+  });
+
+  it("一致箇所が末尾付近の場合は後方の省略記号を付けない", () => {
+    const content = `${"あ".repeat(100)}子育て`;
+    const snippet = buildSnippet(content, "子育て", 10);
+    expect(snippet).toBe(`…${"あ".repeat(10)}子育て`);
+  });
+
+  it("大文字小文字を区別せず一致箇所を探す", () => {
+    const content = `${"a".repeat(50)}KEYWORD${"b".repeat(50)}`;
+    const snippet = buildSnippet(content, "keyword", 5);
+    expect(snippet).toBe("…aaaaaKEYWORDbbbbb…");
+  });
+
+  it("一致しない場合は先頭から radius * 2 文字を返す", () => {
+    const content = "あ".repeat(100);
+    expect(buildSnippet(content, "子育て", 10)).toBe(`${"あ".repeat(20)}…`);
+  });
+
+  it("一致せずテキストが短い場合は全体を返す", () => {
+    expect(buildSnippet("短いテキスト", "子育て", 10)).toBe("短いテキスト");
+  });
+});

--- a/admin/src/features/interview-reports/shared/utils/build-snippet.ts
+++ b/admin/src/features/interview-reports/shared/utils/build-snippet.ts
@@ -1,0 +1,30 @@
+const DEFAULT_SNIPPET_RADIUS = 40;
+
+/**
+ * 検索語の最初の一致箇所を中心に前後 radius 文字を切り出したスニペットを作る。
+ * 切り詰めた側には省略記号を付与する。一致しない場合は先頭から radius * 2 文字を返す。
+ */
+export function buildSnippet(
+  content: string,
+  query: string,
+  radius = DEFAULT_SNIPPET_RADIUS
+): string {
+  const trimmedQuery = query.trim();
+  const matchIndex = trimmedQuery
+    ? content.toLowerCase().indexOf(trimmedQuery.toLowerCase())
+    : -1;
+
+  if (matchIndex === -1) {
+    const head = content.slice(0, radius * 2);
+    return head.length < content.length ? `${head}…` : head;
+  }
+
+  const start = Math.max(0, matchIndex - radius);
+  const end = Math.min(
+    content.length,
+    matchIndex + trimmedQuery.length + radius
+  );
+  const prefix = start > 0 ? "…" : "";
+  const suffix = end < content.length ? "…" : "";
+  return `${prefix}${content.slice(start, end)}${suffix}`;
+}

--- a/admin/src/features/interview-reports/shared/utils/escape-ilike-pattern.test.ts
+++ b/admin/src/features/interview-reports/shared/utils/escape-ilike-pattern.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { escapeIlikePattern } from "./escape-ilike-pattern";
+
+describe("escapeIlikePattern", () => {
+  it("通常の文字列はそのまま返す", () => {
+    expect(escapeIlikePattern("子育て支援")).toBe("子育て支援");
+  });
+
+  it("% をエスケープする", () => {
+    expect(escapeIlikePattern("100%")).toBe("100\\%");
+  });
+
+  it("_ をエスケープする", () => {
+    expect(escapeIlikePattern("user_name")).toBe("user\\_name");
+  });
+
+  it("バックスラッシュをエスケープする", () => {
+    expect(escapeIlikePattern("a\\b")).toBe("a\\\\b");
+  });
+
+  it("複数の特殊文字が混在してもすべてエスケープする", () => {
+    expect(escapeIlikePattern("%_\\")).toBe("\\%\\_\\\\");
+  });
+
+  it("空文字列は空文字列を返す", () => {
+    expect(escapeIlikePattern("")).toBe("");
+  });
+});

--- a/admin/src/features/interview-reports/shared/utils/escape-ilike-pattern.ts
+++ b/admin/src/features/interview-reports/shared/utils/escape-ilike-pattern.ts
@@ -1,0 +1,7 @@
+/**
+ * ilike パターンに埋め込む検索文字列をエスケープする。
+ * `%` と `_` はワイルドカード、`\` はエスケープ文字として解釈されるため無効化する。
+ */
+export function escapeIlikePattern(value: string): string {
+  return value.replace(/[\\%_]/g, "\\$&");
+}

--- a/admin/src/features/interview-reports/shared/utils/format-jst-date-time.test.ts
+++ b/admin/src/features/interview-reports/shared/utils/format-jst-date-time.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { formatJstDateTime } from "./format-jst-date-time";
+
+describe("formatJstDateTime", () => {
+  it("UTCの日時を日本時間のYYYY/MM/DD HH:mm形式に整形する", () => {
+    expect(formatJstDateTime("2026-05-12T07:30:00Z")).toBe("2026/05/12 16:30");
+  });
+
+  it("日付が日本時間で翌日に繰り上がるケースを処理する", () => {
+    expect(formatJstDateTime("2026-01-31T23:00:00Z")).toBe("2026/02/01 08:00");
+  });
+});

--- a/admin/src/features/interview-reports/shared/utils/format-jst-date-time.ts
+++ b/admin/src/features/interview-reports/shared/utils/format-jst-date-time.ts
@@ -1,0 +1,13 @@
+/**
+ * 日時文字列を日本時間の「YYYY/MM/DD HH:mm」形式に整形する。
+ */
+export function formatJstDateTime(dateString: string): string {
+  return new Date(dateString).toLocaleString("ja-JP", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    timeZone: "Asia/Tokyo",
+  });
+}

--- a/admin/src/features/interview-reports/shared/utils/group-matched-messages.test.ts
+++ b/admin/src/features/interview-reports/shared/utils/group-matched-messages.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import type { MatchedUserMessage } from "../types";
+import { groupMatchedMessagesBySession } from "./group-matched-messages";
+
+function makeMessage(
+  id: string,
+  sessionId: string,
+  createdAt: string
+): MatchedUserMessage {
+  return {
+    id,
+    interview_session_id: sessionId,
+    content: `message ${id}`,
+    created_at: createdAt,
+  };
+}
+
+describe("groupMatchedMessagesBySession", () => {
+  it("セッションごとにメッセージをまとめる", () => {
+    // 入力は created_at 降順
+    const messages = [
+      makeMessage("m3", "s1", "2026-01-03T00:00:00Z"),
+      makeMessage("m2", "s2", "2026-01-02T00:00:00Z"),
+      makeMessage("m1", "s1", "2026-01-01T00:00:00Z"),
+    ];
+
+    const groups = groupMatchedMessagesBySession(messages);
+
+    expect(groups).toHaveLength(2);
+    expect(groups[0].sessionId).toBe("s1");
+    expect(groups[1].sessionId).toBe("s2");
+  });
+
+  it("セッションは最新の一致メッセージが新しい順に並ぶ", () => {
+    const messages = [
+      makeMessage("m3", "s2", "2026-01-03T00:00:00Z"),
+      makeMessage("m2", "s1", "2026-01-02T00:00:00Z"),
+      makeMessage("m1", "s2", "2026-01-01T00:00:00Z"),
+    ];
+
+    const groups = groupMatchedMessagesBySession(messages);
+
+    expect(groups.map((g) => g.sessionId)).toEqual(["s2", "s1"]);
+  });
+
+  it("セッション内のメッセージは時系列（昇順）に並ぶ", () => {
+    const messages = [
+      makeMessage("m3", "s1", "2026-01-03T00:00:00Z"),
+      makeMessage("m2", "s1", "2026-01-02T00:00:00Z"),
+      makeMessage("m1", "s1", "2026-01-01T00:00:00Z"),
+    ];
+
+    const groups = groupMatchedMessagesBySession(messages);
+
+    expect(groups[0].messages.map((m) => m.id)).toEqual(["m1", "m2", "m3"]);
+  });
+
+  it("空の入力は空の配列を返す", () => {
+    expect(groupMatchedMessagesBySession([])).toEqual([]);
+  });
+});

--- a/admin/src/features/interview-reports/shared/utils/group-matched-messages.ts
+++ b/admin/src/features/interview-reports/shared/utils/group-matched-messages.ts
@@ -1,0 +1,26 @@
+import type { MatchedUserMessage, SessionMatchGroup } from "../types";
+
+/**
+ * created_at 降順のメッセージ一覧をセッションごとにまとめる。
+ * セッションは最新の一致メッセージが新しい順、
+ * セッション内のメッセージは時系列（昇順）に並べる。
+ */
+export function groupMatchedMessagesBySession(
+  messages: MatchedUserMessage[]
+): SessionMatchGroup[] {
+  const groups = new Map<string, MatchedUserMessage[]>();
+
+  for (const message of messages) {
+    const list = groups.get(message.interview_session_id);
+    if (list) {
+      list.push(message);
+    } else {
+      groups.set(message.interview_session_id, [message]);
+    }
+  }
+
+  return Array.from(groups.entries()).map(([sessionId, sessionMessages]) => ({
+    sessionId,
+    messages: sessionMessages.reverse(),
+  }));
+}

--- a/admin/src/features/interview-reports/shared/utils/normalize-interview-report.test.ts
+++ b/admin/src/features/interview-reports/shared/utils/normalize-interview-report.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { normalizeInterviewReport } from "./normalize-interview-report";
+
+describe("normalizeInterviewReport", () => {
+  it("オブジェクトはそのまま返す", () => {
+    const report = { id: "r1" };
+    expect(normalizeInterviewReport(report)).toBe(report);
+  });
+
+  it("配列の場合は最初の要素を返す", () => {
+    const first = { id: "r1" };
+    expect(normalizeInterviewReport([first, { id: "r2" }])).toBe(first);
+  });
+
+  it("空配列の場合は null を返す", () => {
+    expect(normalizeInterviewReport([])).toBeNull();
+  });
+
+  it("null の場合は null を返す", () => {
+    expect(normalizeInterviewReport(null)).toBeNull();
+  });
+});

--- a/admin/src/features/interview-reports/shared/utils/normalize-interview-report.ts
+++ b/admin/src/features/interview-reports/shared/utils/normalize-interview-report.ts
@@ -1,0 +1,7 @@
+/**
+ * Supabase の join で取得した interview_report を単一オブジェクトに正規化する。
+ * 1:1 リレーションでも生成型上は配列で返るケースがあるため、最初の要素を取り出す。
+ */
+export function normalizeInterviewReport<T>(report: T | T[] | null): T | null {
+  return Array.isArray(report) ? (report[0] ?? null) : report;
+}

--- a/admin/src/features/interview-reports/shared/utils/parse-session-filter-params.ts
+++ b/admin/src/features/interview-reports/shared/utils/parse-session-filter-params.ts
@@ -1,15 +1,15 @@
 import {
   DEFAULT_SESSION_FILTER,
   MODERATION_FILTER_VALUES,
-  ROLE_FILTER_VALUES,
-  SESSION_STATUS_FILTER_VALUES,
-  STANCE_FILTER_VALUES,
-  VISIBILITY_FILTER_VALUES,
   type ModerationFilter,
+  ROLE_FILTER_VALUES,
   type RoleFilter,
+  SESSION_STATUS_FILTER_VALUES,
   type SessionFilterConfig,
   type SessionStatusFilter,
+  STANCE_FILTER_VALUES,
   type StanceFilter,
+  VISIBILITY_FILTER_VALUES,
   type VisibilityFilter,
 } from "../types";
 

--- a/admin/src/features/interview-reports/shared/utils/split-text-by-query.test.ts
+++ b/admin/src/features/interview-reports/shared/utils/split-text-by-query.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { splitTextByQuery } from "./split-text-by-query";
+
+describe("splitTextByQuery", () => {
+  it("一致部分と非一致部分に分割する", () => {
+    expect(splitTextByQuery("保育園の待機児童問題", "待機児童")).toEqual([
+      { text: "保育園の", isMatch: false },
+      { text: "待機児童", isMatch: true },
+      { text: "問題", isMatch: false },
+    ]);
+  });
+
+  it("複数の一致箇所をすべて分割する", () => {
+    expect(splitTextByQuery("支援と支援策", "支援")).toEqual([
+      { text: "支援", isMatch: true },
+      { text: "と", isMatch: false },
+      { text: "支援", isMatch: true },
+      { text: "策", isMatch: false },
+    ]);
+  });
+
+  it("大文字小文字を区別せず一致し、元の表記を保持する", () => {
+    expect(splitTextByQuery("AI と ai の議論", "Ai")).toEqual([
+      { text: "AI", isMatch: true },
+      { text: " と ", isMatch: false },
+      { text: "ai", isMatch: true },
+      { text: " の議論", isMatch: false },
+    ]);
+  });
+
+  it("先頭・末尾が一致する場合も正しく分割する", () => {
+    expect(splitTextByQuery("支援", "支援")).toEqual([
+      { text: "支援", isMatch: true },
+    ]);
+  });
+
+  it("一致しない場合は全体を非一致として返す", () => {
+    expect(splitTextByQuery("高齢者福祉", "子育て")).toEqual([
+      { text: "高齢者福祉", isMatch: false },
+    ]);
+  });
+
+  it("検索語が空白のみの場合は全体を非一致として返す", () => {
+    expect(splitTextByQuery("テキスト", "  ")).toEqual([
+      { text: "テキスト", isMatch: false },
+    ]);
+  });
+
+  it("検索語の前後の空白は無視して一致させる", () => {
+    expect(splitTextByQuery("子育て支援", " 支援 ")).toEqual([
+      { text: "子育て", isMatch: false },
+      { text: "支援", isMatch: true },
+    ]);
+  });
+
+  it("テキストが空の場合は空の非一致セグメントを返す", () => {
+    expect(splitTextByQuery("", "支援")).toEqual([
+      { text: "", isMatch: false },
+    ]);
+  });
+});

--- a/admin/src/features/interview-reports/shared/utils/split-text-by-query.ts
+++ b/admin/src/features/interview-reports/shared/utils/split-text-by-query.ts
@@ -1,0 +1,39 @@
+export interface TextSegment {
+  text: string;
+  isMatch: boolean;
+}
+
+/**
+ * テキストを検索語との一致部分・非一致部分に分割する（大文字小文字は区別しない）。
+ * ハイライト表示のためのセグメント列を返す。検索語が空の場合は全体を非一致として返す。
+ */
+export function splitTextByQuery(text: string, query: string): TextSegment[] {
+  const trimmedQuery = query.trim();
+  if (!trimmedQuery || !text) {
+    return [{ text, isMatch: false }];
+  }
+
+  const lowerText = text.toLowerCase();
+  const lowerQuery = trimmedQuery.toLowerCase();
+  const segments: TextSegment[] = [];
+  let cursor = 0;
+
+  while (cursor < text.length) {
+    const index = lowerText.indexOf(lowerQuery, cursor);
+    if (index === -1) break;
+    if (index > cursor) {
+      segments.push({ text: text.slice(cursor, index), isMatch: false });
+    }
+    segments.push({
+      text: text.slice(index, index + trimmedQuery.length),
+      isMatch: true,
+    });
+    cursor = index + trimmedQuery.length;
+  }
+
+  if (cursor < text.length) {
+    segments.push({ text: text.slice(cursor), isMatch: false });
+  }
+
+  return segments;
+}

--- a/admin/src/lib/routes.ts
+++ b/admin/src/lib/routes.ts
@@ -36,6 +36,8 @@ export const routes = {
   // レポート（インタビュー設定配下）
   billReports: (billId: string, configId: string) =>
     `/bills/${billId}/interview/${configId}/reports` as const,
+  billReportsSearch: (billId: string, configId: string) =>
+    `/bills/${billId}/interview/${configId}/reports/search` as const,
   billReportDetail: (billId: string, configId: string, sessionId: string) =>
     `/bills/${billId}/interview/${configId}/reports/${sessionId}` as const,
 


### PR DESCRIPTION
## 概要

adminのインタビューレポートに、ユーザー発言を全文検索できる専用ページ `/bills/[id]/interview/[configId]/reports/search` を追加します。

### 機能

- **発言検索ページ（新規）**: `interview_messages` の `role='user'` のみを対象に ilike 部分一致で検索
  - 結果はセッション単位のカードで表示（スタンス・公開状態・役割名・開始日時のバッジ付き）
  - 各セッションにヒットした発言の抜粋を最大3件表示（一致箇所を `<mark>` でハイライト、4件以上は「他N件」表記）
  - 対象は最新500件までとし、超過時は打ち切りの注意書きを表示
  - 20セッション/ページのページネーション
- **既存レポート一覧**: ヘッダーに「発言検索」ボタンを追加（一覧のレイアウトは無変更）
- **セッション詳細**: 検索結果からの遷移時に `?highlight=` で検索語を引き継ぎ、チャット履歴内の一致箇所をハイライト

### リファクタリング（本機能に伴う共通化）

- `normalizeInterviewReport`: 3ローダーに重複していた interview_report 配列正規化を `shared/utils/` に集約
- `PaginationNav`: session-list のページネーションJSX（約80行）をコンポーネント化し検索結果と共有
- `formatJstDateTime`: JST日時フォーマットを共通化

### 実装メモ

- 検索クエリは repository 層（`searchUserMessagesByConfigId`）に集約し、`%` `_` `\` は `escapeIlikePattern` でエスケープ
- 純粋関数（スニペット生成・テキスト分割・グルーピング・エスケープ等）は `shared/utils/` に切り出し、すべて同階層にテストを配置
- 新規ページは `routes.billReportsSearch` として `admin/src/lib/routes.ts` に登録（routes.test.ts の同期検証を通過）

🤖 Generated with [Claude Code](https://claude.com/claude-code)