### PR TITLE
2026/07/08 23:40 本番反映

### DIFF
--- a/admin/src/features/bills/server/components/bill-list/bill-list.tsx
+++ b/admin/src/features/bills/server/components/bill-list/bill-list.tsx
@@ -137,7 +137,9 @@ function BillRow({ bill }: { bill: BillWithDietSession }) {
       </TableCell>
       <TableCell className="text-gray-600">
         {bill.submitted_date
-          ? new Date(bill.submitted_date).toLocaleDateString("ja-JP")
+          ? new Date(bill.submitted_date).toLocaleDateString("ja-JP", {
+              timeZone: "Asia/Tokyo",
+            })
           : "-"}
       </TableCell>
       <TableCell>


### PR DESCRIPTION
一覧の submitted_date 整形が toLocaleDateString("ja-JP") で timeZone を 指定していなかったため、UTC で動く server 上では JST 深夜として保存された
timestamptz が前日として表示されていた（編集フォームは Asia/Tokyo 指定済み
なので、編集ページ=6/30・一覧=6/29 の食い違いが起きていた）。
編集フォームと同じく timeZone: "Asia/Tokyo" を指定して揃える。