### PR TITLE
既読のインタビューレポートリンクを紫色で表示

### DIFF
--- a/admin/src/features/experts/server/components/expert-list.tsx
+++ b/admin/src/features/experts/server/components/expert-list.tsx
@@ -62,7 +62,7 @@ export function ExpertList({ experts }: ExpertListProps) {
                               report.configId,
                               report.sessionId
                             )}
-                            className="flex items-center gap-1.5 text-sm text-blue-600 hover:text-blue-800 hover:underline"
+                            className="flex items-center gap-1.5 text-sm text-blue-600 visited:text-purple-600 hover:text-blue-800 hover:underline"
                           >
                             <FileText className="h-3.5 w-3.5 shrink-0" />
                             <span className="truncate max-w-48">

--- a/admin/src/features/interview-reports/server/components/session-list.tsx
+++ b/admin/src/features/interview-reports/server/components/session-list.tsx
@@ -198,7 +198,7 @@ export function SessionList({
                             session.id
                           ) as Route
                         }
-                        className="text-blue-600 hover:underline"
+                        className="text-blue-600 visited:text-purple-600 hover:underline"
                       >
                         {session.id.substring(0, 8)}...
                       </Link>


### PR DESCRIPTION
## 概要

管理画面で一度開いたレポートを一覧上で見分けやすくするため、レポート詳細へのリンクにブラウザ標準の `:visited` スタイルを追加しました。既読のリンクは紫色（`text-purple-600`）で表示されます。

## 変更内容

- `session-list.tsx`: インタビューレポート一覧のセッションIDリンクに `visited:text-purple-600` を追加
- `expert-list.tsx`: 有識者一覧からのレポート詳細リンク（同一ルート）にも一貫性のため同様に追加

DBやJSによる既読管理は行わず、ブラウザの履歴ベースの `:visited` 疑似クラスのみで実現しています（変更は各1行のクラス追加のみ）。

## 挙動の補足

最近のChromeの `:visited` パーティショニング（プライバシー強化）により、**同一サイト内のリンクから遷移した訪問のみ**が着色対象になります。一覧のリンクをクリックして開いた場合は色が変わりますが、コピーしたURLを直接開いた場合は一覧上で色がつきません。「一覧から順に確認していく」ユースケースでは期待通りに動作します。

## 実行テスト記録

- `pnpm lint` / `pnpm typecheck` / `pnpm build` すべて通過
- adminテスト 446件全パス
- ローカル実データで動作確認済み: 一覧からレポートをクリック→戻ると該当リンクが紫色に変化することをスクリーンショットで確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 一部の詳細リンクで、訪問済みの状態が分かりやすく表示されるようになりました。
  * 専門家一覧とセッション一覧の詳細リンクに、訪問後のリンク色が反映されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->