### PR TITLE
Add interview metrics aggregation RPC and MCP tool

### DIFF
--- a/admin/src/features/interview-config/shared/utils/estimate-interview-cost.ts
+++ b/admin/src/features/interview-config/shared/utils/estimate-interview-cost.ts
@@ -35,7 +35,10 @@ const MODEL_PRICING: Record<string, ModelPricing> = {
     inputPerMillion: 2,
     outputPerMillion: 12,
   },
-  "google/gemma-4-26b-a4b-it": { inputPerMillion: 0.06, outputPerMillion: 0.33 },
+  "google/gemma-4-26b-a4b-it": {
+    inputPerMillion: 0.06,
+    outputPerMillion: 0.33,
+  },
   // --- Anthropic ---
   "anthropic/claude-haiku-4.5": { inputPerMillion: 1, outputPerMillion: 5 },
   "anthropic/claude-sonnet-4.6": { inputPerMillion: 3, outputPerMillion: 15 },

--- a/admin/src/features/interview-reports/server/repositories/interview-report-repository.ts
+++ b/admin/src/features/interview-reports/server/repositories/interview-report-repository.ts
@@ -507,6 +507,35 @@ export async function findFeedbackTagsBySessionId(
   return (data || []).map((row) => row.tag);
 }
 
+export type InterviewMetricsByBillRow = {
+  bill_id: string;
+  bill_name: string;
+  conducted_count: number;
+  completed_count: number;
+  completion_rate: number;
+};
+
+/**
+ * 議案ごとのAIインタビュー実施数・完了数・完了率を取得する。
+ * billId を指定すると単一議案に絞り込み、省略すると設定を持つ全議案を返す。
+ */
+export async function findInterviewMetricsByBill(
+  billId?: string
+): Promise<InterviewMetricsByBillRow[]> {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase.rpc("get_interview_metrics_by_bill", {
+    p_bill_id: billId,
+  });
+
+  if (error) {
+    throw new Error(
+      `Failed to fetch interview metrics by bill: ${error.message}`
+    );
+  }
+
+  return data ?? [];
+}
+
 export async function findInterviewStatistics(configId: string) {
   const supabase = createAdminClient();
   const { data, error } = await supabase.rpc("get_interview_statistics", {

--- a/admin/src/features/mcp/server/create-handler.ts
+++ b/admin/src/features/mcp/server/create-handler.ts
@@ -6,6 +6,7 @@ import {
 } from "mcp-handler";
 import { registerBillsTools } from "./tools/register-bills-tools";
 import { registerDietSessionsTools } from "./tools/register-diet-sessions-tools";
+import { registerInterviewMetricsTools } from "./tools/register-interview-metrics-tools";
 import { registerMiraiStanceTools } from "./tools/register-mirai-stance-tools";
 import { registerPreviewTools } from "./tools/register-preview-tools";
 import { registerTagsTools } from "./tools/register-tags-tools";
@@ -17,6 +18,7 @@ export function createAdminMcpHandler() {
     (server) => {
       registerBillsTools(server);
       registerDietSessionsTools(server);
+      registerInterviewMetricsTools(server);
       registerMiraiStanceTools(server);
       registerPreviewTools(server);
       registerTagsTools(server);

--- a/admin/src/features/mcp/server/tools/register-interview-metrics-tools.ts
+++ b/admin/src/features/mcp/server/tools/register-interview-metrics-tools.ts
@@ -1,0 +1,31 @@
+import "server-only";
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { findInterviewMetricsByBill } from "@/features/interview-reports/server/repositories/interview-report-repository";
+import { jsonResult } from "../utils/json-result";
+
+/**
+ * 議案ごとのAIインタビュー実施状況（実施数・完了数・完了率）を取得する内部向け読み取りツール。
+ */
+export function registerInterviewMetricsTools(server: McpServer): void {
+  server.registerTool(
+    "get_interview_metrics_by_bill",
+    {
+      title: "議案ごとのAIインタビュー実施状況を取得",
+      description:
+        "議案ごとにAIインタビューの実施数（開始されたセッション総数）・完了数（completed_atが設定されたセッション数）・完了率（完了数/実施数、0〜1）を返す。AIインタビュー設定を持つ議案のみが対象で、論理削除済みの設定は除外する。1議案に複数の設定がある場合は合算する。billId未指定なら全議案を実施数の多い順で返す。billId指定でその議案のみ返す（設定が無い議案は空配列）。",
+      inputSchema: {
+        billId: z
+          .string()
+          .uuid()
+          .optional()
+          .describe("対象議案のID（未指定なら全議案）"),
+      },
+    },
+    async ({ billId }) => {
+      const metrics = await findInterviewMetricsByBill(billId);
+      return jsonResult(metrics);
+    }
+  );
+}

--- a/packages/supabase/types/supabase.types.ts
+++ b/packages/supabase/types/supabase.types.ts
@@ -1217,6 +1217,16 @@ export type Database = {
           message_count: number
         }[]
       }
+      get_interview_metrics_by_bill: {
+        Args: { p_bill_id?: string }
+        Returns: {
+          bill_id: string
+          bill_name: string
+          completed_count: number
+          completion_rate: number
+          conducted_count: number
+        }[]
+      }
       get_interview_statistics: {
         Args: { p_config_id: string }
         Returns: {

--- a/supabase/migrations/20260706120000_add_get_interview_metrics_by_bill.sql
+++ b/supabase/migrations/20260706120000_add_get_interview_metrics_by_bill.sql
@@ -1,0 +1,44 @@
+-- 議案ごとのAIインタビュー実施状況（実施数・完了数・完了率）を集計するRPC関数。
+-- admin MCP tool (get_interview_metrics_by_bill) から利用する。
+--
+-- 定義:
+--   実施数 (conducted_count): interview_sessions の総数（開始されたセッション。archived含む）
+--   完了数 (completed_count): completed_at が設定されたセッション数
+--   完了率 (completion_rate): completed_count / conducted_count（0〜1、小数第3位で丸め。実施0件は0）
+--
+-- 論理削除済みの設定（interview_configs.deleted_at IS NOT NULL）は除外する。
+-- 1議案に複数の設定がある場合は設定を跨いで合算する。
+-- p_bill_id を指定するとその議案のみ、NULL（未指定）なら設定を持つ全議案を返す。
+create or replace function get_interview_metrics_by_bill(p_bill_id uuid default null)
+returns table (
+  bill_id uuid,
+  bill_name text,
+  conducted_count bigint,
+  completed_count bigint,
+  completion_rate numeric
+)
+language sql
+stable
+as $$
+  select
+    b.id as bill_id,
+    b.name as bill_name,
+    count(s.id) as conducted_count,
+    count(s.completed_at) as completed_count,
+    case
+      when count(s.id) = 0 then 0
+      else round(count(s.completed_at)::numeric / count(s.id)::numeric, 3)
+    end as completion_rate
+  from bills b
+  join interview_configs c
+    on c.bill_id = b.id
+   and c.deleted_at is null
+  left join interview_sessions s
+    on s.interview_config_id = c.id
+  where p_bill_id is null or b.id = p_bill_id
+  group by b.id, b.name
+  order by count(s.id) desc, b.name;
+$$;
+
+comment on function get_interview_metrics_by_bill(uuid) is
+  '議案ごとのAIインタビュー実施数・完了数・完了率を集計する。論理削除済み設定は除外。p_bill_idで単一議案に絞り込める。';

--- a/tests/supabase/db-function/get-interview-metrics-by-bill.test.ts
+++ b/tests/supabase/db-function/get-interview-metrics-by-bill.test.ts
@@ -1,0 +1,144 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  adminClient,
+  cleanupTestBill,
+  cleanupTestUser,
+  createTestBill,
+  createTestUser,
+} from "../utils";
+
+/**
+ * get_interview_metrics_by_bill の統合テスト。
+ *
+ * 検証観点:
+ * - 複数設定を跨いだ実施数・完了数の合算
+ * - completed_at の有無による完了数のカウント
+ * - 完了率（completed/conducted）の算出と丸め
+ * - 論理削除済み設定の除外
+ * - セッション0件の議案（実施0・完了率0）の扱い
+ * - p_bill_id によるフィルタ
+ */
+describe("get_interview_metrics_by_bill", () => {
+  // billA: config1(3件中2件完了) + config2(1件完了) => 実施4・完了3・率0.75
+  let billA: { id: string };
+  // billB: 設定はあるがセッション0件 => 実施0・完了0・率0
+  let billB: { id: string };
+  // billC: 論理削除済み設定のみ（セッションあり） => 結果に含まれない
+  let billC: { id: string };
+  let user: { id: string };
+
+  async function insertSession(configId: string, completed: boolean) {
+    const now = new Date().toISOString();
+    const { error } = await adminClient.from("interview_sessions").insert({
+      interview_config_id: configId,
+      user_id: user.id,
+      started_at: now,
+      completed_at: completed ? now : null,
+    });
+    if (error) throw new Error(`session 作成失敗: ${error.message}`);
+  }
+
+  async function insertConfig(
+    billId: string,
+    name: string,
+    status: "public" | "closed",
+    deleted: boolean
+  ): Promise<string> {
+    const { data, error } = await adminClient
+      .from("interview_configs")
+      .insert({
+        bill_id: billId,
+        status,
+        name,
+        deleted_at: deleted ? new Date().toISOString() : null,
+      })
+      .select()
+      .single();
+    if (error || !data) throw new Error(`config 作成失敗: ${error?.message}`);
+    return data.id;
+  }
+
+  beforeAll(async () => {
+    user = await createTestUser();
+    billA = await createTestBill();
+    billB = await createTestBill();
+    billC = await createTestBill();
+
+    // billA: 2設定を合算
+    const configA1 = await insertConfig(billA.id, "設定A1", "public", false);
+    await insertSession(configA1, true);
+    await insertSession(configA1, true);
+    await insertSession(configA1, false);
+    const configA2 = await insertConfig(billA.id, "設定A2", "closed", false);
+    await insertSession(configA2, true);
+
+    // billB: 設定はあるがセッション無し
+    await insertConfig(billB.id, "設定B", "public", false);
+
+    // billC: 論理削除済み設定（セッション有りだが除外されるべき）
+    const configC = await insertConfig(billC.id, "設定C", "closed", true);
+    await insertSession(configC, true);
+    await insertSession(configC, true);
+  });
+
+  afterAll(async () => {
+    await cleanupTestBill(billA.id);
+    await cleanupTestBill(billB.id);
+    await cleanupTestBill(billC.id);
+    await cleanupTestUser(user.id);
+  });
+
+  it("複数設定を合算し実施数・完了数・完了率を算出する", async () => {
+    const { data, error } = await adminClient.rpc(
+      "get_interview_metrics_by_bill",
+      { p_bill_id: billA.id }
+    );
+
+    expect(error).toBeNull();
+    expect(data).toHaveLength(1);
+    const row = data![0];
+    expect(row.bill_id).toBe(billA.id);
+    expect(Number(row.conducted_count)).toBe(4);
+    expect(Number(row.completed_count)).toBe(3);
+    expect(Number(row.completion_rate)).toBeCloseTo(0.75, 3);
+  });
+
+  it("セッション0件の議案は実施0・完了率0で返す", async () => {
+    const { data, error } = await adminClient.rpc(
+      "get_interview_metrics_by_bill",
+      { p_bill_id: billB.id }
+    );
+
+    expect(error).toBeNull();
+    expect(data).toHaveLength(1);
+    const row = data![0];
+    expect(Number(row.conducted_count)).toBe(0);
+    expect(Number(row.completed_count)).toBe(0);
+    expect(Number(row.completion_rate)).toBe(0);
+  });
+
+  it("論理削除済み設定のみの議案は結果に含まれない", async () => {
+    const { data, error } = await adminClient.rpc(
+      "get_interview_metrics_by_bill",
+      { p_bill_id: billC.id }
+    );
+
+    expect(error).toBeNull();
+    expect(data).toHaveLength(0);
+  });
+
+  it("p_bill_id未指定なら設定を持つ全議案を返す", async () => {
+    const { data, error } = await adminClient.rpc(
+      "get_interview_metrics_by_bill",
+      {}
+    );
+
+    expect(error).toBeNull();
+    const byId = new Map(data!.map((r) => [r.bill_id, r]));
+    expect(byId.has(billA.id)).toBe(true);
+    expect(byId.has(billB.id)).toBe(true);
+    // 論理削除済み設定のみの議案は含まれない
+    expect(byId.has(billC.id)).toBe(false);
+    expect(Number(byId.get(billA.id)!.conducted_count)).toBe(4);
+  });
+});


### PR DESCRIPTION
## Summary
Adds a new database function and corresponding repository/MCP tool to aggregate AI interview metrics (conducted count, completed count, completion rate) by bill. This enables tracking interview progress across multiple configurations per bill.

## Key Changes

### Database Layer
- **New RPC function** `get_interview_metrics_by_bill()` in migration `20260706120000_add_get_interview_metrics_by_bill.sql`
  - Aggregates interview session counts across all non-deleted configurations for a bill
  - Calculates completion rate (completed_at count / total session count) rounded to 3 decimal places
  - Supports optional `p_bill_id` parameter to filter by single bill or return all bills with configurations
  - Excludes logically deleted configurations (`deleted_at IS NOT NULL`)
  - Returns results sorted by conducted count descending

### Repository Layer
- **New function** `findInterviewMetricsByBill()` in `interview-report-repository.ts`
  - Wraps the RPC call with error handling
  - Exports `InterviewMetricsByBillRow` type for type safety
  - Accepts optional `billId` parameter for filtering

### MCP Tool Registration
- **New tool** `get_interview_metrics_by_bill` in `register-interview-metrics-tools.ts`
  - Registers with MCP server for admin use
  - Accepts optional `billId` UUID parameter
  - Returns metrics in JSON format via `jsonResult()` utility
  - Includes descriptive title and documentation

### Type Definitions
- Updated `supabase.types.ts` with RPC function signature and return type

### Testing
- **Comprehensive integration test** in `get-interview-metrics-by-bill.test.ts`
  - Validates aggregation across multiple configurations
  - Tests completion rate calculation and rounding
  - Verifies logical deletion exclusion
  - Tests zero-session bills (returns 0 for all metrics)
  - Validates optional `p_bill_id` filtering
  - Uses test utilities for setup/teardown

## Implementation Details
- Completion rate uses `CASE` to handle division by zero (returns 0 when no sessions)
- `COUNT(s.completed_at)` counts only non-null values, correctly identifying completed sessions
- `GROUP BY b.id, b.name` ensures proper aggregation across multiple configurations
- Test coverage includes edge cases: multiple configs, no sessions, deleted configs, and filtering scenarios

https://claude.ai/code/session_0141sx6op8NSwMqChV5maiNK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 議案ごとの面談実施状況（実施件数、完了件数、完了率）を取得できるようになりました。
  * 複数議案ではなく1議案に絞った集計表示にも対応しました。
  * ツール経由で議案別の集計結果を取得できる機能を追加しました。
* **Bug Fixes**
  * （完了率は実施0件時に0となるなど）集計ロジックの整合性を強化しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->