### PR TITLE
AIインタビュー実施状況に総回答時間(total_duration_seconds)を追加

### DIFF
--- a/admin/src/features/interview-reports/server/repositories/interview-report-repository.ts
+++ b/admin/src/features/interview-reports/server/repositories/interview-report-repository.ts
@@ -513,10 +513,11 @@ export type InterviewMetricsByBillRow = {
   conducted_count: number;
   completed_count: number;
   completion_rate: number;
+  total_duration_seconds: number;
 };
 
 /**
- * 議案ごとのAIインタビュー実施数・完了数・完了率を取得する。
+ * 議案ごとのAIインタビュー実施数・完了数・完了率・総回答時間を取得する。
  * billId を指定すると単一議案に絞り込み、省略すると設定を持つ全議案を返す。
  */
 export async function findInterviewMetricsByBill(

--- a/admin/src/features/mcp/server/tools/register-interview-metrics-tools.ts
+++ b/admin/src/features/mcp/server/tools/register-interview-metrics-tools.ts
@@ -6,7 +6,7 @@ import { findInterviewMetricsByBill } from "@/features/interview-reports/server/
 import { jsonResult } from "../utils/json-result";
 
 /**
- * 議案ごとのAIインタビュー実施状況（実施数・完了数・完了率）を取得する内部向け読み取りツール。
+ * 議案ごとのAIインタビュー実施状況（実施数・完了数・完了率・総回答時間）を取得する内部向け読み取りツール。
  */
 export function registerInterviewMetricsTools(server: McpServer): void {
   server.registerTool(
@@ -14,7 +14,7 @@ export function registerInterviewMetricsTools(server: McpServer): void {
     {
       title: "議案ごとのAIインタビュー実施状況を取得",
       description:
-        "議案ごとにAIインタビューの実施数（開始されたセッション総数）・完了数（completed_atが設定されたセッション数）・完了率（完了数/実施数、0〜1）を返す。AIインタビュー設定を持つ議案のみが対象で、論理削除済みの設定は除外する。1議案に複数の設定がある場合は合算する。billId未指定なら全議案を実施数の多い順で返す。billId指定でその議案のみ返す（設定が無い議案は空配列）。",
+        "議案ごとにAIインタビューの実施数（開始されたセッション総数）・完了数（completed_atが設定されたセッション数）・完了率（完了数/実施数、0〜1）・総回答時間（total_duration_seconds、秒。完了セッションは completed_at−started_at、途中離脱セッションは最終発言までの時間で集計し、発言の無い未完了セッションは集計から除外）を返す。AIインタビュー設定を持つ議案のみが対象で、論理削除済みの設定は除外する。1議案に複数の設定がある場合は合算する。billId未指定なら全議案を実施数の多い順で返す。billId指定でその議案のみ返す（設定が無い議案は空配列）。",
       inputSchema: {
         billId: z
           .string()

--- a/packages/supabase/types/supabase.types.ts
+++ b/packages/supabase/types/supabase.types.ts
@@ -1228,6 +1228,7 @@ export type Database = {
           completed_count: number
           completion_rate: number
           conducted_count: number
+          total_duration_seconds: number
         }[]
       }
       get_interview_statistics: {

--- a/supabase/migrations/20260708120000_add_total_duration_to_interview_metrics_by_bill.sql
+++ b/supabase/migrations/20260708120000_add_total_duration_to_interview_metrics_by_bill.sql
@@ -1,0 +1,63 @@
+-- get_interview_metrics_by_bill に総回答時間（total_duration_seconds）を追加する。
+-- 既存の実施数・完了数・完了率に加え、議案ごとに回答へ費やされた総時間（秒）を返す。
+--
+-- 総回答時間の定義（get_interview_statistics の total_duration_seconds と揃える）:
+--   完了セッション: completed_at - started_at
+--   途中離脱セッション: 最後のメッセージ created_at - started_at
+--   メッセージが無い未完了セッションは終了時刻を確定できないため集計から除外する
+-- 秒単位・小数第0位で丸め、集計対象が無い議案は0とする。
+--
+-- RETURNS TABLE に列を追加するため、CREATE OR REPLACE ではなく DROP してから作り直す。
+drop function if exists get_interview_metrics_by_bill(uuid);
+
+create function get_interview_metrics_by_bill(p_bill_id uuid default null)
+returns table (
+  bill_id uuid,
+  bill_name text,
+  conducted_count bigint,
+  completed_count bigint,
+  completion_rate numeric,
+  total_duration_seconds numeric
+)
+language sql
+stable
+as $$
+  select
+    b.id as bill_id,
+    b.name as bill_name,
+    count(s.id) as conducted_count,
+    count(s.completed_at) as completed_count,
+    case
+      when count(s.id) = 0 then 0
+      else round(count(s.completed_at)::numeric / count(s.id)::numeric, 3)
+    end as completion_rate,
+    round(
+      coalesce(
+        sum(
+          extract(
+            epoch from (coalesce(s.completed_at, lm.last_message_at) - s.started_at)
+          )
+        ),
+        0
+      )::numeric,
+      0
+    ) as total_duration_seconds
+  from bills b
+  join interview_configs c
+    on c.bill_id = b.id
+   and c.deleted_at is null
+  left join interview_sessions s
+    on s.interview_config_id = c.id
+  left join (
+    select im.interview_session_id, max(im.created_at) as last_message_at
+    from interview_messages im
+    group by im.interview_session_id
+  ) lm
+    on lm.interview_session_id = s.id
+  where p_bill_id is null or b.id = p_bill_id
+  group by b.id, b.name
+  order by count(s.id) desc, b.name;
+$$;
+
+comment on function get_interview_metrics_by_bill(uuid) is
+  '議案ごとのAIインタビュー実施数・完了数・完了率・総回答時間（秒）を集計する。論理削除済み設定は除外。p_bill_idで単一議案に絞り込める。';

--- a/tests/supabase/db-function/get-interview-metrics-by-bill.test.ts
+++ b/tests/supabase/db-function/get-interview-metrics-by-bill.test.ts
@@ -16,6 +16,7 @@ import {
  * - 完了率（completed/conducted）の算出と丸め
  * - 論理削除済み設定の除外
  * - セッション0件の議案（実施0・完了率0）の扱い
+ * - 総回答時間（total_duration_seconds）の合算と発言の無い未完了セッションの除外
  * - p_bill_id によるフィルタ
  */
 describe("get_interview_metrics_by_bill", () => {
@@ -25,15 +26,24 @@ describe("get_interview_metrics_by_bill", () => {
   let billB: { id: string };
   // billC: 論理削除済み設定のみ（セッションあり） => 結果に含まれない
   let billC: { id: string };
+  // billD: 総回答時間の検証（60秒+120秒の完了2件 + 発言の無い未完了1件） => 総回答時間180秒
+  let billD: { id: string };
   let user: { id: string };
 
-  async function insertSession(configId: string, completed: boolean) {
-    const now = new Date().toISOString();
+  async function insertSession(
+    configId: string,
+    completed: boolean,
+    durationSeconds = 0
+  ) {
+    const startedAt = new Date();
+    const completedAt = completed
+      ? new Date(startedAt.getTime() + durationSeconds * 1000)
+      : null;
     const { error } = await adminClient.from("interview_sessions").insert({
       interview_config_id: configId,
       user_id: user.id,
-      started_at: now,
-      completed_at: completed ? now : null,
+      started_at: startedAt.toISOString(),
+      completed_at: completedAt ? completedAt.toISOString() : null,
     });
     if (error) throw new Error(`session 作成失敗: ${error.message}`);
   }
@@ -63,6 +73,7 @@ describe("get_interview_metrics_by_bill", () => {
     billA = await createTestBill();
     billB = await createTestBill();
     billC = await createTestBill();
+    billD = await createTestBill();
 
     // billA: 2設定を合算
     const configA1 = await insertConfig(billA.id, "設定A1", "public", false);
@@ -79,12 +90,19 @@ describe("get_interview_metrics_by_bill", () => {
     const configC = await insertConfig(billC.id, "設定C", "closed", true);
     await insertSession(configC, true);
     await insertSession(configC, true);
+
+    // billD: 総回答時間の集計検証（完了60秒 + 完了120秒、発言の無い未完了1件は除外）
+    const configD = await insertConfig(billD.id, "設定D", "public", false);
+    await insertSession(configD, true, 60);
+    await insertSession(configD, true, 120);
+    await insertSession(configD, false);
   });
 
   afterAll(async () => {
     await cleanupTestBill(billA.id);
     await cleanupTestBill(billB.id);
     await cleanupTestBill(billC.id);
+    await cleanupTestBill(billD.id);
     await cleanupTestUser(user.id);
   });
 
@@ -101,6 +119,8 @@ describe("get_interview_metrics_by_bill", () => {
     expect(Number(row.conducted_count)).toBe(4);
     expect(Number(row.completed_count)).toBe(3);
     expect(Number(row.completion_rate)).toBeCloseTo(0.75, 3);
+    // 完了セッションは started_at と completed_at が同時刻のため所要時間0
+    expect(Number(row.total_duration_seconds)).toBe(0);
   });
 
   it("セッション0件の議案は実施0・完了率0で返す", async () => {
@@ -115,6 +135,22 @@ describe("get_interview_metrics_by_bill", () => {
     expect(Number(row.conducted_count)).toBe(0);
     expect(Number(row.completed_count)).toBe(0);
     expect(Number(row.completion_rate)).toBe(0);
+    expect(Number(row.total_duration_seconds)).toBe(0);
+  });
+
+  it("総回答時間（total_duration_seconds）を完了セッションの所要時間の合計として返す", async () => {
+    const { data, error } = await adminClient.rpc(
+      "get_interview_metrics_by_bill",
+      { p_bill_id: billD.id }
+    );
+
+    expect(error).toBeNull();
+    expect(data).toHaveLength(1);
+    const row = data![0];
+    expect(Number(row.conducted_count)).toBe(3);
+    expect(Number(row.completed_count)).toBe(2);
+    // 60秒 + 120秒。発言の無い未完了セッションは集計対象外
+    expect(Number(row.total_duration_seconds)).toBe(180);
   });
 
   it("論理削除済み設定のみの議案は結果に含まれない", async () => {


### PR DESCRIPTION
## 概要

みらいいぬ(admin MCP)が AIインタビュー情報を取得する `get_interview_metrics_by_bill` に、**議案ごとの総回答時間 (`total_duration_seconds`、秒)** を追加します。これまでの実施数・完了数・完了率に加えて、回答者が回答に費やした総時間を取得できるようになります。

安野貴博事務所(瀧沢さん)からの「みらいいぬが AIインタビュー情報を引っ張ってくる機能で総回答時間も取れるようにしたい」という依頼に対応するものです。

## 総回答時間の定義

既存の `get_interview_statistics.total_duration_seconds`(config 単位)と**同じ定義**に揃えました。数値の意味が2ツール間でズレないようにするためです。

- 完了セッション: `completed_at - started_at`
- 途中離脱セッション: `最後のメッセージ created_at - started_at`
- メッセージが無い未完了セッションは終了時刻を確定できないため**集計から除外**
- 秒単位・小数第0位で丸め、集計対象が無い議案は `0`
- 1議案に複数の設定がある場合は合算(実施数・完了数と同じ粒度)

## 変更点

- `supabase/migrations/20260708120000_add_total_duration_to_interview_metrics_by_bill.sql`
  - `get_interview_metrics_by_bill` を `DROP` + 再作成し、`total_duration_seconds numeric` を追加(`RETURNS TABLE` の列追加は `CREATE OR REPLACE` 不可のため `DROP` が必要)。`interview_messages` を最終発言時刻の算出用に `LEFT JOIN`。権限まわりは元の関数と同じ(明示的な `grant`/`revoke` は付けない)ままにしています。
- `admin/src/features/mcp/server/tools/register-interview-metrics-tools.ts`
  - MCP ツールの description を更新し、総回答時間の項目と定義を明記。
- `admin/src/features/interview-reports/server/repositories/interview-report-repository.ts`
  - `InterviewMetricsByBillRow` に `total_duration_seconds: number` を追加。
- `packages/supabase/types/supabase.types.ts`
  - 生成型の `get_interview_metrics_by_bill` の `Returns` に `total_duration_seconds` を追加(`supabase gen types` 相当の手動反映。DB へのアクセスができないため該当1フィールドのみを手で追加しています。ローカルで再生成する場合は同じ差分になるはずです)。
- `tests/supabase/db-function/get-interview-metrics-by-bill.test.ts`
  - 総回答時間の集計テストを追加(完了 60秒 + 120秒 = 180秒、発言の無い未完了セッションは対象外)。既存ケース(billA/billB)にも `total_duration_seconds` の検証を追加。

## 動作確認 / 補足

- ローカルに DB を用意できないため、DB 統合テストの実行は Supabase preview branch の CI に委ねています。ロジックは既存 `get_interview_statistics` の実績ある定義を流用しています。
- CMA(みらいいぬ)側は `get_interview_metrics_by_bill` を既に許可済みで、応答フィールドの追加のみのため whitelist 変更は不要です。マージ + 本番反映後、新しいセッションから総回答時間を取得できます。
- 依頼元 Slack(安野貴博事務所 / 瀧沢瑞生さん)からの要望に基づく変更です。

<!-- mirai-inu-session: sesn_01RpaT4rPkJRgK27BW1WWoka -->