### PR TITLE
インタビュー設定: 質問別の回答者数を集計してレポートページに表示

### DIFF
--- a/admin/src/app/(protected)/bills/[id]/interview/[configId]/reports/page.tsx
+++ b/admin/src/app/(protected)/bills/[id]/interview/[configId]/reports/page.tsx
@@ -8,12 +8,14 @@ import { BatchModerationButton } from "@/features/interview-reports/client/compo
 import { BatchPublishButton } from "@/features/interview-reports/client/components/batch-publish-button";
 import { CopyTsvButton } from "@/features/interview-reports/client/components/copy-tsv-button";
 import { InterviewStatistics } from "@/features/interview-reports/server/components/interview-statistics";
+import { QuestionAnswerCounts } from "@/features/interview-reports/server/components/question-answer-counts";
 import { SessionList } from "@/features/interview-reports/server/components/session-list";
 import {
   getInterviewSessions,
   getInterviewSessionsCount,
 } from "@/features/interview-reports/server/loaders/get-interview-sessions";
 import { getInterviewStatistics } from "@/features/interview-reports/server/loaders/get-interview-statistics";
+import { getQuestionAnswerCounts } from "@/features/interview-reports/server/loaders/get-question-answer-counts";
 import { parseSessionFilterParams } from "@/features/interview-reports/shared/utils/parse-session-filter-params";
 import { parseSessionSortParams } from "@/features/interview-reports/shared/utils/parse-session-sort-params";
 import { routes } from "@/lib/routes";
@@ -52,12 +54,14 @@ export default async function ReportsPage({
     moderation
   );
 
-  const [bill, sessions, totalCount, statistics] = await Promise.all([
-    getBillById(id),
-    getInterviewSessions(configId, currentPage, sortConfig, filterConfig),
-    getInterviewSessionsCount(configId, filterConfig),
-    getInterviewStatistics(configId),
-  ]);
+  const [bill, sessions, totalCount, statistics, questionAnswerCounts] =
+    await Promise.all([
+      getBillById(id),
+      getInterviewSessions(configId, currentPage, sortConfig, filterConfig),
+      getInterviewSessionsCount(configId, filterConfig),
+      getInterviewStatistics(configId),
+      getQuestionAnswerCounts(configId),
+    ]);
 
   if (!bill) {
     notFound();
@@ -92,6 +96,12 @@ export default async function ReportsPage({
       {statistics && (
         <div className="mb-6">
           <InterviewStatistics statistics={statistics} />
+        </div>
+      )}
+
+      {questionAnswerCounts.length > 0 && (
+        <div className="mb-6">
+          <QuestionAnswerCounts counts={questionAnswerCounts} />
         </div>
       )}
 

--- a/admin/src/features/interview-reports/server/components/question-answer-counts.tsx
+++ b/admin/src/features/interview-reports/server/components/question-answer-counts.tsx
@@ -1,0 +1,49 @@
+import "server-only";
+
+import { Card, CardContent } from "@/components/ui/card";
+import type { QuestionAnswerCount } from "../../shared/types";
+import { withAnswerBarPercents } from "../../shared/utils/calc-answer-bar-percents";
+
+interface QuestionAnswerCountsProps {
+  counts: QuestionAnswerCount[];
+}
+
+export function QuestionAnswerCounts({ counts }: QuestionAnswerCountsProps) {
+  const rows = withAnswerBarPercents(counts);
+
+  return (
+    <Card className="py-4">
+      <CardContent className="space-y-3">
+        <p className="text-sm font-semibold">質問別回答者数</p>
+        <div className="space-y-1.5">
+          {rows.map((count) => (
+            <div
+              key={count.questionId}
+              className="flex items-center gap-2 text-sm"
+            >
+              <span className="w-8 shrink-0 text-muted-foreground">
+                Q{count.questionOrder}
+              </span>
+              <span
+                className="min-w-0 flex-1 truncate text-muted-foreground"
+                title={count.question}
+              >
+                {count.question}
+              </span>
+              <div className="h-2 w-40 shrink-0 overflow-hidden rounded-full bg-muted">
+                <div
+                  className="h-full rounded-full bg-primary"
+                  style={{ width: `${count.barPercent}%` }}
+                />
+              </div>
+              <span className="w-36 shrink-0 text-right text-muted-foreground">
+                回答 {count.answeredSessionCount}人 / 提示{" "}
+                {count.askedSessionCount}人
+              </span>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/admin/src/features/interview-reports/server/loaders/get-question-answer-counts.ts
+++ b/admin/src/features/interview-reports/server/loaders/get-question-answer-counts.ts
@@ -1,0 +1,17 @@
+import "server-only";
+
+import type { QuestionAnswerCount } from "../../shared/types";
+import { mapQuestionAnswerCounts } from "../../shared/utils/map-question-answer-counts";
+import { findQuestionAnswerCounts } from "../repositories/interview-report-repository";
+
+export async function getQuestionAnswerCounts(
+  configId: string
+): Promise<QuestionAnswerCount[]> {
+  try {
+    const raw = await findQuestionAnswerCounts(configId);
+    return mapQuestionAnswerCounts(raw);
+  } catch (error) {
+    console.error("Failed to fetch question answer counts:", error);
+    return [];
+  }
+}

--- a/admin/src/features/interview-reports/server/repositories/interview-report-repository.ts
+++ b/admin/src/features/interview-reports/server/repositories/interview-report-repository.ts
@@ -490,6 +490,19 @@ export async function findInterviewStatistics(configId: string) {
   return data?.[0] ?? null;
 }
 
+export async function findQuestionAnswerCounts(configId: string) {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase.rpc("get_question_answer_counts", {
+    p_config_id: configId,
+  });
+
+  if (error) {
+    throw new Error(`Failed to fetch question answer counts: ${error.message}`);
+  }
+
+  return data ?? [];
+}
+
 export async function updateReportVisibility(
   reportId: string,
   isPublic: boolean

--- a/admin/src/features/interview-reports/shared/types/index.ts
+++ b/admin/src/features/interview-reports/shared/types/index.ts
@@ -122,6 +122,14 @@ export type InterviewStatistics = {
   avgCostUsd: number;
 };
 
+export type QuestionAnswerCount = {
+  questionId: string;
+  question: string;
+  questionOrder: number;
+  askedSessionCount: number;
+  answeredSessionCount: number;
+};
+
 // ソート関連の型定義
 export type SessionSortField =
   | "started_at"

--- a/admin/src/features/interview-reports/shared/utils/calc-answer-bar-percents.test.ts
+++ b/admin/src/features/interview-reports/shared/utils/calc-answer-bar-percents.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import type { QuestionAnswerCount } from "../types";
+import { withAnswerBarPercents } from "./calc-answer-bar-percents";
+
+function count(
+  askedSessionCount: number,
+  answeredSessionCount: number
+): QuestionAnswerCount {
+  return {
+    questionId: "q",
+    question: "質問",
+    questionOrder: 1,
+    askedSessionCount,
+    answeredSessionCount,
+  };
+}
+
+describe("withAnswerBarPercents", () => {
+  it("全質問中の最大提示数を分母として回答数の割合を付与する", () => {
+    // maxAsked = 10: 各行の asked ではなく全体の最大値で正規化する
+    const result = withAnswerBarPercents([count(10, 8), count(4, 3)]);
+    expect(result.map((r) => r.barPercent)).toEqual([80, 30]);
+    // 元のフィールドは保持される
+    expect(result[0]).toMatchObject(count(10, 8));
+  });
+
+  it("提示数が0でもゼロ除算しない", () => {
+    expect(withAnswerBarPercents([count(0, 0)])[0].barPercent).toBe(0);
+  });
+
+  it("空配列は空配列を返す", () => {
+    expect(withAnswerBarPercents([])).toEqual([]);
+  });
+});

--- a/admin/src/features/interview-reports/shared/utils/calc-answer-bar-percents.ts
+++ b/admin/src/features/interview-reports/shared/utils/calc-answer-bar-percents.ts
@@ -1,0 +1,14 @@
+import type { QuestionAnswerCount } from "../types";
+
+// バーの長さは全質問中の最大提示セッション数を分母にする。
+// 各行の「提示数に対する回答率」ではなく、質問間の回答者数の
+// ファネル（先頭の質問からどれだけ離脱したか）を比較するための正規化。
+export function withAnswerBarPercents(
+  counts: QuestionAnswerCount[]
+): (QuestionAnswerCount & { barPercent: number })[] {
+  const maxAsked = Math.max(...counts.map((c) => c.askedSessionCount), 1);
+  return counts.map((c) => ({
+    ...c,
+    barPercent: Math.round((c.answeredSessionCount / maxAsked) * 100),
+  }));
+}

--- a/admin/src/features/interview-reports/shared/utils/map-question-answer-counts.test.ts
+++ b/admin/src/features/interview-reports/shared/utils/map-question-answer-counts.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { mapQuestionAnswerCounts } from "./map-question-answer-counts";
+
+describe("mapQuestionAnswerCounts", () => {
+  it("snake_caseの行をcamelCaseに変換する", () => {
+    const result = mapQuestionAnswerCounts([
+      {
+        question_id: "q1",
+        question: "質問1",
+        question_order: 1,
+        asked_session_count: 10,
+        answered_session_count: 8,
+      },
+      {
+        question_id: "q2",
+        question: "質問2",
+        question_order: 2,
+        asked_session_count: 5,
+        answered_session_count: 0,
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        questionId: "q1",
+        question: "質問1",
+        questionOrder: 1,
+        askedSessionCount: 10,
+        answeredSessionCount: 8,
+      },
+      {
+        questionId: "q2",
+        question: "質問2",
+        questionOrder: 2,
+        askedSessionCount: 5,
+        answeredSessionCount: 0,
+      },
+    ]);
+  });
+
+  it("空配列は空配列を返す", () => {
+    expect(mapQuestionAnswerCounts([])).toEqual([]);
+  });
+});

--- a/admin/src/features/interview-reports/shared/utils/map-question-answer-counts.ts
+++ b/admin/src/features/interview-reports/shared/utils/map-question-answer-counts.ts
@@ -1,0 +1,17 @@
+import type { Database } from "@mirai-gikai/supabase";
+import type { QuestionAnswerCount } from "../types";
+
+type RawQuestionAnswerCount =
+  Database["public"]["Functions"]["get_question_answer_counts"]["Returns"][number];
+
+export function mapQuestionAnswerCounts(
+  rows: RawQuestionAnswerCount[]
+): QuestionAnswerCount[] {
+  return rows.map((row) => ({
+    questionId: row.question_id,
+    question: row.question,
+    questionOrder: row.question_order,
+    askedSessionCount: row.asked_session_count,
+    answeredSessionCount: row.answered_session_count,
+  }));
+}

--- a/packages/supabase/types/supabase.types.ts
+++ b/packages/supabase/types/supabase.types.ts
@@ -1120,6 +1120,10 @@ export type Database = {
           session_count: number
         }[]
       }
+      extract_assistant_question_id: {
+        Args: { content: string }
+        Returns: string
+      }
       find_public_reports_by_bill_id_ordered_by_reactions: {
         Args: {
           p_bill_id: string
@@ -1239,6 +1243,16 @@ export type Database = {
           total_cost_usd: number
           total_duration_seconds: number
           total_sessions: number
+        }[]
+      }
+      get_question_answer_counts: {
+        Args: { p_config_id: string }
+        Returns: {
+          answered_session_count: number
+          asked_session_count: number
+          question: string
+          question_id: string
+          question_order: number
         }[]
       }
       is_admin: { Args: never; Returns: boolean }

--- a/supabase/migrations/20260710100000_add_get_question_answer_counts.sql
+++ b/supabase/migrations/20260710100000_add_get_question_answer_counts.sql
@@ -7,6 +7,8 @@
 -- legacy plain-text messages, non-object JSON, or non-UUID ids.
 -- Keep in sync with the TypeScript parser:
 -- web/src/features/interview-session/shared/message-utils.ts (parseMessageContent)
+-- Requires PostgreSQL 16+ (pg_input_is_valid). This project runs PG 17
+-- (see supabase/config.toml major_version).
 CREATE OR REPLACE FUNCTION extract_assistant_question_id(content TEXT)
 RETURNS UUID AS $$
 DECLARE

--- a/supabase/migrations/20260710100000_add_get_question_answer_counts.sql
+++ b/supabase/migrations/20260710100000_add_get_question_answer_counts.sql
@@ -1,0 +1,89 @@
+-- Compute per-question respondent counts for a given interview config
+-- Used for admin interview report list page statistics display
+
+-- Extract the interview_questions.id an assistant message asked.
+-- An assistant message's content is a JSON string carrying the asked
+-- question id as "question_id" (legacy: "questionId"). Returns NULL for
+-- legacy plain-text messages, non-object JSON, or non-UUID ids.
+-- Keep in sync with the TypeScript parser:
+-- web/src/features/interview-session/shared/message-utils.ts (parseMessageContent)
+CREATE OR REPLACE FUNCTION extract_assistant_question_id(content TEXT)
+RETURNS UUID AS $$
+DECLARE
+  parsed JSONB;
+  question_id_text TEXT;
+BEGIN
+  IF content IS NULL OR NOT pg_input_is_valid(content, 'jsonb') THEN
+    RETURN NULL;
+  END IF;
+
+  parsed := content::jsonb;
+  IF jsonb_typeof(parsed) <> 'object' THEN
+    RETURN NULL;
+  END IF;
+
+  question_id_text := COALESCE(
+    parsed ->> 'question_id',
+    parsed ->> 'questionId'
+  );
+  IF question_id_text IS NULL
+    OR NOT pg_input_is_valid(question_id_text, 'uuid') THEN
+    RETURN NULL;
+  END IF;
+
+  RETURN question_id_text::uuid;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+-- A question counts as "asked" in a session when an assistant message
+-- referencing it exists, and as "answered" when a user message exists
+-- after that assistant message.
+CREATE OR REPLACE FUNCTION get_question_answer_counts(p_config_id UUID)
+RETURNS TABLE (
+  question_id UUID,
+  question TEXT,
+  question_order INTEGER,
+  asked_session_count BIGINT,
+  answered_session_count BIGINT
+) AS $$
+BEGIN
+  RETURN QUERY
+  WITH asked AS (
+    SELECT t.session_id, t.created_at, t.qid
+    FROM (
+      SELECT
+        m.interview_session_id AS session_id,
+        m.created_at,
+        extract_assistant_question_id(m.content) AS qid
+      FROM interview_messages m
+      JOIN interview_sessions s ON s.id = m.interview_session_id
+      WHERE s.interview_config_id = p_config_id
+        AND m.role = 'assistant'
+    ) t
+    WHERE t.qid IS NOT NULL
+  ),
+  last_user_message AS (
+    SELECT
+      m.interview_session_id AS session_id,
+      MAX(m.created_at) AS last_user_at
+    FROM interview_messages m
+    JOIN interview_sessions s ON s.id = m.interview_session_id
+    WHERE s.interview_config_id = p_config_id
+      AND m.role = 'user'
+    GROUP BY m.interview_session_id
+  )
+  SELECT
+    q.id AS question_id,
+    q.question,
+    q.question_order,
+    COUNT(DISTINCT a.session_id) AS asked_session_count,
+    COUNT(DISTINCT a.session_id) FILTER (WHERE lu.last_user_at > a.created_at)
+      AS answered_session_count
+  FROM interview_questions q
+  LEFT JOIN asked a ON a.qid = q.id
+  LEFT JOIN last_user_message lu ON lu.session_id = a.session_id
+  WHERE q.interview_config_id = p_config_id
+  GROUP BY q.id, q.question, q.question_order
+  ORDER BY q.question_order;
+END;
+$$ LANGUAGE plpgsql STABLE;

--- a/tests/supabase/db-function/get-question-answer-counts.test.ts
+++ b/tests/supabase/db-function/get-question-answer-counts.test.ts
@@ -1,0 +1,285 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  adminClient,
+  cleanupTestBill,
+  cleanupTestUser,
+  createTestBill,
+  createTestUser,
+  type TestUser,
+} from "../utils";
+
+async function createTestInterviewConfig(
+  billId: string,
+  status: "public" | "closed" = "public"
+) {
+  const { data, error } = await adminClient
+    .from("interview_configs")
+    .insert({
+      bill_id: billId,
+      status,
+      name: `テスト設定 ${Date.now()}`,
+    })
+    .select()
+    .single();
+  if (error) throw new Error(`interview_config 作成失敗: ${error.message}`);
+  return data;
+}
+
+async function createTestQuestion(
+  configId: string,
+  question: string,
+  questionOrder: number
+) {
+  const { data, error } = await adminClient
+    .from("interview_questions")
+    .insert({
+      interview_config_id: configId,
+      question,
+      question_order: questionOrder,
+    })
+    .select()
+    .single();
+  if (error) throw new Error(`interview_question 作成失敗: ${error.message}`);
+  return data;
+}
+
+async function createTestSession(configId: string, userId: string) {
+  const { data, error } = await adminClient
+    .from("interview_sessions")
+    .insert({
+      interview_config_id: configId,
+      user_id: userId,
+      started_at: new Date().toISOString(),
+    })
+    .select()
+    .single();
+  if (error) throw new Error(`interview_session 作成失敗: ${error.message}`);
+  return data;
+}
+
+async function insertMessage(
+  sessionId: string,
+  role: "assistant" | "user",
+  content: string,
+  createdAt: string
+) {
+  const { error } = await adminClient.from("interview_messages").insert({
+    interview_session_id: sessionId,
+    role,
+    content,
+    created_at: createdAt,
+  });
+  if (error) throw new Error(`interview_messages 作成失敗: ${error.message}`);
+}
+
+function assistantContent(questionId: string) {
+  return JSON.stringify({ text: "質問です", question_id: questionId });
+}
+
+const base = new Date("2026-06-01T00:00:00.000Z").getTime();
+const iso = (offsetSec: number) =>
+  new Date(base + offsetSec * 1000).toISOString();
+
+describe("get_question_answer_counts() 関数", () => {
+  let testUser: TestUser;
+  const billIds: string[] = [];
+
+  beforeEach(async () => {
+    testUser = await createTestUser();
+  });
+
+  afterEach(async () => {
+    for (const billId of billIds) {
+      await cleanupTestBill(billId);
+    }
+    billIds.length = 0;
+    await cleanupTestUser(testUser.id);
+  });
+
+  it("質問ごとの提示セッション数と回答セッション数を集計する", async () => {
+    const bill = await createTestBill();
+    billIds.push(bill.id);
+    const config = await createTestInterviewConfig(bill.id);
+    const q1 = await createTestQuestion(config.id, "質問1", 1);
+    const q2 = await createTestQuestion(config.id, "質問2", 2);
+
+    // セッション1: q1提示→回答あり、q2提示→回答なし（離脱）
+    const s1 = await createTestSession(config.id, testUser.id);
+    await insertMessage(s1.id, "assistant", assistantContent(q1.id), iso(0));
+    await insertMessage(s1.id, "user", "回答1", iso(10));
+    await insertMessage(s1.id, "assistant", assistantContent(q2.id), iso(20));
+
+    // セッション2: q1提示→回答あり
+    const s2 = await createTestSession(config.id, testUser.id);
+    await insertMessage(s2.id, "assistant", assistantContent(q1.id), iso(0));
+    await insertMessage(s2.id, "user", "回答2", iso(10));
+
+    const { data, error } = await adminClient.rpc(
+      "get_question_answer_counts",
+      { p_config_id: config.id }
+    );
+
+    expect(error).toBeNull();
+    expect(data).toHaveLength(2);
+    expect(data?.[0]).toMatchObject({
+      question_id: q1.id,
+      question: "質問1",
+      question_order: 1,
+      asked_session_count: 2,
+      answered_session_count: 2,
+    });
+    expect(data?.[1]).toMatchObject({
+      question_id: q2.id,
+      question: "質問2",
+      question_order: 2,
+      asked_session_count: 1,
+      answered_session_count: 0,
+    });
+  });
+
+  it("同一セッションで同じ質問が複数回提示されても1セッションと数える", async () => {
+    const bill = await createTestBill();
+    billIds.push(bill.id);
+    const config = await createTestInterviewConfig(bill.id);
+    const q1 = await createTestQuestion(config.id, "質問1", 1);
+
+    const s1 = await createTestSession(config.id, testUser.id);
+    await insertMessage(s1.id, "assistant", assistantContent(q1.id), iso(0));
+    await insertMessage(s1.id, "user", "回答", iso(10));
+    await insertMessage(s1.id, "assistant", assistantContent(q1.id), iso(20));
+    await insertMessage(s1.id, "user", "追加回答", iso(30));
+
+    const { data, error } = await adminClient.rpc(
+      "get_question_answer_counts",
+      { p_config_id: config.id }
+    );
+
+    expect(error).toBeNull();
+    expect(data?.[0].asked_session_count).toBe(1);
+    expect(data?.[0].answered_session_count).toBe(1);
+  });
+
+  it("legacyのcamelCaseキー（questionId）も集計する", async () => {
+    const bill = await createTestBill();
+    billIds.push(bill.id);
+    const config = await createTestInterviewConfig(bill.id);
+    const q1 = await createTestQuestion(config.id, "質問1", 1);
+
+    const s1 = await createTestSession(config.id, testUser.id);
+    await insertMessage(
+      s1.id,
+      "assistant",
+      JSON.stringify({ text: "質問です", questionId: q1.id }),
+      iso(0)
+    );
+    await insertMessage(s1.id, "user", "回答", iso(10));
+
+    const { data, error } = await adminClient.rpc(
+      "get_question_answer_counts",
+      { p_config_id: config.id }
+    );
+
+    expect(error).toBeNull();
+    expect(data?.[0].asked_session_count).toBe(1);
+    expect(data?.[0].answered_session_count).toBe(1);
+  });
+
+  it("JSONでないメッセージや不正なquestion_idはスキップする", async () => {
+    const bill = await createTestBill();
+    billIds.push(bill.id);
+    const config = await createTestInterviewConfig(bill.id);
+    const q1 = await createTestQuestion(config.id, "質問1", 1);
+
+    const s1 = await createTestSession(config.id, testUser.id);
+    // 非JSONのプレーンテキスト
+    await insertMessage(s1.id, "assistant", "プレーンテキストの質問", iso(0));
+    // JSONだがオブジェクトでない
+    await insertMessage(s1.id, "assistant", '"文字列JSON"', iso(10));
+    // question_idがUUIDでない
+    await insertMessage(
+      s1.id,
+      "assistant",
+      JSON.stringify({ text: "質問", question_id: "not-a-uuid" }),
+      iso(20)
+    );
+    // question_idなし
+    await insertMessage(
+      s1.id,
+      "assistant",
+      JSON.stringify({ text: "質問のみ" }),
+      iso(30)
+    );
+    await insertMessage(s1.id, "user", "回答", iso(40));
+
+    const { data, error } = await adminClient.rpc(
+      "get_question_answer_counts",
+      { p_config_id: config.id }
+    );
+
+    expect(error).toBeNull();
+    expect(data).toHaveLength(1);
+    expect(data?.[0].question_id).toBe(q1.id);
+    expect(data?.[0].asked_session_count).toBe(0);
+    expect(data?.[0].answered_session_count).toBe(0);
+  });
+
+  it("一度も提示されていない質問も0件で返す", async () => {
+    const bill = await createTestBill();
+    billIds.push(bill.id);
+    const config = await createTestInterviewConfig(bill.id);
+    await createTestQuestion(config.id, "質問1", 1);
+    await createTestQuestion(config.id, "質問2", 2);
+
+    const { data, error } = await adminClient.rpc(
+      "get_question_answer_counts",
+      { p_config_id: config.id }
+    );
+
+    expect(error).toBeNull();
+    expect(data).toHaveLength(2);
+    expect(data?.every((row) => row.asked_session_count === 0)).toBe(true);
+  });
+
+  it("別configのセッションは集計に含まれない", async () => {
+    const bill = await createTestBill();
+    billIds.push(bill.id);
+    const config1 = await createTestInterviewConfig(bill.id);
+    const config2 = await createTestInterviewConfig(bill.id, "closed");
+    const q1 = await createTestQuestion(config1.id, "質問1", 1);
+
+    // config2のセッションがconfig1の質問IDを参照しても数えない
+    const s2 = await createTestSession(config2.id, testUser.id);
+    await insertMessage(s2.id, "assistant", assistantContent(q1.id), iso(0));
+    await insertMessage(s2.id, "user", "回答", iso(10));
+
+    const { data, error } = await adminClient.rpc(
+      "get_question_answer_counts",
+      { p_config_id: config1.id }
+    );
+
+    expect(error).toBeNull();
+    expect(data).toHaveLength(1);
+    expect(data?.[0].asked_session_count).toBe(0);
+  });
+
+  it("question_orderの昇順で返す", async () => {
+    const bill = await createTestBill();
+    billIds.push(bill.id);
+    const config = await createTestInterviewConfig(bill.id);
+    await createTestQuestion(config.id, "質問B", 2);
+    await createTestQuestion(config.id, "質問A", 1);
+    await createTestQuestion(config.id, "質問C", 3);
+
+    const { data, error } = await adminClient.rpc(
+      "get_question_answer_counts",
+      { p_config_id: config.id }
+    );
+
+    expect(error).toBeNull();
+    expect(data?.map((row) => row.question)).toEqual([
+      "質問A",
+      "質問B",
+      "質問C",
+    ]);
+  });
+});

--- a/web/src/features/interview-session/shared/message-utils.ts
+++ b/web/src/features/interview-session/shared/message-utils.ts
@@ -19,6 +19,10 @@ export function isValidReport(
 
 /**
  * JSONとして保存されたメッセージをパースして、textとreportとquickRepliesに分離する
+ *
+ * question_id の抽出規約はDB側の extract_assistant_question_id 関数
+ * （supabase/migrations/20260710100000_add_get_question_answer_counts.sql）
+ * と同期を保つこと
  */
 export function parseMessageContent(content: string): {
   text: string;


### PR DESCRIPTION
## 概要

各インタビュー設定について、それぞれの質問（Q）に何人が回答してくれているのかを集計し、admin のインタビューレポート一覧ページ（統計パネルの下）に「質問別回答者数」カードとして表示します。

## 実装内容

### DB（マイグレーション）
- `extract_assistant_question_id(content TEXT) RETURNS UUID`: assistantメッセージのJSON contentから `question_id`（legacy: `questionId`）を安全に抽出するヘルパー関数。非JSON（プレーンテキストのlegacyメッセージ）・非オブジェクトJSON・非UUIDは `pg_input_is_valid` でNULLに落とす。TS側パーサー `parseMessageContent`（web/src/features/interview-session/shared/message-utils.ts）と相互参照コメントで同期を担保。
- `get_question_answer_counts(p_config_id UUID)`: 質問ごとに
  - **提示セッション数** = その質問を参照するassistantメッセージが存在するセッション数（DISTINCT）
  - **回答セッション数** = 提示後にuserメッセージが存在するセッション数（DISTINCT）

  を返すRPC。回答判定は相関EXISTSではなくセッションごとの最終userメッセージ時刻とのJOINで計算（メッセージ数に対して線形）。一度も提示されていない質問も0件で返し、`question_order` 昇順でソート。

### admin
- `findQuestionAnswerCounts`（repository）→ `getQuestionAnswerCounts`（loader）→ `QuestionAnswerCounts`（Server Component）を既存の `get_interview_statistics` パターンに合わせて追加
- バーの長さは全質問中の最大提示セッション数を分母に正規化（質問間の離脱ファネル比較用）。計算は純粋関数 `withAnswerBarPercents` として `shared/utils/` に切り出し

## 「回答した」の定義

その質問を尋ねるassistantメッセージの後に、同一セッション内でuserメッセージが1件以上存在すること（＝質問が提示されたまま離脱した場合は提示のみカウント）。

## 実行テスト記録

- `tests/supabase/db-function/get-question-answer-counts.test.ts`（統合テスト7件、ローカルSupabase実インスタンス）: 集計・同一質問の重複提示・legacy camelCaseキー・不正JSON/UUIDスキップ・未提示質問の0件返却・config分離・ソート順
- `pnpm --filter admin test`: 451件パス（`map-question-answer-counts.test.ts`, `calc-answer-bar-percents.test.ts` 含む）
- `pnpm lint` / `pnpm typecheck`: パス
- `pnpm build` / `pnpm --filter web test`: ローカル環境ではdevelopブランチでも同一エラーで失敗する既存の環境問題（Google Fonts解決・jsdom依存のESM問題）のため、CIでの確認とします

## スキーマ変更

- 新規マイグレーション `20260710100000_add_get_question_answer_counts.sql`（DB関数2つの追加のみ、テーブル変更なし）
- `packages/supabase/types/supabase.types.ts` に関数型を追加

## 今後の改善候補（別issue想定）

`question_id` はassistantメッセージのJSON文字列内にのみ存在するため、SQL/TSの2箇所にパース規約が存在します。`interview_messages` に `question_id` カラムを追加して書き込み時に正規化すれば、本RPCは単純なJOINになりパースの二重実装が解消されます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 面談レポートに、質問ごとの提示数・回答数を集計して表示する新セクションを追加しました。
  * 回答状況を進捗バーと「回答数/提示数」形式の数値で視覚化します。
* **改善**
  * 集計結果がない場合は、質問回答状況のセクションを表示しないようにしました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->