### PR TITLE
fix(web): 公開側の日付表示をJST固定にして前日ズレを修正

### DIFF
--- a/web/src/features/interview-report/shared/components/report-interviewee-card.tsx
+++ b/web/src/features/interview-report/shared/components/report-interviewee-card.tsx
@@ -5,7 +5,10 @@ import {
   userCategoryLabels,
 } from "@/features/user-topic-analysis/shared/utils/topic-category";
 import { cn } from "@/lib/utils";
-import { formatRoleDescriptionLines } from "../utils/format-utils";
+import {
+  formatAnsweredAt,
+  formatRoleDescriptionLines,
+} from "../utils/format-utils";
 
 /** stance を 期待/懸念 ラベルにマップ（neutral 等は表示しない）。 */
 function stanceLabel(stance: string | null): {
@@ -19,15 +22,6 @@ function stanceLabel(stance: string | null): {
     return { text: "懸念", className: "text-stance-against-light" };
   }
   return null;
-}
-
-/** 回答日時を "YYYY.M.D HH:mm" で表示する。 */
-function formatAnsweredAt(iso: string | null): string {
-  if (!iso) return "";
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return "";
-  const p = (n: number) => String(n).padStart(2, "0");
-  return `${d.getFullYear()}.${d.getMonth() + 1}.${d.getDate()} ${p(d.getHours())}:${p(d.getMinutes())}`;
 }
 
 /** セッションの所要時間（分）。算出できなければ null。 */

--- a/web/src/features/interview-report/shared/utils/format-utils.test.ts
+++ b/web/src/features/interview-report/shared/utils/format-utils.test.ts
@@ -1,5 +1,30 @@
 import { describe, expect, it } from "vitest";
-import { formatRoleDescriptionLines, parseOpinions } from "./format-utils";
+import {
+  formatAnsweredAt,
+  formatRoleDescriptionLines,
+  parseOpinions,
+} from "./format-utils";
+
+describe("formatAnsweredAt", () => {
+  it("null・不正な値は空文字", () => {
+    expect(formatAnsweredAt(null)).toBe("");
+    expect(formatAnsweredAt("not-a-date")).toBe("");
+  });
+
+  it("YYYY.M.D HH:mm 形式（日本時間）で整形する", () => {
+    // 2026-06-30T01:05:00Z = 2026-06-30T10:05:00+09:00
+    expect(formatAnsweredAt("2026-06-30T01:05:00.000Z")).toBe(
+      "2026.6.30 10:05"
+    );
+  });
+
+  it("実行環境のタイムゾーンによらずJSTの暦日・時刻で整形する", () => {
+    // 2026-06-29T15:30:00Z = 2026-06-30T00:30:00+09:00（UTC暦日では前日）
+    expect(formatAnsweredAt("2026-06-29T15:30:00.000Z")).toBe(
+      "2026.6.30 00:30"
+    );
+  });
+});
 
 describe("formatRoleDescriptionLines", () => {
   it("splits by newlines, trims, and adds bullet prefix", () => {

--- a/web/src/features/interview-report/shared/utils/format-utils.ts
+++ b/web/src/features/interview-report/shared/utils/format-utils.ts
@@ -17,6 +17,30 @@ export function formatRoleDescriptionLines(text: string): string[] {
   return lines.map((line) => (line.startsWith("・") ? line : `・${line}`));
 }
 
+const jstAnsweredAtFormat = new Intl.DateTimeFormat("ja-JP", {
+  year: "numeric",
+  month: "numeric",
+  day: "numeric",
+  hour: "2-digit",
+  minute: "2-digit",
+  hour12: false,
+  timeZone: "Asia/Tokyo",
+});
+
+/**
+ * 回答日時を "YYYY.M.D HH:mm"（日本時間）で整形する。
+ * null・不正な値のときは空文字を返す。
+ */
+export function formatAnsweredAt(iso: string | null): string {
+  if (!iso) return "";
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return "";
+  const parts = jstAnsweredAtFormat.formatToParts(date);
+  const get = (type: Intl.DateTimeFormatPartTypes) =>
+    parts.find((p) => p.type === type)?.value ?? "";
+  return `${get("year")}.${get("month")}.${get("day")} ${get("hour")}:${get("minute")}`;
+}
+
 export interface ParsedOpinion {
   title: string;
   content: string;

--- a/web/src/features/user-topic-analysis/shared/utils/format-opinion-date.test.ts
+++ b/web/src/features/user-topic-analysis/shared/utils/format-opinion-date.test.ts
@@ -26,4 +26,11 @@ describe("formatOpinionDate", () => {
     );
     expect(formatOpinionDate("2025-01-06T00:00:00.000Z", now)).toBe("2025.1.6");
   });
+
+  it("絶対表記は実行環境のタイムゾーンによらずJSTの暦日で表示する", () => {
+    // 2025-12-05T15:00:00Z = 2025-12-06T00:00:00+09:00（UTC暦日では前日）
+    expect(formatOpinionDate("2025-12-05T15:00:00.000Z", now)).toBe(
+      "2025.12.6"
+    );
+  });
 });

--- a/web/src/features/user-topic-analysis/shared/utils/format-opinion-date.ts
+++ b/web/src/features/user-topic-analysis/shared/utils/format-opinion-date.ts
@@ -1,8 +1,10 @@
+import { formatDateWithDots } from "@/lib/utils/date";
+
 /**
  * トピック詳細の意見カードに表示する日時を整形する純粋関数。
  *
  * - 30日以内: 相対表記（例: "2時間前" "1週間前"）
- * - それ以前: 絶対日付 "YYYY.M.D"
+ * - それ以前: 絶対日付 "YYYY.M.D"（日本時間）
  *
  * null/不正な値のときは空文字を返す。
  */
@@ -24,5 +26,5 @@ export function formatOpinionDate(
   if (diffHours < 24) return `${diffHours}時間前`;
   if (diffDays < 7) return `${diffDays}日前`;
   if (diffDays < 30) return `${Math.floor(diffDays / 7)}週間前`;
-  return `${date.getFullYear()}.${date.getMonth() + 1}.${date.getDate()}`;
+  return formatDateWithDots(dateString);
 }

--- a/web/src/lib/utils/date.test.ts
+++ b/web/src/lib/utils/date.test.ts
@@ -14,6 +14,15 @@ describe("formatDate", () => {
   it("formats an ISO datetime string", () => {
     expect(formatDate("2025-03-05T10:00:00Z")).toBe("2025年3月5日");
   });
+
+  it("formats a JST-midnight timestamptz as the JST date regardless of runtime timezone", () => {
+    // 2026-06-30T00:00:00+09:00 = 2026-06-29T15:00:00Z（UTC暦日では前日）
+    expect(formatDate("2026-06-30T00:00:00+09:00")).toBe("2026年6月30日");
+  });
+
+  it("returns an empty string for an invalid date string", () => {
+    expect(formatDate("not-a-date")).toBe("");
+  });
 });
 
 describe("formatDateWithDots", () => {
@@ -27,6 +36,15 @@ describe("formatDateWithDots", () => {
 
   it("formats double-digit month and day", () => {
     expect(formatDateWithDots("2025-12-31")).toBe("2025.12.31");
+  });
+
+  it("formats a JST-midnight timestamptz as the JST date regardless of runtime timezone", () => {
+    // 2026-06-30T00:00:00+09:00 = 2026-06-29T15:00:00Z（UTC暦日では前日）
+    expect(formatDateWithDots("2026-06-30T00:00:00+09:00")).toBe("2026.6.30");
+  });
+
+  it("returns an empty string for an invalid date string", () => {
+    expect(formatDateWithDots("not-a-date")).toBe("");
   });
 });
 

--- a/web/src/lib/utils/date.ts
+++ b/web/src/lib/utils/date.ts
@@ -1,10 +1,18 @@
+const jstLongDateFormat = new Intl.DateTimeFormat("ja-JP", {
+  year: "numeric",
+  month: "long",
+  day: "numeric",
+  timeZone: "Asia/Tokyo",
+});
+
+const jstNumericDateFormat = new Intl.DateTimeFormat("ja-JP", {
+  timeZone: "Asia/Tokyo",
+});
+
 export function formatDate(dateString: string): string {
   const date = new Date(dateString);
-  return new Intl.DateTimeFormat("ja-JP", {
-    year: "numeric",
-    month: "long",
-    day: "numeric",
-  }).format(date);
+  if (Number.isNaN(date.getTime())) return "";
+  return jstLongDateFormat.format(date);
 }
 
 /**
@@ -13,10 +21,8 @@ export function formatDate(dateString: string): string {
  */
 export function formatDateWithDots(dateString: string): string {
   const date = new Date(dateString);
-  const year = date.getFullYear();
-  const month = date.getMonth() + 1;
-  const day = date.getDate();
-  return `${year}.${month}.${day}`;
+  if (Number.isNaN(date.getTime())) return "";
+  return jstNumericDateFormat.format(date).replaceAll("/", ".");
 }
 
 /**


### PR DESCRIPTION
## 概要

admin側の修正（#909）に続き、公開側（web）の日付表示のタイムゾーン未固定による前日ズレを修正します。

DBの `timestamptz` にはJST深夜として日付が保存される（例: `2026-06-30T00:00:00+09:00` = UTCでは `2026-06-29T15:00:00Z`）ため、UTC稼働のサーバー（Vercel）でタイムゾーン未指定のまま整形すると前日の暦日で表示されていました。

### 修正箇所

1. **`web/src/lib/utils/date.ts`（本体）**: `formatDate` / `formatDateWithDots` を `timeZone: "Asia/Tokyo"` 固定に変更
   - 影響画面: 議案詳細ヘッダー・議案カードの「◯.◯.◯ 提出」、会期の開始日表示など（adminで 6/30 と入力した提出日が公開側で 6/29 と表示されていた）
2. **`report-interviewee-card.tsx` の `formatAnsweredAt`**: 同じ構造のバグ。ローカルTZゲッター使用のため、UTCサーバーではレポート詳細の「回答日時」が常時9時間ズレ（JST 0時〜9時開始のセッションは日付も前日）。`shared/utils/format-utils.ts` に純粋関数として切り出してJST固定
3. **`format-opinion-date.ts`**: 意見カードの30日超の絶対日付表示（`YYYY.M.D`）が同バグ。修正済みの `formatDateWithDots` に委譲して一元化

### あわせて実施

- `Intl.DateTimeFormat` インスタンスをモジュールレベルで共有し、一覧レンダリング時の毎回生成を排除
- 不正な日付文字列で `Intl.DateTimeFormat#format` が `RangeError` をthrowしないよう `Number.isNaN` ガードを追加（空文字を返す）

### スコープ外

- `diet_sessions` のDATE型文字列（`YYYY-MM-DD`）を負オフセットTZのブラウザで表示した場合の別クラスのズレ（軽微・国内利用では発生しない）
- `getJapanTime` のハック的実装（現状の利用箇所では正しく動作）

## 実行テスト記録

- `pnpm lint` / `pnpm typecheck` / `pnpm build` 通過
- `pnpm test` 全ワークスペース通過（webの16件のunhandled errorsはdevelopでも再現する既存の環境問題）
- 追加した回帰テスト（「UTC暦日では前日」となる境界ケース）は `TZ=UTC` / `TZ=Asia/Tokyo` の両環境で通過を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 回答日時や日付表示が日本時間（JST）基準で統一され、環境による表示ズレが起きにくくなりました。
  * 日付を「YYYY.M.D HH:mm」形式やドット区切りで見やすく表示するようになりました。

* **バグ修正**
  * 無効な日時が入力された場合に、不要な表示ではなく空文字を返すよう改善しました。
  * タイムゾーン差による日付のずれを修正しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->