### PR TITLE
MCP: チャット利用状況の集計ツール get_chat_usage_metrics を追加

### DIFF
--- a/admin/src/features/mcp/server/create-handler.ts
+++ b/admin/src/features/mcp/server/create-handler.ts
@@ -5,6 +5,7 @@ import {
   experimental_withMcpAuth as withMcpAuth,
 } from "mcp-handler";
 import { registerBillsTools } from "./tools/register-bills-tools";
+import { registerChatUsageTools } from "./tools/register-chat-usage-tools";
 import { registerDietSessionsTools } from "./tools/register-diet-sessions-tools";
 import { registerInterviewMetricsTools } from "./tools/register-interview-metrics-tools";
 import { registerMiraiStanceTools } from "./tools/register-mirai-stance-tools";
@@ -17,6 +18,7 @@ export function createAdminMcpHandler() {
   const baseHandler = createMcpHandler(
     (server) => {
       registerBillsTools(server);
+      registerChatUsageTools(server);
       registerDietSessionsTools(server);
       registerInterviewMetricsTools(server);
       registerMiraiStanceTools(server);

--- a/admin/src/features/mcp/server/repositories/chat-usage-repository.ts
+++ b/admin/src/features/mcp/server/repositories/chat-usage-repository.ts
@@ -1,0 +1,22 @@
+import "server-only";
+
+import { createAdminClient } from "@mirai-gikai/supabase";
+
+export async function findChatUsageMetrics(params: {
+  from?: string;
+  to?: string;
+  billId?: string;
+}) {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase.rpc("get_chat_usage_metrics", {
+    p_from: params.from,
+    p_to: params.to,
+    p_bill_id: params.billId,
+  });
+
+  if (error) {
+    throw new Error(`Failed to fetch chat usage metrics: ${error.message}`);
+  }
+
+  return data ?? [];
+}

--- a/admin/src/features/mcp/server/tools/register-chat-usage-tools.ts
+++ b/admin/src/features/mcp/server/tools/register-chat-usage-tools.ts
@@ -1,0 +1,51 @@
+import "server-only";
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { findChatUsageMetrics } from "../repositories/chat-usage-repository";
+import { jsonResult } from "../utils/json-result";
+
+/**
+ * チャット機能の利用状況（chat_usage_events）を集計する内部向け読み取りツール。
+ */
+export function registerChatUsageTools(server: McpServer): void {
+  server.registerTool(
+    "get_chat_usage_metrics",
+    {
+      title: "チャット機能の利用状況を取得",
+      description:
+        "チャット・AIインタビューのLLM利用イベント（chat_usage_events）をprompt_nameごとに集計して返す。" +
+        "各行は prompt_name / event_count（LLM応答回数）/ unique_user_count / unique_session_count / total_tokens / total_cost_usd（USD）で、event_count降順。" +
+        "session_idを記録しないイベントは unique_session_count に含まれない（event_countには含まれる）。" +
+        "prompt_nameの内訳: top-chat-system=トップページのチャット、bill-chat-system-normal / bill-chat-system-hard=議案ページのチャット（難易度別）、" +
+        "interview-chat / interview-initial-question / interview-summary=AIインタビュー関連。" +
+        "from/to は occurred_at の範囲（fromは以上、toは未満）。未指定なら全期間。" +
+        "billId指定時は metadata.billId でフィルタする。議案チャットとインタビュー系はbillIdを記録するが、トップページチャット（top-chat-system）は記録しないため、指定するとトップチャットは結果に含まれない。",
+      inputSchema: {
+        from: z
+          .string()
+          .datetime({ offset: true })
+          .optional()
+          .describe(
+            "集計開始日時（ISO 8601、この日時以降）。未指定なら制限なし"
+          ),
+        to: z
+          .string()
+          .datetime({ offset: true })
+          .optional()
+          .describe(
+            "集計終了日時（ISO 8601、この日時より前）。未指定なら制限なし"
+          ),
+        billId: z
+          .string()
+          .uuid()
+          .optional()
+          .describe("対象議案のID（議案チャットのみに絞る場合に指定）"),
+      },
+    },
+    async ({ from, to, billId }) => {
+      const metrics = await findChatUsageMetrics({ from, to, billId });
+      return jsonResult(metrics);
+    }
+  );
+}

--- a/packages/supabase/types/supabase.types.ts
+++ b/packages/supabase/types/supabase.types.ts
@@ -1217,6 +1217,17 @@ export type Database = {
           last_sign_in_at: string
         }[]
       }
+      get_chat_usage_metrics: {
+        Args: { p_bill_id?: string; p_from?: string; p_to?: string }
+        Returns: {
+          event_count: number
+          prompt_name: string
+          total_cost_usd: number
+          total_tokens: number
+          unique_session_count: number
+          unique_user_count: number
+        }[]
+      }
       get_interview_message_counts: {
         Args: { session_ids: string[] }
         Returns: {

--- a/supabase/migrations/20260713100000_add_get_chat_usage_metrics.sql
+++ b/supabase/migrations/20260713100000_add_get_chat_usage_metrics.sql
@@ -1,0 +1,50 @@
+-- チャット利用状況（chat_usage_events）を prompt_name ごとに集計する
+-- 内部向けMCPツール get_chat_usage_metrics 用
+--
+-- prompt_name の例:
+--   bill-chat-system-* … 議案ページのAIチャット
+--   interview-chat / interview-summary / interview-initial-question … AIインタビュー
+-- p_bill_id は metadata->>'billId' でのフィルタ。議案チャットとインタビュー系は
+-- billId を記録するが、トップページチャット（top-chat-system）は記録しないため、
+-- 指定時はトップチャットのイベントは対象外になる。
+--
+-- occurred_at / metadata->>'billId' へのインデックスは意図的に追加していない:
+-- 全期間集計はどのみち全件スキャンが必要で（実測: 15万行で約170ms）、
+-- 低頻度の内部ツールのためにイベント挿入（ホットパス）へ恒常的な
+-- インデックス維持コストを載せる方が高くつくため。ダッシュボード等から
+-- 定常的に呼ぶようになったら occurred_at 単独インデックスの追加を検討する。
+create or replace function public.get_chat_usage_metrics(
+  p_from timestamptz default null,
+  p_to timestamptz default null,
+  p_bill_id uuid default null
+)
+returns table (
+  prompt_name text,
+  event_count bigint,
+  unique_user_count bigint,
+  unique_session_count bigint,
+  total_tokens bigint,
+  total_cost_usd numeric
+)
+language sql
+stable
+as $$
+  select
+    coalesce(e.prompt_name, '(unknown)') as prompt_name,
+    count(*) as event_count,
+    count(distinct e.user_id) as unique_user_count,
+    count(distinct e.session_id) as unique_session_count,
+    coalesce(sum(e.total_tokens), 0)::bigint as total_tokens,
+    coalesce(sum(e.cost_usd), 0) as total_cost_usd
+  from public.chat_usage_events e
+  where (p_from is null or e.occurred_at >= p_from)
+    and (p_to is null or e.occurred_at < p_to)
+    and (p_bill_id is null or e.metadata ->> 'billId' = p_bill_id::text)
+  group by 1
+  order by event_count desc;
+$$;
+
+revoke execute on function public.get_chat_usage_metrics(timestamptz, timestamptz, uuid) from public;
+revoke execute on function public.get_chat_usage_metrics(timestamptz, timestamptz, uuid) from anon;
+revoke execute on function public.get_chat_usage_metrics(timestamptz, timestamptz, uuid) from authenticated;
+grant execute on function public.get_chat_usage_metrics(timestamptz, timestamptz, uuid) to service_role;

--- a/tests/mcp/chat-usage-tools.test.ts
+++ b/tests/mcp/chat-usage-tools.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { registerChatUsageTools } from "../../admin/src/features/mcp/server/tools/register-chat-usage-tools";
+import type { Database } from "../../packages/supabase/types/supabase.types";
+import {
+  adminClient,
+  cleanupTestUser,
+  createTestUser,
+  type TestUser,
+} from "../supabase/utils";
+import { createTestRegistry, type TestMcpRegistry } from "./utils";
+
+// 既存データと干渉しないよう、未来の期間にテストデータを置き from/to で絞り込む
+// （tests/supabase/db-function/get-chat-usage-metrics.test.ts とも干渉しないよう年をずらしている）
+const WINDOW_FROM = "2034-01-01T00:00:00.000Z";
+const WINDOW_TO = "2034-01-02T00:00:00.000Z";
+
+type MetricsRow =
+  Database["public"]["Functions"]["get_chat_usage_metrics"]["Returns"][number];
+
+describe("MCP chat usage tools", () => {
+  let registry: TestMcpRegistry;
+  let testUser: TestUser;
+
+  beforeEach(async () => {
+    registry = createTestRegistry();
+    registerChatUsageTools(registry.asMcpServer());
+    testUser = await createTestUser();
+  });
+
+  afterEach(async () => {
+    await adminClient
+      .from("chat_usage_events")
+      .delete()
+      .eq("user_id", testUser.id);
+    await cleanupTestUser(testUser.id);
+  });
+
+  describe("get_chat_usage_metrics", () => {
+    it("期間内のチャット利用状況をprompt_nameごとに返す", async () => {
+      expect(registry.hasTool("get_chat_usage_metrics")).toBe(true);
+
+      const { error } = await adminClient.from("chat_usage_events").insert({
+        user_id: testUser.id,
+        prompt_name: "mcp-test-chat",
+        model: "test-model",
+        total_tokens: 500,
+        cost_usd: 0.05,
+        occurred_at: "2034-01-01T12:00:00.000Z",
+      });
+      if (error) throw new Error(error.message);
+
+      const result = await registry.callTool<MetricsRow[]>(
+        "get_chat_usage_metrics",
+        { from: WINDOW_FROM, to: WINDOW_TO }
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        prompt_name: "mcp-test-chat",
+        event_count: 1,
+        unique_user_count: 1,
+        total_tokens: 500,
+      });
+    });
+  });
+});

--- a/tests/supabase/db-function/get-chat-usage-metrics.test.ts
+++ b/tests/supabase/db-function/get-chat-usage-metrics.test.ts
@@ -1,0 +1,201 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  adminClient,
+  cleanupTestUser,
+  createTestUser,
+  type TestUser,
+} from "../utils";
+
+// 既存データと干渉しないよう、未来の期間にテストデータを置き
+// from/to で必ず絞り込んで検証する
+// （tests/mcp/chat-usage-tools.test.ts とも干渉しないよう年をずらしている）
+const WINDOW_FROM = "2033-01-01T00:00:00.000Z";
+const WINDOW_TO = "2033-01-02T00:00:00.000Z";
+const iso = (offsetSec: number) =>
+  new Date(new Date(WINDOW_FROM).getTime() + offsetSec * 1000).toISOString();
+
+async function insertUsageEvent(params: {
+  userId: string;
+  promptName: string | null;
+  occurredAt: string;
+  sessionId?: string;
+  billId?: string;
+  totalTokens?: number;
+  costUsd?: number;
+}): Promise<void> {
+  const { error } = await adminClient.from("chat_usage_events").insert({
+    user_id: params.userId,
+    session_id: params.sessionId ?? null,
+    prompt_name: params.promptName,
+    model: "test-model",
+    total_tokens: params.totalTokens ?? 100,
+    cost_usd: params.costUsd ?? 0.01,
+    occurred_at: params.occurredAt,
+    metadata: params.billId ? { billId: params.billId } : null,
+  });
+  if (error) throw new Error(`chat_usage_events 作成失敗: ${error.message}`);
+}
+
+describe("get_chat_usage_metrics() 関数", () => {
+  let user1: TestUser;
+  let user2: TestUser;
+  beforeEach(async () => {
+    user1 = await createTestUser();
+    user2 = await createTestUser();
+  });
+
+  afterEach(async () => {
+    await adminClient
+      .from("chat_usage_events")
+      .delete()
+      .in("user_id", [user1.id, user2.id]);
+    await cleanupTestUser(user1.id);
+    await cleanupTestUser(user2.id);
+  });
+
+  it("prompt_nameごとに件数・ユニークユーザー・トークン・コストを集計する", async () => {
+    // test-chat-a: user1が2回（同一セッション）、user2が1回
+    await insertUsageEvent({
+      userId: user1.id,
+      promptName: "test-chat-a",
+      occurredAt: iso(0),
+      sessionId: "session-1",
+      totalTokens: 100,
+      costUsd: 0.01,
+    });
+    await insertUsageEvent({
+      userId: user1.id,
+      promptName: "test-chat-a",
+      occurredAt: iso(10),
+      sessionId: "session-1",
+      totalTokens: 200,
+      costUsd: 0.02,
+    });
+    await insertUsageEvent({
+      userId: user2.id,
+      promptName: "test-chat-a",
+      occurredAt: iso(20),
+      sessionId: "session-2",
+      totalTokens: 300,
+      costUsd: 0.03,
+    });
+    // test-chat-b: user1が1回
+    await insertUsageEvent({
+      userId: user1.id,
+      promptName: "test-chat-b",
+      occurredAt: iso(30),
+      totalTokens: 50,
+      costUsd: 0.005,
+    });
+
+    const { data, error } = await adminClient.rpc("get_chat_usage_metrics", {
+      p_from: WINDOW_FROM,
+      p_to: WINDOW_TO,
+    });
+
+    expect(error).toBeNull();
+    expect(data).toHaveLength(2);
+    // event_count 降順
+    expect(data?.[0]).toMatchObject({
+      prompt_name: "test-chat-a",
+      event_count: 3,
+      unique_user_count: 2,
+      unique_session_count: 2,
+      total_tokens: 600,
+    });
+    expect(Number(data?.[0].total_cost_usd)).toBeCloseTo(0.06, 6);
+    expect(data?.[1]).toMatchObject({
+      prompt_name: "test-chat-b",
+      event_count: 1,
+      unique_user_count: 1,
+      unique_session_count: 0,
+      total_tokens: 50,
+    });
+  });
+
+  it("期間フィルタが機能する（from以上・to未満）", async () => {
+    await insertUsageEvent({
+      userId: user1.id,
+      promptName: "test-chat-range",
+      occurredAt: iso(0),
+    });
+    await insertUsageEvent({
+      userId: user1.id,
+      promptName: "test-chat-range",
+      occurredAt: iso(3600),
+    });
+
+    // 前半のみを対象にする
+    const { data, error } = await adminClient.rpc("get_chat_usage_metrics", {
+      p_from: WINDOW_FROM,
+      p_to: iso(1800),
+    });
+
+    expect(error).toBeNull();
+    const row = data?.find((r) => r.prompt_name === "test-chat-range");
+    expect(row?.event_count).toBe(1);
+  });
+
+  it("billIdフィルタは metadata.billId が一致するイベントのみ返す", async () => {
+    const billId = crypto.randomUUID();
+    await insertUsageEvent({
+      userId: user1.id,
+      promptName: "test-bill-chat",
+      occurredAt: iso(0),
+      billId,
+    });
+    await insertUsageEvent({
+      userId: user1.id,
+      promptName: "test-bill-chat",
+      occurredAt: iso(10),
+      billId: crypto.randomUUID(), // 別議案
+    });
+    await insertUsageEvent({
+      userId: user1.id,
+      promptName: "test-no-bill",
+      occurredAt: iso(20), // metadataなし
+    });
+
+    const { data, error } = await adminClient.rpc("get_chat_usage_metrics", {
+      p_from: WINDOW_FROM,
+      p_to: WINDOW_TO,
+      p_bill_id: billId,
+    });
+
+    expect(error).toBeNull();
+    expect(data).toHaveLength(1);
+    expect(data?.[0]).toMatchObject({
+      prompt_name: "test-bill-chat",
+      event_count: 1,
+    });
+  });
+
+  it("prompt_nameがNULLのイベントは (unknown) に集計する", async () => {
+    await insertUsageEvent({
+      userId: user1.id,
+      promptName: null,
+      occurredAt: iso(0),
+    });
+
+    const { data, error } = await adminClient.rpc("get_chat_usage_metrics", {
+      p_from: WINDOW_FROM,
+      p_to: WINDOW_TO,
+    });
+
+    expect(error).toBeNull();
+    expect(data?.[0]).toMatchObject({
+      prompt_name: "(unknown)",
+      event_count: 1,
+    });
+  });
+
+  it("該当イベントがない場合は空配列を返す", async () => {
+    const { data, error } = await adminClient.rpc("get_chat_usage_metrics", {
+      p_from: "2032-01-01T00:00:00.000Z",
+      p_to: "2032-01-02T00:00:00.000Z",
+    });
+
+    expect(error).toBeNull();
+    expect(data).toEqual([]);
+  });
+});


### PR DESCRIPTION
## 概要

内部向けMCP（admin `/api/mcp`）に、チャット機能の利用状況を確認できる読み取りツール `get_chat_usage_metrics` を追加します。

「トップ/議案チャット・AIインタビューがどれだけ使われているか」を、MCP経由で（Claude等から）直接聞けるようになります。

## 実装内容

### DB関数 `get_chat_usage_metrics(p_from, p_to, p_bill_id)`
`chat_usage_events` を `prompt_name` ごとに集計して返します（`event_count` 降順）：

| カラム | 意味 |
|---|---|
| `prompt_name` | 利用種別（`top-chat-system` / `bill-chat-system-normal` / `bill-chat-system-hard` / `interview-chat` / `interview-initial-question` / `interview-summary`、NULLは `(unknown)`） |
| `event_count` | LLM応答回数 |
| `unique_user_count` / `unique_session_count` | ユニークユーザー / セッション数 |
| `total_tokens` / `total_cost_usd` | 総トークン / 総コスト（USD） |

- `p_from` / `p_to`: `occurred_at` の範囲（from以上・to未満）。未指定なら全期間
- `p_bill_id`: `metadata->>'billId'` でフィルタ。議案チャット・インタビュー系はbillIdを記録するが、トップチャットは記録しないため対象外になる（コード実測で確認済み）
- 既存の `sum_chat_usage_cost` と同じ `language sql stable` + service_role限定のgrant/revokeパターン

### MCPツール
- `admin/src/features/mcp/server/tools/register-chat-usage-tools.ts`（repository経由でRPC呼び出し、既存の `register-interview-metrics-tools` と同構成）
- adminにチャットのドメインfeatureが存在しないため、repositoryは `features/mcp/server/repositories/` に新設

### インデックスを追加しない判断について
Codexレビューで `occurred_at` / `metadata->>'billId'` のインデックス追加が提案されましたが、ローカルの実測（15万行）で全期間集計167ms・期間指定22msであり、低頻度の内部ツールのためにイベント挿入ホットパスへ恒常的なインデックス維持コストを載せる方が高くつくため見送りました（判断理由はマイグレーションコメントに明記）。ダッシュボード等から定常的に呼ぶようになった時点で `occurred_at` 単独インデックスを追加します。

## 実行テスト記録

- `tests/supabase/db-function/get-chat-usage-metrics.test.ts`: 5件（集計・降順ソート・期間境界・billIdフィルタ・NULL prompt_name・空結果）。既存データと干渉しないよう未来期間（2033年）にテストデータを配置
- `tests/mcp/chat-usage-tools.test.ts`: ツール登録＋実RPC呼び出し1件（2034年に配置）
- `pnpm --filter admin test`: 487件パス / `pnpm lint` / `pnpm typecheck`: パス
- ローカル実データでのスモークテスト: top-chat 51,170回（16,020ユーザー）、interview-chat 51,117回、bill-chat計35,342回等が正しく集計されることを確認
- `pnpm build` / `pnpm --filter web test`: developでも同一エラーとなるローカル環境問題のためCIで確認

## スキーマ変更

- 新規マイグレーション `20260713100000_add_get_chat_usage_metrics.sql`（DB関数の追加のみ、テーブル変更なし）
- `packages/supabase/types/supabase.types.ts` に関数型を追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 管理用MCPサーバーに、チャット利用状況の集計ツールを追加しました。
  * 期間や議案を指定して、イベント数、利用者数、セッション数、トークン数、コストを確認できます。
  * チャット種別ごとの集計結果を取得できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->