### PR TITLE
fix(admin): 議案一覧の法案提出日が1日ずれる（JST未固定）を修正

### DIFF
--- a/admin/src/features/bills/server/components/bill-list/bill-list.tsx
+++ b/admin/src/features/bills/server/components/bill-list/bill-list.tsx
@@ -137,7 +137,9 @@ function BillRow({ bill }: { bill: BillWithDietSession }) {
       </TableCell>
       <TableCell className="text-gray-600">
         {bill.submitted_date
-          ? new Date(bill.submitted_date).toLocaleDateString("ja-JP")
+          ? new Date(bill.submitted_date).toLocaleDateString("ja-JP", {
+              timeZone: "Asia/Tokyo",
+            })
           : "-"}
       </TableCell>
       <TableCell>


### PR DESCRIPTION
## 事象
admin で、同じ議案の「法案提出日」が
- 議案編集ページ（基本情報）＝ **6/30**
- 議案一覧の「法案提出日」列＝ **6/29**

と1日ずれて表示されていた。

## 原因
`submitted_date` は `TIMESTAMP WITH TIME ZONE`（timestamptz）で、保存時に **JST深夜**として書き込まれる（`create-bill.ts` / `update-bill-with-side-effects.ts` がいずれも `` `${submitted_date}T00:00:00+09:00` `` を付与）。
例：入力「2026-06-30」→ 保存値は `2026-06-30T00:00:00+09:00` = UTC では `2026-06-29T15:00:00Z`。

表示側の差：
- 編集フォーム（`bill-edit-form.tsx`）は `toLocaleDateString("sv-SE", { timeZone: "Asia/Tokyo" })` で **JST固定** → 6/30（正）
- 一覧（`bill-list.tsx`）は `toLocaleDateString("ja-JP")` で **timeZone未指定**。一覧は Server Component で、サーバ（Vercel/Node）は既定 **UTC** 稼働のため、`2026-06-29T15:00:00Z` が前日 **2026/6/29** として整形される（誤）。

つまり保存値は正しく、一覧の整形だけが timezone を固定していないことによる off-by-one。

## 修正
一覧の `toLocaleDateString` に、編集フォームと同じ `timeZone: "Asia/Tokyo"` を付与して揃える。1行相当の変更。

## 補足（このPRの範囲外・要判断）
公開側（web）の `web/src/lib/utils/date.ts` の `formatDateWithDots` / `formatDate` も timezone を固定しておらず（`formatDateWithDots` は `getFullYear()/getMonth()/getDate()` のローカル時刻ゲッター、`formatDate` は `Intl.DateTimeFormat("ja-JP")` の timeZone 未指定）、SSR（UTC）では同じ off-by-one を起こす構造です。`bill-detail-header.tsx`（提出日表示）等が該当。公開ページの表示にも影響し得るため、別PADでの追随修正を推奨します（本PRは報告のあった admin 一覧に絞っています）。

## 出典（Slack）
https://team-mirai-staff.slack.com/files/U0AM7S3JY0G/F0BG38A2J84/image.png

<!-- mirai-inu-session: sesn_01YBdgapLowjBwbbrKFghjXa -->