### PR TITLE
発言検索にスタンス・役割・役割名のフィルタを追加

### DIFF
--- a/admin/src/app/(protected)/bills/[id]/interview/[configId]/reports/search/page.tsx
+++ b/admin/src/app/(protected)/bills/[id]/interview/[configId]/reports/search/page.tsx
@@ -7,6 +7,7 @@ import { getBillById } from "@/features/bills-edit/server/loaders/get-bill-by-id
 import { MessageSearchForm } from "@/features/interview-reports/client/components/message-search-form";
 import { MessageSearchResults } from "@/features/interview-reports/server/components/message-search-results";
 import { searchUserMessages } from "@/features/interview-reports/server/loaders/search-user-messages";
+import { parseMessageSearchFilterParams } from "@/features/interview-reports/shared/utils/parse-message-search-filter-params";
 import { routes } from "@/lib/routes";
 
 interface ReportsSearchPageProps {
@@ -17,6 +18,9 @@ interface ReportsSearchPageProps {
   searchParams: Promise<{
     q?: string;
     page?: string;
+    stance?: string;
+    role?: string;
+    roleTitle?: string;
   }>;
 }
 
@@ -25,13 +29,14 @@ export default async function ReportsSearchPage({
   searchParams,
 }: ReportsSearchPageProps) {
   const { id, configId } = await params;
-  const { q, page } = await searchParams;
+  const { q, page, stance, role, roleTitle } = await searchParams;
   const query = (q ?? "").trim();
   const currentPage = Math.max(1, Number(page) || 1);
+  const filters = parseMessageSearchFilterParams(stance, role, roleTitle);
 
   const [bill, result] = await Promise.all([
     getBillById(id),
-    query ? searchUserMessages(configId, query, currentPage) : null,
+    query ? searchUserMessages(configId, query, currentPage, filters) : null,
   ]);
 
   if (!bill) {
@@ -58,7 +63,7 @@ export default async function ReportsSearchPage({
       </div>
 
       <div className="mb-6">
-        <MessageSearchForm initialQuery={query} />
+        <MessageSearchForm initialQuery={query} initialFilters={filters} />
       </div>
 
       {result ? (
@@ -66,6 +71,7 @@ export default async function ReportsSearchPage({
           billId={id}
           configId={configId}
           query={query}
+          filters={filters}
           result={result}
           currentPage={currentPage}
         />

--- a/admin/src/features/interview-reports/client/components/filter-select.tsx
+++ b/admin/src/features/interview-reports/client/components/filter-select.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+interface FilterSelectProps {
+  label: string;
+  value: string;
+  options: readonly { value: string; label: string }[];
+  onChange: (value: string) => void;
+}
+
+export function FilterSelect({
+  label,
+  value,
+  options,
+  onChange,
+}: FilterSelectProps) {
+  return (
+    <div className="flex items-center gap-2">
+      <span className="text-sm font-medium text-gray-700 whitespace-nowrap">
+        {label}
+      </span>
+      <Select value={value} onValueChange={onChange}>
+        <SelectTrigger aria-label={label} className="w-40 h-9">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {options.map((option) => (
+            <SelectItem key={option.value} value={option.value}>
+              {option.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}

--- a/admin/src/features/interview-reports/client/components/message-search-form.tsx
+++ b/admin/src/features/interview-reports/client/components/message-search-form.tsx
@@ -6,27 +6,48 @@ import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import {
+  MESSAGE_SEARCH_STANCE_FILTER_OPTIONS,
+  ROLE_FILTER_OPTIONS,
+} from "../../shared/constants";
+import type {
+  MessageSearchFilterConfig,
+  MessageSearchStanceFilter,
+  RoleFilter,
+} from "../../shared/types";
+import { appendMessageSearchFilterParams } from "../../shared/utils/parse-message-search-filter-params";
+import { FilterSelect } from "./filter-select";
 
 interface MessageSearchFormProps {
   initialQuery: string;
+  initialFilters: MessageSearchFilterConfig;
 }
 
-export function MessageSearchForm({ initialQuery }: MessageSearchFormProps) {
+export function MessageSearchForm({
+  initialQuery,
+  initialFilters,
+}: MessageSearchFormProps) {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const [query, setQuery] = useState(initialQuery);
+  const [filters, setFilters] =
+    useState<MessageSearchFilterConfig>(initialFilters);
 
   function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
     const params = new URLSearchParams(searchParams.toString());
-    const trimmed = query.trim();
 
-    if (trimmed) {
-      params.set("q", trimmed);
+    const trimmedQuery = query.trim();
+    if (trimmedQuery) {
+      params.set("q", trimmedQuery);
     } else {
       params.delete("q");
     }
+    appendMessageSearchFilterParams(params, {
+      ...filters,
+      roleTitle: filters.roleTitle.trim(),
+    });
 
     // 検索条件変更時はページを1にリセット
     params.delete("page");
@@ -35,18 +56,55 @@ export function MessageSearchForm({ initialQuery }: MessageSearchFormProps) {
   }
 
   return (
-    <form onSubmit={handleSubmit} className="flex items-center gap-2">
-      <Input
-        value={query}
-        onChange={(event) => setQuery(event.target.value)}
-        placeholder="ユーザーの発言を検索"
-        aria-label="発言検索キーワード"
-        className="max-w-md"
-      />
-      <Button type="submit">
-        <Search className="h-4 w-4" />
-        検索
-      </Button>
+    <form onSubmit={handleSubmit} className="space-y-3">
+      <div className="flex items-center gap-2">
+        <Input
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="ユーザーの発言を検索"
+          aria-label="発言検索キーワード"
+          className="max-w-md"
+        />
+        <Button type="submit">
+          <Search className="h-4 w-4" />
+          検索
+        </Button>
+      </div>
+      <div className="flex flex-wrap items-center gap-4">
+        <FilterSelect
+          label="スタンス"
+          value={filters.stance}
+          options={MESSAGE_SEARCH_STANCE_FILTER_OPTIONS}
+          onChange={(stance) =>
+            setFilters({
+              ...filters,
+              stance: stance as MessageSearchStanceFilter,
+            })
+          }
+        />
+        <FilterSelect
+          label="役割"
+          value={filters.role}
+          options={ROLE_FILTER_OPTIONS}
+          onChange={(role) =>
+            setFilters({ ...filters, role: role as RoleFilter })
+          }
+        />
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium text-gray-700 whitespace-nowrap">
+            役割名
+          </span>
+          <Input
+            value={filters.roleTitle}
+            onChange={(event) =>
+              setFilters({ ...filters, roleTitle: event.target.value })
+            }
+            placeholder="例: 医師（部分一致）"
+            aria-label="役割名フィルタ"
+            className="w-[200px]"
+          />
+        </div>
+      </div>
     </form>
   );
 }

--- a/admin/src/features/interview-reports/client/components/session-filter-bar.tsx
+++ b/admin/src/features/interview-reports/client/components/session-filter-bar.tsx
@@ -2,15 +2,10 @@
 
 import type { Route } from "next";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+import { ROLE_FILTER_OPTIONS, stanceLabels } from "../../shared/constants";
 import type { SessionFilterConfig } from "../../shared/types";
 import { DEFAULT_SESSION_FILTER } from "../../shared/types";
+import { FilterSelect } from "./filter-select";
 
 interface SessionFilterBarProps {
   currentFilters: SessionFilterConfig;
@@ -31,18 +26,11 @@ const VISIBILITY_OPTIONS = [
 
 const STANCE_OPTIONS = [
   { value: "all", label: "すべて" },
-  { value: "for", label: "賛成" },
-  { value: "against", label: "反対" },
-  { value: "neutral", label: "中立" },
-] as const;
-
-const ROLE_OPTIONS = [
-  { value: "all", label: "すべて" },
-  { value: "subject_expert", label: "専門的な有識者" },
-  { value: "work_related", label: "業務に関係" },
-  { value: "daily_life_affected", label: "暮らしに影響" },
-  { value: "general_citizen", label: "一般的な関心" },
-] as const;
+  ...(["for", "against", "neutral"] as const).map((stance) => ({
+    value: stance,
+    label: stanceLabels[stance],
+  })),
+];
 
 const MODERATION_OPTIONS = [
   { value: "all", label: "すべて" },
@@ -96,7 +84,7 @@ export function SessionFilterBar({ currentFilters }: SessionFilterBarProps) {
       <FilterSelect
         label="役割"
         value={currentFilters.role}
-        options={ROLE_OPTIONS}
+        options={ROLE_FILTER_OPTIONS}
         onChange={(v) => handleFilterChange("role", v)}
       />
       <FilterSelect
@@ -105,38 +93,6 @@ export function SessionFilterBar({ currentFilters }: SessionFilterBarProps) {
         options={MODERATION_OPTIONS}
         onChange={(v) => handleFilterChange("moderation", v)}
       />
-    </div>
-  );
-}
-
-function FilterSelect({
-  label,
-  value,
-  options,
-  onChange,
-}: {
-  label: string;
-  value: string;
-  options: readonly { value: string; label: string }[];
-  onChange: (value: string) => void;
-}) {
-  return (
-    <div className="flex items-center gap-2">
-      <span className="text-sm font-medium text-gray-700 whitespace-nowrap">
-        {label}
-      </span>
-      <Select value={value} onValueChange={onChange}>
-        <SelectTrigger aria-label={label} className="w-40 h-9">
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent>
-          {options.map((option) => (
-            <SelectItem key={option.value} value={option.value}>
-              {option.label}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
     </div>
   );
 }

--- a/admin/src/features/interview-reports/server/components/message-search-results.tsx
+++ b/admin/src/features/interview-reports/server/components/message-search-results.tsx
@@ -3,9 +3,13 @@ import type { Route } from "next";
 import Link from "next/link";
 import { Card, CardContent } from "@/components/ui/card";
 import { routes } from "@/lib/routes";
-import type { MessageSearchSession } from "../../shared/types";
+import type {
+  MessageSearchFilterConfig,
+  MessageSearchSession,
+} from "../../shared/types";
 import { buildSnippet } from "../../shared/utils/build-snippet";
 import { formatJstDateTime } from "../../shared/utils/format-jst-date-time";
+import { appendMessageSearchFilterParams } from "../../shared/utils/parse-message-search-filter-params";
 import type { MessageSearchResult } from "../loaders/search-user-messages";
 import { SEARCH_SESSIONS_PER_PAGE } from "../loaders/search-user-messages";
 import { HighlightedText } from "./highlighted-text";
@@ -19,6 +23,7 @@ interface MessageSearchResultsProps {
   billId: string;
   configId: string;
   query: string;
+  filters: MessageSearchFilterConfig;
   result: MessageSearchResult;
   currentPage: number;
 }
@@ -27,10 +32,12 @@ function buildSearchPageUrl(
   billId: string,
   configId: string,
   query: string,
+  filters: MessageSearchFilterConfig,
   page: number
 ): Route {
   const params = new URLSearchParams();
   params.set("q", query);
+  appendMessageSearchFilterParams(params, filters);
   if (page > 1) {
     params.set("page", String(page));
   }
@@ -120,6 +127,7 @@ export function MessageSearchResults({
   billId,
   configId,
   query,
+  filters,
   result,
   currentPage,
 }: MessageSearchResultsProps) {
@@ -163,7 +171,9 @@ export function MessageSearchResults({
         className="mt-6"
         totalPages={totalPages}
         currentPage={currentPage}
-        buildHref={(page) => buildSearchPageUrl(billId, configId, query, page)}
+        buildHref={(page) =>
+          buildSearchPageUrl(billId, configId, query, filters, page)
+        }
       />
     </div>
   );

--- a/admin/src/features/interview-reports/server/components/stance-badge.tsx
+++ b/admin/src/features/interview-reports/server/components/stance-badge.tsx
@@ -1,46 +1,27 @@
 import { Badge } from "@/components/ui/badge";
+import { stanceLabels } from "../../shared/constants";
 
 interface StanceBadgeProps {
   stance: string | null;
 }
 
-const stanceConfig: Record<string, { label: string; className: string }> = {
-  for: {
-    label: "賛成",
-    className: "bg-green-50 text-green-700 border-green-200",
-  },
-  against: {
-    label: "反対",
-    className: "bg-red-50 text-red-700 border-red-200",
-  },
-  neutral: {
-    label: "中立",
-    className: "bg-gray-50 text-gray-700 border-gray-200",
-  },
-  conditional_for: {
-    label: "条件付き賛成",
-    className: "bg-blue-50 text-blue-700 border-blue-200",
-  },
-  conditional_against: {
-    label: "条件付き反対",
-    className: "bg-orange-50 text-orange-700 border-orange-200",
-  },
-  considering: {
-    label: "検討中",
-    className: "bg-yellow-50 text-yellow-700 border-yellow-200",
-  },
-  continued_deliberation: {
-    label: "継続審議",
-    className: "bg-purple-50 text-purple-700 border-purple-200",
-  },
+const stanceClassNames: Record<string, string> = {
+  for: "bg-green-50 text-green-700 border-green-200",
+  against: "bg-red-50 text-red-700 border-red-200",
+  neutral: "bg-gray-50 text-gray-700 border-gray-200",
+  conditional_for: "bg-blue-50 text-blue-700 border-blue-200",
+  conditional_against: "bg-orange-50 text-orange-700 border-orange-200",
+  considering: "bg-yellow-50 text-yellow-700 border-yellow-200",
+  continued_deliberation: "bg-purple-50 text-purple-700 border-purple-200",
 };
 
 export function StanceBadge({ stance }: StanceBadgeProps) {
   if (!stance) return <span className="text-gray-400">-</span>;
 
-  const config = stanceConfig[stance] || {
-    label: stance,
-    className: "bg-gray-50 text-gray-700 border-gray-200",
+  const config = {
+    label: (stanceLabels as Record<string, string>)[stance] ?? stance,
+    className:
+      stanceClassNames[stance] ?? "bg-gray-50 text-gray-700 border-gray-200",
   };
 
   return (

--- a/admin/src/features/interview-reports/server/loaders/search-user-messages.ts
+++ b/admin/src/features/interview-reports/server/loaders/search-user-messages.ts
@@ -1,6 +1,9 @@
 import "server-only";
 
-import type { MessageSearchSession } from "../../shared/types";
+import type {
+  MessageSearchFilterConfig,
+  MessageSearchSession,
+} from "../../shared/types";
 import { groupMatchedMessagesBySession } from "../../shared/utils/group-matched-messages";
 import { normalizeInterviewReport } from "../../shared/utils/normalize-interview-report";
 import {
@@ -26,12 +29,14 @@ export interface MessageSearchResult {
 export async function searchUserMessages(
   configId: string,
   query: string,
-  page = 1
+  page: number,
+  filters: MessageSearchFilterConfig
 ): Promise<MessageSearchResult> {
   const matchedMessages = await searchUserMessagesByConfigId(
     configId,
     query,
-    MAX_SEARCH_MESSAGES
+    MAX_SEARCH_MESSAGES,
+    filters
   );
   const groups = groupMatchedMessagesBySession(matchedMessages);
 

--- a/admin/src/features/interview-reports/server/repositories/interview-report-repository.ts
+++ b/admin/src/features/interview-reports/server/repositories/interview-report-repository.ts
@@ -2,9 +2,13 @@ import "server-only";
 
 import { isReportAutoPublishEligible } from "@mirai-gikai/shared/report-publication/auto-publish";
 import { createAdminClient } from "@mirai-gikai/supabase";
-import type { SessionFilterConfig } from "../../shared/types";
+import type {
+  MessageSearchFilterConfig,
+  SessionFilterConfig,
+} from "../../shared/types";
 import { DEFAULT_SESSION_FILTER } from "../../shared/types";
 import { escapeIlikePattern } from "../../shared/utils/escape-ilike-pattern";
+import { hasReportLevelSearchFilters } from "../../shared/utils/parse-message-search-filter-params";
 
 function toRpcFilterParams(filters: SessionFilterConfig) {
   return {
@@ -444,17 +448,45 @@ export async function findInterviewMessagesBySessionId(sessionId: string) {
 export async function searchUserMessagesByConfigId(
   configId: string,
   query: string,
-  limit: number
+  limit: number,
+  filters: MessageSearchFilterConfig
 ) {
   const supabase = createAdminClient();
-  const { data, error } = await supabase
+  // レポートレベルのフィルタ指定時のみ interview_report まで inner join し、
+  // レポート未生成のセッションを除外する。
+  // embed のカラムはフィルタにのみ使うため取得しない（空の embed でも
+  // inner join とネストしたフィルタは機能する）
+  const selectQuery = hasReportLevelSearchFilters(filters)
+    ? "id, interview_session_id, content, created_at, interview_sessions!inner(interview_report!inner())"
+    : "id, interview_session_id, content, created_at, interview_sessions!inner()";
+
+  let queryBuilder = supabase
     .from("interview_messages")
-    .select(
-      "id, interview_session_id, content, created_at, interview_sessions!inner(interview_config_id)"
-    )
+    .select(selectQuery)
     .eq("role", "user")
     .eq("interview_sessions.interview_config_id", configId)
-    .ilike("content", `%${escapeIlikePattern(query)}%`)
+    .ilike("content", `%${escapeIlikePattern(query)}%`);
+
+  if (filters.stance !== "all") {
+    queryBuilder = queryBuilder.eq(
+      "interview_sessions.interview_report.stance",
+      filters.stance
+    );
+  }
+  if (filters.role !== "all") {
+    queryBuilder = queryBuilder.eq(
+      "interview_sessions.interview_report.role",
+      filters.role
+    );
+  }
+  if (filters.roleTitle !== "") {
+    queryBuilder = queryBuilder.ilike(
+      "interview_sessions.interview_report.role_title",
+      `%${escapeIlikePattern(filters.roleTitle)}%`
+    );
+  }
+
+  const { data, error } = await queryBuilder
     .order("created_at", { ascending: false })
     .limit(limit);
 

--- a/admin/src/features/interview-reports/shared/constants.ts
+++ b/admin/src/features/interview-reports/shared/constants.ts
@@ -1,3 +1,5 @@
+import { formatRoleLabel as formatRoleLabelPure } from "./utils/format-role-label";
+
 /**
  * インタビューレポートの役割の型
  */
@@ -20,7 +22,64 @@ export const roleLabels: Record<InterviewReportRole, string> = {
   general_citizen: "一般的な関心",
 };
 
-import { formatRoleLabel as formatRoleLabelPure } from "./utils/format-role-label";
+/**
+ * インタビューレポートで扱うスタンス
+ * （stance_type_enum のうち free_vote はレポートでは使用しないため除外）
+ */
+export const interviewReportStances = [
+  "for",
+  "against",
+  "neutral",
+  "conditional_for",
+  "conditional_against",
+  "considering",
+  "continued_deliberation",
+] as const;
+
+export type InterviewReportStance = (typeof interviewReportStances)[number];
+
+/**
+ * スタンスのラベルマッピング
+ */
+export const stanceLabels: Record<InterviewReportStance, string> = {
+  for: "賛成",
+  against: "反対",
+  neutral: "中立",
+  conditional_for: "条件付き賛成",
+  conditional_against: "条件付き反対",
+  considering: "検討中",
+  continued_deliberation: "継続審議",
+};
+
+const ALL_OPTION = { value: "all", label: "すべて" } as const;
+
+/**
+ * 役割フィルタの選択肢（セッション一覧・発言検索で共用）
+ */
+export const ROLE_FILTER_OPTIONS: readonly {
+  value: string;
+  label: string;
+}[] = [
+  ALL_OPTION,
+  ...interviewReportRoles.map((role) => ({
+    value: role,
+    label: roleLabels[role],
+  })),
+];
+
+/**
+ * 発言検索のスタンスフィルタの選択肢（全スタンス対象）
+ */
+export const MESSAGE_SEARCH_STANCE_FILTER_OPTIONS: readonly {
+  value: string;
+  label: string;
+}[] = [
+  ALL_OPTION,
+  ...interviewReportStances.map((stance) => ({
+    value: stance,
+    label: stanceLabels[stance],
+  })),
+];
 
 /**
  * 役割ラベルとrole_titleを中黒で結合して表示用文字列を生成

--- a/admin/src/features/interview-reports/shared/types/index.ts
+++ b/admin/src/features/interview-reports/shared/types/index.ts
@@ -1,5 +1,9 @@
 import type { Database } from "@mirai-gikai/supabase";
 import type { SortConfig } from "@/lib/sort";
+import {
+  type InterviewReportStance,
+  interviewReportStances,
+} from "../constants";
 
 export type InterviewSession =
   Database["public"]["Tables"]["interview_sessions"]["Row"];
@@ -110,6 +114,26 @@ export const DEFAULT_SESSION_FILTER: SessionFilterConfig = {
   stance: "all",
   role: "all",
   moderation: "all",
+};
+
+// 発言検索のスタンスフィルタ。バッジ表示と同じ全スタンスを対象にする
+// （セッション一覧の StanceFilter は賛成/反対/中立のみ）
+export type MessageSearchStanceFilter = "all" | InterviewReportStance;
+
+export const MESSAGE_SEARCH_STANCE_FILTER_VALUES: readonly MessageSearchStanceFilter[] =
+  ["all", ...interviewReportStances] as const;
+
+// 発言検索のフィルタ。roleTitle は部分一致（空文字 = フィルタなし）
+export interface MessageSearchFilterConfig {
+  stance: MessageSearchStanceFilter;
+  role: RoleFilter;
+  roleTitle: string;
+}
+
+export const DEFAULT_MESSAGE_SEARCH_FILTER: MessageSearchFilterConfig = {
+  stance: "all",
+  role: "all",
+  roleTitle: "",
 };
 
 export type InterviewStatistics = {

--- a/admin/src/features/interview-reports/shared/utils/parse-message-search-filter-params.test.ts
+++ b/admin/src/features/interview-reports/shared/utils/parse-message-search-filter-params.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import {
+  appendMessageSearchFilterParams,
+  hasReportLevelSearchFilters,
+  parseMessageSearchFilterParams,
+} from "./parse-message-search-filter-params";
+
+describe("parseMessageSearchFilterParams", () => {
+  it("有効な値をそのまま返す", () => {
+    expect(
+      parseMessageSearchFilterParams("for", "subject_expert", "医師")
+    ).toEqual({
+      stance: "for",
+      role: "subject_expert",
+      roleTitle: "医師",
+    });
+  });
+
+  it("条件付きスタンスも有効な値として受け付ける", () => {
+    expect(parseMessageSearchFilterParams("conditional_for").stance).toBe(
+      "conditional_for"
+    );
+    expect(
+      parseMessageSearchFilterParams("continued_deliberation").stance
+    ).toBe("continued_deliberation");
+  });
+
+  it("不正な値はデフォルトにフォールバックする", () => {
+    expect(parseMessageSearchFilterParams("invalid", "invalid")).toEqual({
+      stance: "all",
+      role: "all",
+      roleTitle: "",
+    });
+  });
+
+  it("未指定はデフォルトを返す", () => {
+    expect(parseMessageSearchFilterParams()).toEqual({
+      stance: "all",
+      role: "all",
+      roleTitle: "",
+    });
+  });
+
+  it("roleTitleは前後の空白を除去する", () => {
+    expect(
+      parseMessageSearchFilterParams(undefined, undefined, "  医師  ")
+    ).toEqual({
+      stance: "all",
+      role: "all",
+      roleTitle: "医師",
+    });
+  });
+});
+
+describe("hasReportLevelSearchFilters", () => {
+  it("すべてデフォルトならfalse", () => {
+    expect(
+      hasReportLevelSearchFilters({ stance: "all", role: "all", roleTitle: "" })
+    ).toBe(false);
+  });
+
+  it("いずれかが指定されていればtrue", () => {
+    expect(
+      hasReportLevelSearchFilters({ stance: "for", role: "all", roleTitle: "" })
+    ).toBe(true);
+    expect(
+      hasReportLevelSearchFilters({
+        stance: "all",
+        role: "general_citizen",
+        roleTitle: "",
+      })
+    ).toBe(true);
+    expect(
+      hasReportLevelSearchFilters({
+        stance: "all",
+        role: "all",
+        roleTitle: "医師",
+      })
+    ).toBe(true);
+  });
+});
+
+describe("appendMessageSearchFilterParams", () => {
+  it("デフォルト以外の値のみパラメータに書き出す", () => {
+    const params = new URLSearchParams();
+    appendMessageSearchFilterParams(params, {
+      stance: "conditional_for",
+      role: "all",
+      roleTitle: "医師",
+    });
+    expect(params.get("stance")).toBe("conditional_for");
+    expect(params.has("role")).toBe(false);
+    expect(params.get("roleTitle")).toBe("医師");
+  });
+
+  it("デフォルト値に戻した場合は既存のパラメータを削除する", () => {
+    const params = new URLSearchParams("stance=for&role=general_citizen");
+    appendMessageSearchFilterParams(params, {
+      stance: "all",
+      role: "all",
+      roleTitle: "",
+    });
+    expect(params.toString()).toBe("");
+  });
+
+  it("parseMessageSearchFilterParamsと往復して一致する", () => {
+    const filters = {
+      stance: "against",
+      role: "work_related",
+      roleTitle: "教員",
+    } as const;
+    const params = new URLSearchParams();
+    appendMessageSearchFilterParams(params, filters);
+    expect(
+      parseMessageSearchFilterParams(
+        params.get("stance") ?? undefined,
+        params.get("role") ?? undefined,
+        params.get("roleTitle") ?? undefined
+      )
+    ).toEqual(filters);
+  });
+});

--- a/admin/src/features/interview-reports/shared/utils/parse-message-search-filter-params.ts
+++ b/admin/src/features/interview-reports/shared/utils/parse-message-search-filter-params.ts
@@ -1,0 +1,54 @@
+import {
+  DEFAULT_MESSAGE_SEARCH_FILTER,
+  MESSAGE_SEARCH_STANCE_FILTER_VALUES,
+  type MessageSearchFilterConfig,
+  type MessageSearchStanceFilter,
+  ROLE_FILTER_VALUES,
+  type RoleFilter,
+} from "../types";
+import { parseEnum } from "./parse-session-filter-params";
+
+export function parseMessageSearchFilterParams(
+  stance?: string,
+  role?: string,
+  roleTitle?: string
+): MessageSearchFilterConfig {
+  return {
+    stance: parseEnum<MessageSearchStanceFilter>(
+      stance,
+      MESSAGE_SEARCH_STANCE_FILTER_VALUES,
+      DEFAULT_MESSAGE_SEARCH_FILTER.stance
+    ),
+    role: parseEnum<RoleFilter>(
+      role,
+      ROLE_FILTER_VALUES,
+      DEFAULT_MESSAGE_SEARCH_FILTER.role
+    ),
+    roleTitle: (roleTitle ?? "").trim(),
+  };
+}
+
+export function hasReportLevelSearchFilters(
+  filters: MessageSearchFilterConfig
+): boolean {
+  return (
+    filters.stance !== "all" ||
+    filters.role !== "all" ||
+    filters.roleTitle !== ""
+  );
+}
+
+// フィルタをURLクエリパラメータに書き出す（デフォルト値のパラメータは省略）。
+// parseMessageSearchFilterParams と対になるシリアライズ処理
+export function appendMessageSearchFilterParams(
+  params: URLSearchParams,
+  filters: MessageSearchFilterConfig
+): void {
+  for (const key of ["stance", "role", "roleTitle"] as const) {
+    if (filters[key] !== DEFAULT_MESSAGE_SEARCH_FILTER[key]) {
+      params.set(key, filters[key]);
+    } else {
+      params.delete(key);
+    }
+  }
+}

--- a/admin/src/features/interview-reports/shared/utils/parse-session-filter-params.ts
+++ b/admin/src/features/interview-reports/shared/utils/parse-session-filter-params.ts
@@ -13,7 +13,7 @@ import {
   type VisibilityFilter,
 } from "../types";
 
-function parseEnum<T extends string>(
+export function parseEnum<T extends string>(
   value: string | undefined,
   validValues: readonly T[],
   defaultValue: T


### PR DESCRIPTION
## 概要

admin の発言検索ページ（インタビューレポート一覧 → 発言検索）で、以下の条件で発言を絞り込めるようにします。

- **スタンス**: 賛成 / 反対 / 中立 / 条件付き賛成 / 条件付き反対 / 検討中 / 継続審議（全7種。実データに条件付きスタンスが存在するため、レポート一覧の3種より広い選択肢にしています）
- **役割**: 4分類（専門的な有識者 / 業務に関係 / 暮らしに影響 / 一般的な関心）
- **役割名**: フリーテキスト部分一致（例:「医」→「医薬品物流担当」がヒット）

フィルタ条件は URL クエリパラメータに反映され、ページネーションでも維持されます。

## 実装内容

### 検索クエリ（repository）
- `searchUserMessagesByConfigId` に filters 引数を追加。スタンス・役割・役割名は `interview_report` にあるため、**フィルタ指定時のみ** `interview_sessions!inner(interview_report!inner())` まで inner join してネストパスで絞り込み（レポート未生成セッションはフィルタ時のみ除外）。フィルタなしの通常検索には join を追加しないため性能影響なし
- embed カラムは取得しない（空embedでも join とフィルタは機能することをローカル実クエリで検証済み）
- `roleTitle` の部分一致には既存の `escapeIlikePattern` を適用

### フィルタの定義・パース（shared）
- `MessageSearchFilterConfig` 型と `parseMessageSearchFilterParams` / `appendMessageSearchFilterParams`（URL⇔フィルタの往復変換）/ `hasReportLevelSearchFilters` を純粋関数として追加、テスト10件
- 不正なクエリパラメータはデフォルト（すべて）にフォールバック

### リファクタ（重複排除）
- `FilterSelect` をセッション一覧のフィルタバーから `client/components/filter-select.tsx` に抽出して共用（コピー時に失われていた `aria-label` も復元）
- 役割・スタンスのラベルを `shared/constants.ts` に一元化（`stanceLabels` / `ROLE_FILTER_OPTIONS`）。`stance-badge` とセッション一覧フィルタも同じラベル定義を参照するように変更

## 実行テスト記録

- `pnpm --filter admin test`: 497件パス（新規 `parse-message-search-filter-params.test.ts` 10件含む）
- `pnpm lint` / `pnpm typecheck`: パス
- ローカルSupabase実データで動作確認: スタンス「条件付き賛成」で絞り込み→全結果に該当バッジのみ表示、役割名「医」→ 該当role_titleのみヒット、「専門的な有識者×医」→ 0件（該当データの役割はwork_relatedのため正しい）
- `pnpm build` / `pnpm --filter web test`: developブランチでも同一エラーとなるローカル環境問題（フォント解決・jsdom ESM）のため、CIでの確認とします

## スキーマ変更

なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 発言検索で、スタンス・役割・役割名による絞り込みに対応しました。
  - 検索条件を指定したままページ移動できるようになりました。
  - スタンスや役割を選択できるフィルターUIを追加しました。
- **テスト**
  - 検索フィルターの入力、URL反映、無効値処理を検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->