### PR TITLE
feat(web): フッターに自主制作ガイドラインへの導線を追加

### DIFF
--- a/web/src/components/layouts/desktop-menu/links.tsx
+++ b/web/src/components/layouts/desktop-menu/links.tsx
@@ -30,6 +30,11 @@ const links: FooterLinkItem[] = [
     href: EXTERNAL_LINKS.FAQ,
     external: true,
   },
+  {
+    label: "自主制作ガイドライン",
+    href: EXTERNAL_LINKS.FORK_GUIDELINES_NOTE,
+    external: true,
+  },
 ];
 
 /**

--- a/web/src/components/layouts/footer/footer.config.ts
+++ b/web/src/components/layouts/footer/footer.config.ts
@@ -49,4 +49,9 @@ export const policyLinks: FooterPolicyLink[] = [
     label: "プライバシーポリシー",
     href: routes.privacy(),
   },
+  {
+    label: "自主制作ガイドライン",
+    href: EXTERNAL_LINKS.FORK_GUIDELINES_NOTE,
+    external: true,
+  },
 ];

--- a/web/src/config/external-links.ts
+++ b/web/src/config/external-links.ts
@@ -9,4 +9,5 @@ export const EXTERNAL_LINKS = {
   TERMS: "https://team-mir.ai/terms",
   PRIVACY: "https://team-mir.ai/privacy",
   FAQ: "https://team-mirai.notion.site/FAQ-28cf6f56bae180bd84e7f7ae80f806a1",
+  FORK_GUIDELINES_NOTE: "https://note.com/team_mirai_jp/n/nc59ec347e8c7",
 } as const;


### PR DESCRIPTION
## 概要

みらい議会の地方版を自主制作する方向けの[運用ガイドライン（note記事）](https://note.com/team_mirai_jp/n/nc59ec347e8c7)への導線を追加します。

- フッター（`footer.config.ts` の policyLinks）に「自主制作ガイドライン」リンクを追加
- デスクトップメニューのフッターリンク（`desktop-menu/links.tsx`）にも同リンクを追加
  - ※ `DesktopMenu` は現状どのページからも使用されていないコンポーネントですが、将来有効化されたときにリンク構成が揃うよう追加しています
- リンク先は `EXTERNAL_LINKS.FORK_GUIDELINES_NOTE` として定数化

## 背景

自主制作したものがチームみらい本家のものと誤認されないようにするためのガイドラインが公開されたが、noteを見に行かないと見つけられないため、サイト内に導線を設ける依頼があった。

Closes GIKAI-358

## スクリーンショット

| モバイル (390px) | デスクトップ (1600px) |
|:---:|:---:|
| <img src="https://pub-d6de2fb179d948d18c6b1ed89fcf1061.r2.dev/pr-913/footer-mobile.png" width="300" /> | <img src="https://pub-d6de2fb179d948d18c6b1ed89fcf1061.r2.dev/pr-913/footer-desktop.png" width="450" /> |

## Test plan

- [x] `pnpm lint` / `pnpm typecheck` 通過
- [x] フッターに「自主制作ガイドライン」が表示されること（モバイル/デスクトップともスクリーンショットで確認）
- [x] `external: true` により note記事が新規タブ（`noreferrer`）で開く実装であること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * フッターメニューに「自主制作ガイドライン」へのリンクを追加しました。
  * リンクは外部ページとして新しいタブで開きます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
