### PR TITLE
トピック分析の定期実行: Cloud Scheduler をプロビジョニングに追加

### DIFF
--- a/docs/20260715_1043_トピック分析スケジューラー化.md
+++ b/docs/20260715_1043_トピック分析スケジューラー化.md
@@ -1,0 +1,82 @@
+# ユーザー向けトピック分析の定期実行（Cloud Scheduler）設定
+
+[トピック分析CloudRun実行基盤設計](20260609_1200_トピック分析CloudRun実行基盤設計.md) §9 で「次フェーズ」とされていた cron（定期実行）を有効化するための設計・手順。プロビジョニングは [infra/cloud-run/provision.sh](../infra/cloud-run/provision.sh) に追加済みで、本書はその背景と運用をまとめる。
+
+## 1. 方針: `--mode=cron` は実装せず `--mode=analyze-all` を叩く
+
+元設計では「Cloud Scheduler が `--mode=cron` で起動し、worker がトリガ条件で対象議案を選別する」想定だったが、その後 worker に実装された `--mode=analyze-all`（全議案・増分）が同じ役割を既に果たしている:
+
+- 全議案を走査し、**対象意見が無い議案・新規意見が無い分析済み議案はスキップ**する（`runAnalyzeAll` / strategy=incremental）。
+- スキップ判定は DB の意見抽出状態に基づくため、日次で回しても LLM コストは新規意見分のみ。
+- admin の手動一括実行（`/api/user-topic-analysis/dispatch-all`）と同一経路であり、挙動が二重化しない。
+
+よって worker 側の追加実装は不要とし、**Cloud Scheduler から既存の `--mode=analyze-all` を起動する**構成を採る。
+
+## 2. 構成
+
+```
+[Cloud Scheduler: topic-analysis-cron-<env>]
+   │  日次 cron（既定 6:00 Asia/Tokyo）
+   │  POST https://run.googleapis.com/v2/projects/<P>/locations/<R>/jobs/<JOB>:run
+   │  body: {"overrides":{"containerOverrides":[{"args":["--mode=analyze-all"]}]}}
+   │  認証: OAuth（scheduler SA）
+   ▼
+[Cloud Run Job: topic-analysis-worker-<env>]  --mode=analyze-all（増分）
+   ▼
+Supabase（topic_analysis_version / topic / topic_opinion）
+```
+
+### 追加リソース（provision.sh が冪等に作成）
+
+| リソース | 内容 |
+| :-- | :-- |
+| API | `cloudscheduler.googleapis.com` を有効化 |
+| SA `topic-analysis-scheduler` | Scheduler が Job を起動する専用 SA。custom role `topicAnalysisJobInvoker`（`run.jobs.run` + `run.jobs.runWithOverrides`）+ runtime SA への actAs。**鍵は発行しない**（Scheduler がGCP内部で OAuth トークンを取得する） |
+| Cloud Scheduler `topic-analysis-cron-<DEPLOY_ENV>` | 上記 HTTP ターゲット。既存なら設定を更新（provision.sh が設定のオーナー） |
+
+- admin 用の invoker SA を使い回さず専用 SA にするのは、Vercel に鍵を置く invoker と権限のライフサイクルを分離するため（漏えい時の影響範囲を限定）。
+- overrides で args を渡すため `run.jobs.runWithOverrides` が必要。既存の custom role をそのまま付与する。
+
+### 設定（config.env）
+
+| 変数 | 既定 | 用途 |
+| :-- | :-- | :-- |
+| `SCHEDULER_CRON` | `0 6 * * *` | cron 式（毎日 6:00） |
+| `SCHEDULER_TIMEZONE` | `Asia/Tokyo` | タイムゾーン |
+| `SCHEDULER_PAUSED` | `0` | `1` で PAUSED 状態に揃える（環境ごとに停止したい場合） |
+| `SCHEDULER_JOB_NAME` | `topic-analysis-cron-<DEPLOY_ENV>` | ジョブ名の明示指定 |
+| `SCHEDULER_SA_NAME` | `topic-analysis-scheduler` | SA 名の明示指定 |
+
+## 3. 適用手順（環境ごと）
+
+```bash
+# 既存の config.env（staging / production）をそのまま使い、provision を再実行するだけ
+CONFIG_FILE=infra/cloud-run/config.env.staging    bash infra/cloud-run/provision.sh
+CONFIG_FILE=infra/cloud-run/config.env.production bash infra/cloud-run/provision.sh
+```
+
+staging を止めておきたい場合は `config.env.staging` に `export SCHEDULER_PAUSED=1` を追加して実行する。
+
+## 4. 動作確認
+
+```bash
+# スケジュールを待たず手動トリガ
+gcloud scheduler jobs run topic-analysis-cron-<env> --location asia-northeast1
+
+# Job 実行が起きたことを確認
+gcloud run jobs executions list --job topic-analysis-worker-<env> --region asia-northeast1
+
+# worker のログ（analyze-all の進捗・skip 判定が出る）
+gcloud logging read 'resource.type="cloud_run_job"' --limit 50
+```
+
+確認ポイント:
+
+- 新規意見が無い議案が `skip (新規意見なし)` でスキップされること。
+- 実行後に admin のトピック分析画面で version が増えている（新規意見があった議案のみ）こと。
+
+## 5. 運用・ロールバック
+
+- **停止**: `SCHEDULER_PAUSED=1` で provision 再実行（または `gcloud scheduler jobs pause`）。ジョブ定義は残るため再開は `0` に戻すだけ。
+- **多重起動**: Cloud Run Job 側は `parallelism=1 / tasks=1`。Scheduler は日次のため、手動実行（admin の dispatch-all）と重なる可能性は低いが、重なった場合も version 作成は議案ごとに直列でありスキップ判定が効く。
+- **失敗時**: Job の `max-retries=1` に委譲。Scheduler 側のリトライは設定しない（翌日の実行で追いつく増分設計のため）。

--- a/infra/cloud-run/README.md
+++ b/infra/cloud-run/README.md
@@ -11,13 +11,15 @@
 
 | リソース | 内容 |
 | --- | --- |
-| API | run / artifactregistry / secretmanager を有効化 |
+| API | run / artifactregistry / secretmanager / cloudscheduler を有効化 |
 | Artifact Registry | docker リポジトリ（既定 `topic-analysis`） |
 | Secret Manager | `SUPABASE_URL` / `SUPABASE_SECRET_KEY` / `AI_GATEWAY_API_KEY` に **環境サフィックス**を付けたもの（例 `SUPABASE_URL_STAGING`）。**コンテナのみ**・値は別途 |
 | SA: runtime | Job 実行用。secret 読み取り権限 |
-| SA: invoker | admin が `jobs:run` を呼ぶ用。run.invoker + runtime への actAs |
+| SA: invoker | admin が `jobs:run` を呼ぶ用。custom invoker role + runtime への actAs |
+| SA: scheduler | Cloud Scheduler が `jobs:run` を呼ぶ用。custom invoker role + runtime への actAs（**鍵は発行しない**） |
 | SA: deployer | CI（`deploy_worker.yml`）用。AR writer + run.developer + actAs |
 | Cloud Run Job | `topic-analysis-worker-<DEPLOY_ENV>`（batch 向け設定）。**無ければ作成**、以後の image 更新は CI |
+| Cloud Scheduler | `topic-analysis-cron-<DEPLOY_ENV>`。日次（既定 6:00 JST）で Job を `--mode=analyze-all`（全議案・増分）で起動。**作成 or 設定更新**（冪等） |
 
 ## 環境（staging / production）の分離
 
@@ -77,11 +79,22 @@ CONFIG_FILE=infra/cloud-run/config.env.production bash infra/cloud-run/provision
 - **SA キーの発行**は既定で無効。`GENERATE_KEYS=1` のときだけ発行し、Vercel/GitHub へ登録後に
   ローカルの鍵ファイル（`*-key.json`・gitignore 済み）を必ず削除する。
 
+## 定期実行（Cloud Scheduler）
+
+日次（既定 6:00 JST）で Cloud Run Job を `--mode=analyze-all`（全議案・増分）で起動する
+Cloud Scheduler ジョブを作成する。スケジュールは `SCHEDULER_CRON` / `SCHEDULER_TIMEZONE`、
+停止したい環境は `SCHEDULER_PAUSED=1` で調整する（config.example.env 参照）。
+設計の背景・動作確認・運用は
+[docs/20260715_1043_トピック分析スケジューラー化.md](../../docs/20260715_1043_トピック分析スケジューラー化.md)
+を参照。
+
 ## 冪等性
 
 - 既存リソースは `describe` で検知して skip（API 有効化・IAM binding は元来冪等）。
 - Cloud Run Job は「無ければ作成」のみ。**イメージ差し替えは CI（`deploy_worker.yml`）**が担うため、
   既存 Job には触れない。
+- Cloud Scheduler は provision.sh が設定のオーナー。既存なら **設定を更新**し、
+  有効/一時停止も `SCHEDULER_PAUSED` に揃える。
 
 ## 関連
 

--- a/infra/cloud-run/config.example.env
+++ b/infra/cloud-run/config.example.env
@@ -30,6 +30,15 @@ export GCP_AR_REPO="topic-analysis"
 # export SECRET_VALUE_SUPABASE_SECRET_KEY="sb_secret_xxx"
 # export SECRET_VALUE_AI_GATEWAY_API_KEY="xxx"
 
+# ── Cloud Scheduler（定期実行・任意） ──
+# 毎日 SCHEDULER_CRON の時刻に Cloud Run Job を --mode=analyze-all（全議案・増分）で起動する。
+# 詳細は docs/20260715_1043_トピック分析スケジューラー化.md を参照。
+# export SCHEDULER_CRON="0 6 * * *"        # 既定: 毎日 6:00
+# export SCHEDULER_TIMEZONE="Asia/Tokyo"   # 既定: Asia/Tokyo
+# export SCHEDULER_PAUSED=1                # 一時停止状態で作りたい環境（例: staging）は 1
+# Scheduler ジョブ名を明示指定したい場合のみ（既定: topic-analysis-cron-<DEPLOY_ENV>）。
+# export SCHEDULER_JOB_NAME="topic-analysis-cron-staging"
+
 # ── 初回 Job 作成に使うイメージ（任意） ──
 # 未指定なら worker/Dockerfile から bootstrap イメージをビルド&push して作成する。
 # export WORKER_IMAGE="asia-northeast1-docker.pkg.dev/<project>/topic-analysis/topic-analysis-worker:<tag>"

--- a/infra/cloud-run/provision.sh
+++ b/infra/cloud-run/provision.sh
@@ -40,8 +40,13 @@ AR_REPO="${GCP_AR_REPO:-topic-analysis}"
 RUNTIME_SA_NAME="${RUNTIME_SA_NAME:-topic-analysis-runtime}"
 INVOKER_SA_NAME="${INVOKER_SA_NAME:-topic-analysis-invoker}"
 DEPLOYER_SA_NAME="${DEPLOYER_SA_NAME:-topic-analysis-deployer}"
+SCHEDULER_SA_NAME="${SCHEDULER_SA_NAME:-topic-analysis-scheduler}"
 WORKER_IMAGE="${WORKER_IMAGE:-}"      # 空なら初回 Job 作成時に bootstrap をビルド
 GENERATE_KEYS="${GENERATE_KEYS:-0}"   # 1 のとき SA キーを発行（既定は無効＝安全側）
+# Cloud Scheduler（定期実行）。cron 式と一時停止フラグは環境ごとに config.env で調整する。
+SCHEDULER_CRON="${SCHEDULER_CRON:-0 6 * * *}"
+SCHEDULER_TIMEZONE="${SCHEDULER_TIMEZONE:-Asia/Tokyo}"
+SCHEDULER_PAUSED="${SCHEDULER_PAUSED:-0}"   # 1 のとき一時停止状態にする（リソースは作る）
 
 if [[ -z "$PROJECT_ID" ]]; then
   echo "ERROR: GCP_PROJECT_ID が未設定です（config.env か環境変数で指定）。" >&2
@@ -60,10 +65,12 @@ fi
 ENV_UPPER="$(printf '%s' "$DEPLOY_ENV" | tr '[:lower:]' '[:upper:]')"
 SECRET_SUFFIX="${SECRET_SUFFIX:-_${ENV_UPPER}}"
 JOB="${GCP_TOPIC_ANALYSIS_JOB:-topic-analysis-worker-${DEPLOY_ENV}}"
+SCHEDULER_JOB="${SCHEDULER_JOB_NAME:-topic-analysis-cron-${DEPLOY_ENV}}"
 
 RUNTIME_SA="${RUNTIME_SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
 INVOKER_SA="${INVOKER_SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
 DEPLOYER_SA="${DEPLOYER_SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
+SCHEDULER_SA="${SCHEDULER_SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
 # worker が読む環境変数名（固定）。実体の Secret 名は ${ENV_VAR}${SECRET_SUFFIX}。
 SECRET_ENV_VARS=(SUPABASE_URL SUPABASE_SECRET_KEY AI_GATEWAY_API_KEY)
 # この環境で作成・参照する実 Secret 名。
@@ -78,11 +85,12 @@ log "環境: DEPLOY_ENV=${DEPLOY_ENV} / Secret 接尾辞=${SECRET_SUFFIX} / Job=
 gcloud config set project "$PROJECT_ID" >/dev/null
 
 # ── 1. API 有効化（services enable は冪等） ──
-log "API 有効化 (run / artifactregistry / secretmanager)"
+log "API 有効化 (run / artifactregistry / secretmanager / cloudscheduler)"
 gcloud services enable \
   run.googleapis.com \
   artifactregistry.googleapis.com \
   secretmanager.googleapis.com \
+  cloudscheduler.googleapis.com \
   --project "$PROJECT_ID"
 
 # ── 2. Artifact Registry リポジトリ ──
@@ -140,6 +148,7 @@ ensure_sa() {
 ensure_sa "$RUNTIME_SA_NAME" "Topic Analysis Worker Runtime"
 ensure_sa "$INVOKER_SA_NAME" "Topic Analysis Job Invoker (admin)"
 ensure_sa "$DEPLOYER_SA_NAME" "Topic Analysis Worker Deployer (CI)"
+ensure_sa "$SCHEDULER_SA_NAME" "Topic Analysis Scheduler (cron)"
 
 # ── 5. runtime SA に各 secret の読み取り権限（add-iam-policy-binding は冪等） ──
 for s in "${SECRETS[@]}"; do
@@ -187,9 +196,10 @@ else
     --memory 1Gi
 fi
 
-# ── 7. invoker SA（admin が Job を起動）: jobs.run + jobs.runWithOverrides + actAs ──
-# admin は overrides（--mode 等の args 上書き）で起動するため run.jobs.runWithOverrides が要る。
-# roles/run.invoker には含まれないので、最小権限のカスタムロールを定義して付与する
+# ── 7. invoker / scheduler SA（Job を起動する側）: jobs.run + jobs.runWithOverrides + actAs ──
+# admin・Cloud Scheduler とも overrides（--mode 等の args 上書き）で起動するため
+# run.jobs.runWithOverrides が要る。roles/run.invoker には含まれないので、
+# 最小権限のカスタムロールを定義して付与する
 # （roles/run.developer は job 更新・削除まで許してしまい broad すぎるため避ける）。
 INVOKER_ROLE_ID="topicAnalysisJobInvoker"
 if gcloud iam roles describe "$INVOKER_ROLE_ID" \
@@ -204,17 +214,62 @@ else
     --description="Execute the topic-analysis Cloud Run job (with overrides)" \
     --permissions="run.jobs.run,run.jobs.runWithOverrides" >/dev/null
 fi
-gcloud projects add-iam-policy-binding "$PROJECT_ID" \
-  --member="serviceAccount:${INVOKER_SA}" \
-  --role="projects/${PROJECT_ID}/roles/${INVOKER_ROLE_ID}" \
-  --condition=None >/dev/null
-gcloud iam service-accounts add-iam-policy-binding "$RUNTIME_SA" \
-  --project "$PROJECT_ID" \
-  --member="serviceAccount:${INVOKER_SA}" \
-  --role="roles/iam.serviceAccountUser" >/dev/null
-log "invoker SA に jobs.run/runWithOverrides（custom role）+ runtime SA への actAs を付与"
+for sa in "$INVOKER_SA" "$SCHEDULER_SA"; do
+  gcloud projects add-iam-policy-binding "$PROJECT_ID" \
+    --member="serviceAccount:${sa}" \
+    --role="projects/${PROJECT_ID}/roles/${INVOKER_ROLE_ID}" \
+    --condition=None >/dev/null
+  gcloud iam service-accounts add-iam-policy-binding "$RUNTIME_SA" \
+    --project "$PROJECT_ID" \
+    --member="serviceAccount:${sa}" \
+    --role="roles/iam.serviceAccountUser" >/dev/null
+done
+log "invoker / scheduler SA に jobs.run/runWithOverrides（custom role）+ runtime SA への actAs を付与"
 
-# ── 8. deployer SA（CI がイメージ push + Job 更新）: AR writer + run.developer + actAs ──
+# ── 8. Cloud Scheduler（定期実行: 全議案の増分分析）──
+# run.jobs.run（Cloud Run Admin API v2）を OAuth で叩き、overrides で --mode=analyze-all を渡す。
+# 設計・運用は docs/20260715_1043_トピック分析スケジューラー化.md を参照。
+RUN_JOB_URI="https://run.googleapis.com/v2/projects/${PROJECT_ID}/locations/${REGION}/jobs/${JOB}:run"
+SCHEDULER_BODY='{"overrides":{"containerOverrides":[{"args":["--mode=analyze-all"]}]}}'
+scheduler_flags=(
+  --location "$REGION"
+  --project "$PROJECT_ID"
+  --schedule "$SCHEDULER_CRON"
+  --time-zone "$SCHEDULER_TIMEZONE"
+  --uri "$RUN_JOB_URI"
+  --http-method POST
+  --message-body "$SCHEDULER_BODY"
+  --oauth-service-account-email "$SCHEDULER_SA"
+  --attempt-deadline 180s
+)
+# describe 1回で存在確認と state 取得を兼ねる（update は state を保持する）。
+scheduler_state="$(gcloud scheduler jobs describe "$SCHEDULER_JOB" \
+  --location "$REGION" --project "$PROJECT_ID" \
+  --format='value(state)' 2>/dev/null || true)"
+if [[ -n "$scheduler_state" ]]; then
+  log "scheduler '$SCHEDULER_JOB' は既存（設定を更新: cron='${SCHEDULER_CRON}' tz=${SCHEDULER_TIMEZONE}）"
+  gcloud scheduler jobs update http "$SCHEDULER_JOB" \
+    "${scheduler_flags[@]}" \
+    --update-headers Content-Type=application/json >/dev/null
+else
+  log "scheduler '$SCHEDULER_JOB' を作成（cron='${SCHEDULER_CRON}' tz=${SCHEDULER_TIMEZONE}）"
+  gcloud scheduler jobs create http "$SCHEDULER_JOB" \
+    "${scheduler_flags[@]}" \
+    --headers Content-Type=application/json >/dev/null
+  scheduler_state="ENABLED"   # 新規作成直後は必ず ENABLED
+fi
+# 望む状態（有効/一時停止）へ冪等に揃える。
+if [[ "$SCHEDULER_PAUSED" == "1" && "$scheduler_state" != "PAUSED" ]]; then
+  log "scheduler '$SCHEDULER_JOB' を一時停止（SCHEDULER_PAUSED=1）"
+  gcloud scheduler jobs pause "$SCHEDULER_JOB" \
+    --location "$REGION" --project "$PROJECT_ID" >/dev/null
+elif [[ "$SCHEDULER_PAUSED" != "1" && "$scheduler_state" == "PAUSED" ]]; then
+  log "scheduler '$SCHEDULER_JOB' を再開"
+  gcloud scheduler jobs resume "$SCHEDULER_JOB" \
+    --location "$REGION" --project "$PROJECT_ID" >/dev/null
+fi
+
+# ── 9. deployer SA（CI がイメージ push + Job 更新）: AR writer + run.developer + actAs ──
 gcloud artifacts repositories add-iam-policy-binding "$AR_REPO" \
   --location "$REGION" --project "$PROJECT_ID" \
   --member="serviceAccount:${DEPLOYER_SA}" \
@@ -229,7 +284,7 @@ gcloud iam service-accounts add-iam-policy-binding "$RUNTIME_SA" \
   --role="roles/iam.serviceAccountUser" >/dev/null
 log "deployer SA に artifactregistry.writer + run.developer + actAs を付与"
 
-# ── 9. SA キー発行（任意・GENERATE_KEYS=1 のときのみ。鍵はコミットしない＝gitignore 済み） ──
+# ── 10. SA キー発行（任意・GENERATE_KEYS=1 のときのみ。鍵はコミットしない＝gitignore 済み） ──
 if [[ "$GENERATE_KEYS" == "1" ]]; then
   log "SA キーを発行（invoker-key.json / deployer-key.json）"
   gcloud iam service-accounts keys create "${REPO_ROOT}/invoker-key.json" \


### PR DESCRIPTION
## 概要

ユーザー向けトピック分析ジョブのスケジューラー化（[CloudRun実行基盤設計](docs/20260609_1200_トピック分析CloudRun実行基盤設計.md) §9 で「次フェーズ」とされていた cron の有効化）。

worker には `--mode=cron` を新設せず、既存の `--mode=analyze-all`（全議案・増分。新規意見の無い議案はスキップ）を Cloud Scheduler から起動する構成を採用。worker / admin のコード変更はなし。

## 変更内容

- `infra/cloud-run/provision.sh`
  - `cloudscheduler.googleapis.com` の API 有効化を追加
  - Scheduler 専用 SA `topic-analysis-scheduler` を作成（既存 custom role `topicAnalysisJobInvoker` + runtime SA への actAs を付与。admin 用 invoker SA とは鍵ライフサイクル分離のため別 SA。**鍵は発行しない**）
  - Cloud Scheduler ジョブ `topic-analysis-cron-<DEPLOY_ENV>` を作成 or 設定更新（冪等）。日次（既定 `0 6 * * *` Asia/Tokyo）で Cloud Run Admin API `jobs:run` を OAuth で叩き、overrides で `--mode=analyze-all` を渡す
  - `SCHEDULER_PAUSED=1` で PAUSED 状態へ冪等に揃える（環境ごとの停止用）
- `infra/cloud-run/config.example.env`: `SCHEDULER_CRON` / `SCHEDULER_TIMEZONE` / `SCHEDULER_PAUSED` / `SCHEDULER_JOB_NAME` を追記
- `infra/cloud-run/README.md`: 作成リソース表と定期実行セクションを追加
- `docs/20260715_1043_トピック分析スケジューラー化.md`: 設計・適用手順・動作確認・運用（新規）

## 適用方法（インフラ反映）

マージ後、環境ごとに provision を再実行するだけ（冪等）:

```bash
CONFIG_FILE=infra/cloud-run/config.env.staging    bash infra/cloud-run/provision.sh
CONFIG_FILE=infra/cloud-run/config.env.production bash infra/cloud-run/provision.sh
```

staging を止めておく場合は config に `export SCHEDULER_PAUSED=1` を追加。

## 実行テスト記録

- `bash -n infra/cloud-run/provision.sh`（構文チェック）: OK
- `pnpm lint` / `pnpm typecheck` / `pnpm build`: 通過
- `pnpm test`: web の 16 unhandled errors は develop でも同様に発生する既存事象（本PRの差分はシェルスクリプト・Markdown のみでテスト対象コードなし）
- GCP への実プロビジョニングは未実施（マージ後に手動で `provision.sh` を実行して反映する）

🤖 Generated with [Claude Code](https://claude.com/claude-code)