### PR TITLE
AIインタビューの選択モデルに Gemma 4 26B A4B (MoE) を追加

### DIFF
--- a/admin/src/features/interview-config/shared/utils/chat-model-options.ts
+++ b/admin/src/features/interview-config/shared/utils/chat-model-options.ts
@@ -37,6 +37,7 @@ const GOOGLE_MODELS = [
     value: "google/gemini-3.1-pro-preview",
     label: "Gemini 3.1 Pro Preview",
   },
+  { value: "google/gemma-4-26b-a4b-it", label: "Gemma 4 26B A4B (MoE)" },
 ] as const;
 
 const ANTHROPIC_MODELS = [

--- a/admin/src/features/interview-config/shared/utils/estimate-interview-cost.ts
+++ b/admin/src/features/interview-config/shared/utils/estimate-interview-cost.ts
@@ -35,6 +35,7 @@ const MODEL_PRICING: Record<string, ModelPricing> = {
     inputPerMillion: 2,
     outputPerMillion: 12,
   },
+  "google/gemma-4-26b-a4b-it": { inputPerMillion: 0.06, outputPerMillion: 0.33 },
   // --- Anthropic ---
   "anthropic/claude-haiku-4.5": { inputPerMillion: 1, outputPerMillion: 5 },
   "anthropic/claude-sonnet-4.6": { inputPerMillion: 3, outputPerMillion: 15 },

--- a/packages/shared/src/ai/models.ts
+++ b/packages/shared/src/ai/models.ts
@@ -22,6 +22,7 @@ export const AI_MODELS = {
   gemini3_flash_preview: "google/gemini-3-flash-preview",
   gemini3_1_flash_lite_preview: "google/gemini-3.1-flash-lite-preview",
   gemini3_1_pro_preview: "google/gemini-3.1-pro-preview",
+  gemma4_26b_a4b: "google/gemma-4-26b-a4b-it",
   // --- Anthropic ---
   claude_haiku_4_5: "anthropic/claude-haiku-4.5",
   claude_sonnet_4_6: "anthropic/claude-sonnet-4.6",

--- a/web/src/lib/ai/calculate-ai-cost.ts
+++ b/web/src/lib/ai/calculate-ai-cost.ts
@@ -83,6 +83,10 @@ export const modelPricing: Record<string, ModelPricing> = {
     inputTokensPerMillionUsd: 2,
     outputTokensPerMillionUsd: 12,
   },
+  [AI_MODELS.gemma4_26b_a4b]: {
+    inputTokensPerMillionUsd: 0.06,
+    outputTokensPerMillionUsd: 0.33,
+  },
   // --- Anthropic ---
   [AI_MODELS.claude_haiku_4_5]: {
     inputTokensPerMillionUsd: 1,


### PR DESCRIPTION
## 概要

みらい議会 admin のAIインタビュー設定で選べるモデルに、Google の open-weight MoE モデル **Gemma 4 26B A4B** (`google/gemma-4-26b-a4b-it`) を追加します。

中原さん(古川事務所)からの依頼です。定数削減法案のAIインタビューでモデルを比較検討している流れで、低コストな選択肢として Gemma を試したいという要望でした。
- 依頼元スレッド: #3_政務調査会_みらい議会議論 系スレッドでの「gemma4 a4b をいれたい」

## 背景

現状のインタビューチャットのモデル選択肢は GPT-5.x / Gemini 3 / Claude 系のみで、Gemma 系がありません。GPT-5.1 Instant で 1回あたり約19〜20円というコスト感で、より安価な選択肢が欲しいという文脈です。

`google/gemma-4-26b-a4b-it` は Vercel AI Gateway で正式に利用可能な MoE モデル(26B 総パラメータ・約4B active)で、AI SDK で `model` にこの ID を指定すれば使えます。料金は $0.06/M input・$0.33/M output(OpenRouter 掲載値)。この推定前提(入力85k・出力3k tokens/回)だと **約1円/回** となり、GPT-5.1 Instant 比で大幅に安い選択肢になります。

## 変更内容

| ファイル | 変更 |
|---|---|
| `packages/shared/src/ai/models.ts` | `AI_MODELS` に `gemma4_26b_a4b` を登録 |
| `admin/.../interview-config/shared/utils/chat-model-options.ts` | `GOOGLE_MODELS` に追加(UIドロップダウンに表示) |
| `admin/.../interview-config/shared/utils/estimate-interview-cost.ts` | 推定コスト表示用の料金を追加 |
| `web/src/lib/ai/calculate-ai-cost.ts` | 実コスト計算用の料金を追加 |

4ファイルすべてが必要な理由(既存テスト `chat-model-options.test.ts` の要件でもあります):
- `AI_MODELS` への登録: `isKnownModel=true` が UI 選択肢の必須条件(未登録だと backfill dispatch が「未知のモデルID」で 400 になる乖離が起きる、というテストの意図に沿う)
- `estimate-interview-cost.ts`: 「全モデルに推定コストが設定されている」テストを満たすため(未設定だと `estimatedCost` が null になり落ちる)
- `web/.../calculate-ai-cost.ts`: `calculateUsageCostUsd` は未登録モデルで実行時に throw するため、実インタビューで選ぶと落ちる。必須

## 確認したこと

- モデル ID `google/gemma-4-26b-a4b-it` が Vercel AI Gateway で利用可能なこと(公式ドキュメント記載)
- モデル選択のバリデーションは `isValidChatModel`(= `CHAT_MODEL_OPTIONS`)で完結しており、`GOOGLE_MODELS` への追加で通ること
- 既存テスト(value 形式・isKnownModel・ラベル・重複なし・推定コスト・グループ数/順序)を壊さない構成であること

## レビュー時に見てほしい点

- 表示ラベルは「Gemma 4 26B A4B (MoE)」にしています。好みで変えてOKです
- 料金は OpenRouter 掲載の list price($0.06/$0.33)を採用しています。Vercel AI Gateway 実請求で差があれば数値を直してください(コスト表示・トラッキングにのみ影響、モデル動作には無関係)
- シミュレーション機能側のモデル選択肢(`interview-simulation/shared/constants.ts` の `SIMULATION_MODEL_OPTIONS`)には**あえて追加していません**(今回の依頼はインタビューチャットのモデルのため)。シミュでも選べるようにしたい場合は1行追加で対応できます

<!-- mirai-inu-session: sesn_01Vy8K7FjUVgVz6pGyyu2CWp -->