### PR TITLE
管理画面レポート詳細: メッセージ単位のリンクをコピー可能に

### DIFF
--- a/admin/src/features/interview-reports/client/components/copy-message-link-button.tsx
+++ b/admin/src/features/interview-reports/client/components/copy-message-link-button.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { Link as LinkIcon } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { getMessageAnchorId } from "../../shared/utils/message-anchor";
+
+interface CopyMessageLinkButtonProps {
+  messageId: string;
+}
+
+export function CopyMessageLinkButton({
+  messageId,
+}: CopyMessageLinkButtonProps) {
+  const handleClick = async () => {
+    const url = `${window.location.origin}${window.location.pathname}#${getMessageAnchorId(messageId)}`;
+    try {
+      await navigator.clipboard.writeText(url);
+      toast.success("メッセージへのリンクをコピーしました");
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? `リンクのコピーに失敗しました: ${error.message}`
+          : "リンクのコピーに失敗しました"
+      );
+    }
+  };
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={handleClick}
+      className="h-6 w-6 text-gray-400 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity"
+      title="このメッセージへのリンクをコピー"
+      aria-label="このメッセージへのリンクをコピー"
+    >
+      <LinkIcon className="size-3.5" />
+    </Button>
+  );
+}

--- a/admin/src/features/interview-reports/server/components/session-detail.tsx
+++ b/admin/src/features/interview-reports/server/components/session-detail.tsx
@@ -2,6 +2,7 @@ import "server-only";
 import { Bot, Clock, Lightbulb, MessageCircle, User } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { CopyMessageLinkButton } from "../../client/components/copy-message-link-button";
 import { RegenerateContentRichnessButton } from "../../client/components/regenerate-content-richness-button";
 import { RegenerateModerationButton } from "../../client/components/regenerate-moderation-button";
 import { ReportVisibilityToggle } from "../../client/components/report-visibility-toggle";
@@ -10,6 +11,7 @@ import { FEEDBACK_TAG_LABELS } from "../../shared/constants/feedback-tags";
 import type { InterviewSessionDetail } from "../../shared/types";
 import { formatDuration, getSessionStatus } from "../../shared/types";
 import { getMessageDisplayText } from "../../shared/utils/get-message-display-text";
+import { getMessageAnchorId } from "../../shared/utils/message-anchor";
 import { parseOpinions } from "../../shared/utils/parse-opinions";
 import { ModerationBadge } from "./moderation-badge";
 import { RatingStars } from "./rating-stars";
@@ -356,10 +358,12 @@ export function SessionDetail({ session, billId }: SessionDetailProps) {
             <div className="space-y-4">
               {messages.map((message) => {
                 const isAssistant = message.role === "assistant";
+                const reverseClass = isAssistant ? "" : "flex-row-reverse";
                 return (
                   <div
                     key={message.id}
-                    className={`flex gap-3 ${isAssistant ? "" : "flex-row-reverse"}`}
+                    id={getMessageAnchorId(message.id)}
+                    className={`group flex gap-3 scroll-mt-24 rounded-xl target:bg-amber-50 target:ring-2 target:ring-amber-200 target:p-2 target:-m-2 ${reverseClass}`}
                   >
                     <div
                       className={`w-8 h-8 rounded-full flex items-center justify-center shrink-0 ${
@@ -386,10 +390,13 @@ export function SessionDetail({ session, billId }: SessionDetailProps) {
                       >
                         {getMessageDisplayText(message.content)}
                       </div>
-                      <div className="text-xs text-gray-400 mt-1 px-1">
+                      <div
+                        className={`flex items-center gap-1 text-xs text-gray-400 mt-1 px-1 ${reverseClass}`}
+                      >
                         {new Date(message.created_at).toLocaleString("ja-JP", {
                           timeZone: "Asia/Tokyo",
                         })}
+                        <CopyMessageLinkButton messageId={message.id} />
                       </div>
                     </div>
                   </div>

--- a/admin/src/features/interview-reports/shared/utils/message-anchor.test.ts
+++ b/admin/src/features/interview-reports/shared/utils/message-anchor.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest";
+import { getMessageAnchorId } from "./message-anchor";
+
+describe("getMessageAnchorId", () => {
+  it("メッセージIDからアンカーIDを生成する", () => {
+    expect(getMessageAnchorId("abc-123")).toBe("message-abc-123");
+  });
+});

--- a/admin/src/features/interview-reports/shared/utils/message-anchor.ts
+++ b/admin/src/features/interview-reports/shared/utils/message-anchor.ts
@@ -1,0 +1,8 @@
+/**
+ * チャットメッセージのアンカーID。
+ * session-detail.tsx の DOM id と CopyMessageLinkButton のリンク生成で
+ * 共通利用し、フォーマットの不一致を防ぐ。
+ */
+export function getMessageAnchorId(messageId: string): string {
+  return `message-${messageId}`;
+}


### PR DESCRIPTION
## 概要

管理画面のインタビューレポート詳細ページで、チャット履歴の各メッセージへの共有リンクを発行できるようにしました。「このレポートのこのメッセージを管理者間で共有したい」というユースケースに対応します。

## 変更内容

- **リンクコピーボタン追加** (`copy-message-link-button.tsx`): メッセージにホバーするとタイムスタンプ横にリンクアイコンが表示され、クリックで `.../reports/<sessionId>#message-<messageId>` 形式のURLをクリップボードにコピー（toastで通知）
- **メッセージアンカー付与** (`session-detail.tsx`): 各メッセージに `id` 属性と `scroll-mt-24` を付与。リンクを開くとブラウザのアンカー機能で該当メッセージへスクロールし、`target:` スタイル（アンバー背景＋リング）でハイライト
- **アンカーID生成の純粋関数化** (`shared/utils/message-anchor.ts` + テスト): DOM側とリンク生成側でフォーマットを共通化

routes.ts は変更していません（`routes.test.ts` がhash付きルートを許容しないため、URLは現在ページのURL＋アンカーで組み立て）。

## 実行テスト記録

- `pnpm lint` / `pnpm typecheck` / `pnpm build` すべて通過
- adminテスト 447件全パス（新規 `message-anchor.test.ts` 含む）
- ローカル実データ（150メッセージのセッション）で動作確認済み: ホバー表示→コピー→リンクを開いてスクロール＆ハイライトまで確認
- ※ webテストの `html-encoding-sniffer` ESMエラーはdevelopでも再現する既存の環境問題（本変更と無関係）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * チャット内の各メッセージへ直接移動できるリンクコピー機能を追加しました。
  * メッセージごとにアンカー付きURLを表示・コピーできるようになりました。
* **改善**
  * メッセージ表示に日時とリンク操作を追加し、会話の共有や参照がしやすくなりました。
* **テスト**
  * アンカーIDの生成ルールを確認するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->