### PR TITLE
AIモデル選択肢にGPT-5.6 (Sol/Terra/Luna) と Claude Sonnet 5 を追加

### DIFF
--- a/admin/src/features/interview-config/shared/utils/chat-model-options.ts
+++ b/admin/src/features/interview-config/shared/utils/chat-model-options.ts
@@ -29,6 +29,9 @@ const OPENAI_MODELS = [
   { value: "openai/gpt-5.1-instant", label: "GPT-5.1 Instant" },
   { value: "openai/gpt-5.1-thinking", label: "GPT-5.1 Thinking" },
   { value: "openai/gpt-5.2", label: "GPT-5.2" },
+  { value: "openai/gpt-5.6-sol", label: "GPT-5.6 Sol" },
+  { value: "openai/gpt-5.6-terra", label: "GPT-5.6 Terra" },
+  { value: "openai/gpt-5.6-luna", label: "GPT-5.6 Luna" },
 ] as const;
 
 const GOOGLE_MODELS = [
@@ -42,6 +45,7 @@ const GOOGLE_MODELS = [
 const ANTHROPIC_MODELS = [
   { value: "anthropic/claude-haiku-4.5", label: "Claude Haiku 4.5" },
   { value: "anthropic/claude-sonnet-4.6", label: "Claude Sonnet 4.6" },
+  { value: "anthropic/claude-sonnet-5", label: "Claude Sonnet 5" },
   { value: "anthropic/claude-opus-4.6", label: "Claude Opus 4.6" },
 ] as const;
 

--- a/admin/src/features/interview-config/shared/utils/estimate-interview-cost.test.ts
+++ b/admin/src/features/interview-config/shared/utils/estimate-interview-cost.test.ts
@@ -29,6 +29,38 @@ describe("estimateInterviewCostUsd", () => {
     expect(cost).toBeCloseTo(0.0515, 4);
   });
 
+  it("GPT-5.6 Solの推定コストを正しく算出する", () => {
+    // input: 5 * 85000 / 1M = 0.425
+    // output: 30 * 3000 / 1M = 0.09
+    // total: 0.515
+    const cost = estimateInterviewCostUsd("openai/gpt-5.6-sol");
+    expect(cost).toBeCloseTo(0.515, 4);
+  });
+
+  it("GPT-5.6 Terraの推定コストを正しく算出する", () => {
+    // input: 2.5 * 85000 / 1M = 0.2125
+    // output: 15 * 3000 / 1M = 0.045
+    // total: 0.2575
+    const cost = estimateInterviewCostUsd("openai/gpt-5.6-terra");
+    expect(cost).toBeCloseTo(0.2575, 4);
+  });
+
+  it("GPT-5.6 Lunaの推定コストを正しく算出する", () => {
+    // input: 1 * 85000 / 1M = 0.085
+    // output: 6 * 3000 / 1M = 0.018
+    // total: 0.103
+    const cost = estimateInterviewCostUsd("openai/gpt-5.6-luna");
+    expect(cost).toBeCloseTo(0.103, 4);
+  });
+
+  it("Claude Sonnet 5の推定コストを正しく算出する", () => {
+    // input: 3 * 85000 / 1M = 0.255
+    // output: 15 * 3000 / 1M = 0.045
+    // total: 0.30
+    const cost = estimateInterviewCostUsd("anthropic/claude-sonnet-5");
+    expect(cost).toBeCloseTo(0.3, 4);
+  });
+
   it("不明なモデルに対してnullを返す", () => {
     expect(estimateInterviewCostUsd("unknown/model")).toBeNull();
   });

--- a/admin/src/features/interview-config/shared/utils/estimate-interview-cost.ts
+++ b/admin/src/features/interview-config/shared/utils/estimate-interview-cost.ts
@@ -29,6 +29,9 @@ const MODEL_PRICING: Record<string, ModelPricing> = {
   "openai/gpt-5.1-instant": { inputPerMillion: 1.25, outputPerMillion: 10 },
   "openai/gpt-5.1-thinking": { inputPerMillion: 1.25, outputPerMillion: 10 },
   "openai/gpt-5.2": { inputPerMillion: 1.75, outputPerMillion: 14 },
+  "openai/gpt-5.6-sol": { inputPerMillion: 5, outputPerMillion: 30 },
+  "openai/gpt-5.6-terra": { inputPerMillion: 2.5, outputPerMillion: 15 },
+  "openai/gpt-5.6-luna": { inputPerMillion: 1, outputPerMillion: 6 },
   // --- Google ---
   "google/gemini-3-flash": { inputPerMillion: 0.5, outputPerMillion: 3 },
   "google/gemini-3.1-pro-preview": {
@@ -38,6 +41,7 @@ const MODEL_PRICING: Record<string, ModelPricing> = {
   // --- Anthropic ---
   "anthropic/claude-haiku-4.5": { inputPerMillion: 1, outputPerMillion: 5 },
   "anthropic/claude-sonnet-4.6": { inputPerMillion: 3, outputPerMillion: 15 },
+  "anthropic/claude-sonnet-5": { inputPerMillion: 3, outputPerMillion: 15 },
   "anthropic/claude-opus-4.6": { inputPerMillion: 5, outputPerMillion: 25 },
 };
 

--- a/packages/shared/src/ai/models.ts
+++ b/packages/shared/src/ai/models.ts
@@ -17,6 +17,9 @@ export const AI_MODELS = {
   gpt5_1_instant: "openai/gpt-5.1-instant",
   gpt5_1_thinking: "openai/gpt-5.1-thinking",
   gpt5_2: "openai/gpt-5.2",
+  gpt5_6_sol: "openai/gpt-5.6-sol",
+  gpt5_6_terra: "openai/gpt-5.6-terra",
+  gpt5_6_luna: "openai/gpt-5.6-luna",
   // --- Google ---
   gemini3_flash: "google/gemini-3-flash",
   gemini3_flash_preview: "google/gemini-3-flash-preview",
@@ -25,6 +28,7 @@ export const AI_MODELS = {
   // --- Anthropic ---
   claude_haiku_4_5: "anthropic/claude-haiku-4.5",
   claude_sonnet_4_6: "anthropic/claude-sonnet-4.6",
+  claude_sonnet_5: "anthropic/claude-sonnet-5",
   claude_opus_4_6: "anthropic/claude-opus-4.6",
 } as const;
 

--- a/web/src/lib/ai/calculate-ai-cost.test.ts
+++ b/web/src/lib/ai/calculate-ai-cost.test.ts
@@ -38,6 +38,18 @@ describe("calculateUsageCostUsd", () => {
 
     // GPT-5.2: $1.75 input + $14.00 output = $15.75
     expect(calculateUsageCostUsd(AI_MODELS.gpt5_2, usage)).toBeCloseTo(15.75);
+    // GPT-5.6 Sol: $5.00 input + $30.00 output = $35.00
+    expect(calculateUsageCostUsd(AI_MODELS.gpt5_6_sol, usage)).toBeCloseTo(35);
+    // GPT-5.6 Terra: $2.50 input + $15.00 output = $17.50
+    expect(calculateUsageCostUsd(AI_MODELS.gpt5_6_terra, usage)).toBeCloseTo(
+      17.5
+    );
+    // GPT-5.6 Luna: $1.00 input + $6.00 output = $7.00
+    expect(calculateUsageCostUsd(AI_MODELS.gpt5_6_luna, usage)).toBeCloseTo(7);
+    // Claude Sonnet 5: $3.00 input + $15.00 output = $18.00
+    expect(calculateUsageCostUsd(AI_MODELS.claude_sonnet_5, usage)).toBeCloseTo(
+      18
+    );
     // Claude Sonnet 4.6: $3.00 input + $15.00 output = $18.00
     expect(
       calculateUsageCostUsd(AI_MODELS.claude_sonnet_4_6, usage)

--- a/web/src/lib/ai/calculate-ai-cost.ts
+++ b/web/src/lib/ai/calculate-ai-cost.ts
@@ -70,6 +70,18 @@ export const modelPricing: Record<string, ModelPricing> = {
     inputTokensPerMillionUsd: 1.75,
     outputTokensPerMillionUsd: 14,
   },
+  [AI_MODELS.gpt5_6_sol]: {
+    inputTokensPerMillionUsd: 5,
+    outputTokensPerMillionUsd: 30,
+  },
+  [AI_MODELS.gpt5_6_terra]: {
+    inputTokensPerMillionUsd: 2.5,
+    outputTokensPerMillionUsd: 15,
+  },
+  [AI_MODELS.gpt5_6_luna]: {
+    inputTokensPerMillionUsd: 1,
+    outputTokensPerMillionUsd: 6,
+  },
   // --- Google ---
   [AI_MODELS.gemini3_flash]: {
     inputTokensPerMillionUsd: 0.5,
@@ -89,6 +101,10 @@ export const modelPricing: Record<string, ModelPricing> = {
     outputTokensPerMillionUsd: 5,
   },
   [AI_MODELS.claude_sonnet_4_6]: {
+    inputTokensPerMillionUsd: 3,
+    outputTokensPerMillionUsd: 15,
+  },
+  [AI_MODELS.claude_sonnet_5]: {
     inputTokensPerMillionUsd: 3,
     outputTokensPerMillionUsd: 15,
   },


### PR DESCRIPTION
## 概要

OpenAIのGPT-5.6ファミリー（[発表](https://openai.com/index/previewing-gpt-5-6-sol/)）とAnthropicのClaude Sonnet 5を、インタビューチャットのモデル選択肢に追加します。

### 追加モデルと価格（USD / 1Mトークン）

| モデル | Gateway ID | 入力 | 出力 |
|---|---|---|---|
| GPT-5.6 Sol | `openai/gpt-5.6-sol` | $5.00 | $30.00 |
| GPT-5.6 Terra | `openai/gpt-5.6-terra` | $2.50 | $15.00 |
| GPT-5.6 Luna | `openai/gpt-5.6-luna` | $1.00 | $6.00 |
| Claude Sonnet 5 | `anthropic/claude-sonnet-5` | $3.00 | $15.00 |

モデルIDはVercel AI Gatewayのモデル一覧に掲載されている表記に合わせています。Claude Sonnet 5は2026-08-31まで導入価格（$2/$10）が適用されますが、価格テーブルには恒久的な定価（$3/$15）を採用しています。

## 変更内容

- `packages/shared/src/ai/models.ts`: `AI_MODELS` に4モデルを追加
- `web/src/lib/ai/calculate-ai-cost.ts`: `modelPricing` に価格を追加
- `admin/.../estimate-interview-cost.ts`: `MODEL_PRICING` に価格を追加
- `admin/.../chat-model-options.ts`: モデル選択UIの選択肢に追加
- 上記に対応する回帰テストを `calculate-ai-cost.test.ts` / `estimate-interview-cost.test.ts` に追加

## 実行テスト記録

- `pnpm lint` / `pnpm typecheck` / `pnpm build` 通過
- `pnpm --filter admin test`（450 passed）/ `pnpm --filter @mirai-gikai/shared test`（74 passed）/ `pnpm --filter web test`（758 passed ※既存のhtml-encoding-sniffer ESMエラー16件はdevelopでも再現する環境問題）
- セルフレビュー: /simplify（4観点クリーン）、Codex review（指摘なし）、テストガイドラインチェック（指摘1件→admin側の回帰テスト追加で対応済み）、コード品質チェック（軽微のみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - OpenAIの新しい3モデルとAnthropicのClaude Sonnet 5を、チャットモデルの選択肢に追加しました。
  - 追加モデルが有効なモデルとして認識され、面接設定で選択できるようになりました。

- **改善**
  - 追加モデルを利用した場合も、入力・出力トークン数に基づく推定費用を正しく表示できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->