### PR TITLE
2026/07/03 本番反映

### DIFF
--- a/admin/src/features/interview-config/shared/utils/chat-model-options.ts
+++ b/admin/src/features/interview-config/shared/utils/chat-model-options.ts
@@ -37,6 +37,7 @@ const GOOGLE_MODELS = [
     value: "google/gemini-3.1-pro-preview",
     label: "Gemini 3.1 Pro Preview",
   },
+  { value: "google/gemma-4-26b-a4b-it", label: "Gemma 4 26B A4B (MoE)" },
 ] as const;
 
 const ANTHROPIC_MODELS = [

--- a/admin/src/features/interview-config/shared/utils/estimate-interview-cost.ts
+++ b/admin/src/features/interview-config/shared/utils/estimate-interview-cost.ts
@@ -35,6 +35,7 @@ const MODEL_PRICING: Record<string, ModelPricing> = {
     inputPerMillion: 2,
     outputPerMillion: 12,
   },
+  "google/gemma-4-26b-a4b-it": { inputPerMillion: 0.06, outputPerMillion: 0.33 },
   // --- Anthropic ---
   "anthropic/claude-haiku-4.5": { inputPerMillion: 1, outputPerMillion: 5 },
   "anthropic/claude-sonnet-4.6": { inputPerMillion: 3, outputPerMillion: 15 },

--- a/packages/shared/src/ai/models.ts
+++ b/packages/shared/src/ai/models.ts
@@ -22,6 +22,7 @@ export const AI_MODELS = {
   gemini3_flash_preview: "google/gemini-3-flash-preview",
   gemini3_1_flash_lite_preview: "google/gemini-3.1-flash-lite-preview",
   gemini3_1_pro_preview: "google/gemini-3.1-pro-preview",
+  gemma4_26b_a4b: "google/gemma-4-26b-a4b-it",
   // --- Anthropic ---
   claude_haiku_4_5: "anthropic/claude-haiku-4.5",
   claude_sonnet_4_6: "anthropic/claude-sonnet-4.6",

--- a/web/src/lib/ai/calculate-ai-cost.ts
+++ b/web/src/lib/ai/calculate-ai-cost.ts
@@ -83,6 +83,10 @@ export const modelPricing: Record<string, ModelPricing> = {
     inputTokensPerMillionUsd: 2,
     outputTokensPerMillionUsd: 12,
   },
+  [AI_MODELS.gemma4_26b_a4b]: {
+    inputTokensPerMillionUsd: 0.06,
+    outputTokensPerMillionUsd: 0.33,
+  },
   // --- Anthropic ---
   [AI_MODELS.claude_haiku_4_5]: {
     inputTokensPerMillionUsd: 1,


### PR DESCRIPTION
みらい議会 admin のAIインタビュー設定で選べるモデルに、Google の
open-weight MoE モデル google/gemma-4-26b-a4b-it を追加する。 Vercel AI Gateway で利用可能なモデル。低コスト(約1円/回)の選択肢として提供する。

- packages/shared/src/ai/models.ts: AI_MODELS に gemma4_26b_a4b を登録 (isKnownModel / backfill dispatch のため必須)
- interview-config/chat-model-options.ts: GOOGLE_MODELS に追加(UIドロップダウン)
- interview-config/estimate-interview-cost.ts: 推定コスト表示用の料金を追加
- web/src/lib/ai/calculate-ai-cost.ts: 実コスト計算用の料金を追加 (未登録だと calculateUsageCostUsd が実行時に throw するため必須)

料金は $0.06/M input・$0.33/M output(OpenRouter 掲載値)を採用。