### PR TITLE
admin: トピック分析結果からトピックを個別削除できるようにする

### DIFF
--- a/admin/src/features/user-topic-analysis/client/components/delete-topic-button.tsx
+++ b/admin/src/features/user-topic-analysis/client/components/delete-topic-button.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { Loader2, Trash2 } from "lucide-react";
+import { useTransition } from "react";
+import { Button } from "@/components/ui/button";
+import { deleteTopicAction } from "../../server/actions/delete-topic-actions";
+
+/** 個別トピックを削除するボタン（LLM の誤割当トピックを取り除く手動操作）。 */
+export function DeleteTopicButton({
+  topicId,
+  versionId,
+  billId,
+  title,
+}: {
+  topicId: string;
+  versionId: string;
+  billId: string;
+  title: string;
+}) {
+  const [isPending, startTransition] = useTransition();
+
+  return (
+    <Button
+      type="button"
+      size="sm"
+      variant="outline"
+      disabled={isPending}
+      onClick={() => {
+        const confirmed = window.confirm(
+          `トピック「${title}」を削除しますか？ 紐づく意見の割当も削除されます（意見自体は削除されません）。この操作は取り消せません。`
+        );
+        if (!confirmed) return;
+        startTransition(async () => {
+          await deleteTopicAction({ topicId, versionId, billId });
+        });
+      }}
+    >
+      {isPending ? (
+        <Loader2 className="size-4 animate-spin" />
+      ) : (
+        <Trash2 className="size-4" />
+      )}
+      削除
+    </Button>
+  );
+}

--- a/admin/src/features/user-topic-analysis/server/actions/delete-topic-actions.ts
+++ b/admin/src/features/user-topic-analysis/server/actions/delete-topic-actions.ts
@@ -1,0 +1,17 @@
+"use server";
+
+import { deleteTopic } from "@mirai-gikai/topic-analysis-core/repository";
+import { revalidatePath } from "next/cache";
+import { requireAdmin } from "@/features/auth/server/lib/auth-server";
+import { routes } from "@/lib/routes";
+
+/** Admin による個別トピック削除（LLM の誤割当トピックを取り除く手動操作）。 */
+export async function deleteTopicAction(input: {
+  topicId: string;
+  versionId: string;
+  billId: string;
+}): Promise<void> {
+  await requireAdmin();
+  await deleteTopic(input.topicId, input.versionId);
+  revalidatePath(routes.billUserTopicAnalysis(input.billId));
+}

--- a/admin/src/features/user-topic-analysis/server/components/user-topic-analysis-page.tsx
+++ b/admin/src/features/user-topic-analysis/server/components/user-topic-analysis-page.tsx
@@ -5,6 +5,7 @@ import {
   getTopicsWithOpinions,
   listVersionsByBill,
 } from "@mirai-gikai/topic-analysis-core/repository";
+import { DeleteTopicButton } from "../../client/components/delete-topic-button";
 import { PublishToggleButton } from "../../client/components/publish-toggle-button";
 import { RunAnalysisButton } from "../../client/components/run-analysis-button";
 
@@ -118,9 +119,17 @@ export async function UserTopicAnalysisPage({ billId }: { billId: string }) {
                   <li key={topic.id} className="rounded border p-4">
                     <div className="flex items-baseline justify-between gap-2">
                       <h3 className="font-semibold">{topic.title}</h3>
-                      <span className="shrink-0 text-sm text-gray-500">
-                        {opinions.length}件
-                      </span>
+                      <div className="flex shrink-0 items-center gap-2">
+                        <span className="text-sm text-gray-500">
+                          {opinions.length}件
+                        </span>
+                        <DeleteTopicButton
+                          topicId={topic.id}
+                          versionId={latestCompleted.id}
+                          billId={billId}
+                          title={topic.title}
+                        />
+                      </div>
                     </div>
                     <p className="mt-1 text-sm text-gray-600">
                       {topic.description}

--- a/packages/topic-analysis-core/src/repositories/analysis-repository.ts
+++ b/packages/topic-analysis-core/src/repositories/analysis-repository.ts
@@ -425,6 +425,31 @@ export async function listVersionsByBill(billId: string) {
   return data ?? [];
 }
 
+/**
+ * トピックを個別削除する（Admin 手動操作）。
+ * LLM の誤割当でタイトル・概要と紐づく意見が整合しないトピックを取り除くための操作。
+ * versionId も条件に入れて別 version の同名 topic を誤削除しないようにする。
+ * topic_opinion（割当）は FK ON DELETE CASCADE で自動削除される（意見自体は削除されない）。
+ */
+export async function deleteTopic(
+  topicId: string,
+  versionId: string
+): Promise<void> {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("topic")
+    .delete()
+    .eq("id", topicId)
+    .eq("version_id", versionId)
+    .select("id");
+  if (error) {
+    throw new Error(`Failed to delete topic: ${error.message}`);
+  }
+  if (!data || data.length === 0) {
+    throw new Error(`Topic not found: ${topicId}`);
+  }
+}
+
 /** version のトピックと割当意見（結果ビュー用）。 */
 export async function getTopicsWithOpinions(versionId: string) {
   const supabase = createAdminClient();


### PR DESCRIPTION
## 背景
本番のユーザー向けトピック分析結果に、LLM の誤割当で「タイトル・概要と紐づく意見が整合しない」トピックが存在する。増分分析は既存トピックの割当を凍結して引き継ぐため自然回復しないため、admin から問題トピックを個別削除できるようにする。

## 変更内容
1. `packages/topic-analysis-core/src/repositories/analysis-repository.ts`
   - `deleteTopic(topicId, versionId)` を追加。`topic` テーブルを `id` と `version_id` の両方で絞って delete し、`.select("id")` で削除行を確認、0 行なら `Topic not found` を throw。
   - `topic_opinion`（割当）は FK ON DELETE CASCADE で自動削除される（意見自体は削除されない）。
   - `versionId` も条件に入れて別 version の同名 topic を誤削除しないようにしている。
2. `admin/src/features/user-topic-analysis/server/actions/delete-topic-actions.ts`（新規）
   - `deleteTopicAction({ topicId, versionId, billId })`: `requireAdmin()` → `deleteTopic` → `revalidatePath`。既存 `publish-actions.ts` のパターンに準拠。
3. `admin/src/features/user-topic-analysis/client/components/delete-topic-button.tsx`（新規）
   - `Trash2` アイコン + `Button`(variant="outline" size="sm")。`window.confirm` で確認後、`useTransition` で action 実行。pending 中は `Loader2` スピナー + disabled。既存 `publish-toggle-button.tsx` のパターンに準拠。
4. `admin/src/features/user-topic-analysis/server/components/user-topic-analysis-page.tsx`
   - 「最新の分析結果」の各トピックのヘッダ行に `DeleteTopicButton` を追加。

## 実行テスト記録
- `pnpm lint`: 通過（既存の警告のみ、本 PR の追加ファイルは警告なし）
- `pnpm typecheck`: 通過
- `pnpm build`: 通過
- `pnpm --filter admin test`: 487 passed
- `pnpm --filter @mirai-gikai/topic-analysis-core test`: 77 passed
- `pnpm test`（全体）: 全 752 テスト passed。web ワークスペースの `html-encoding-sniffer` の `ERR_REQUIRE_ESM` は本 PR と無関係の既存の環境依存エラー（本 PR は web を変更していない）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - ユーザートピック分析画面で、個別のトピックを削除できるようになりました。
  - 削除前に確認ダイアログを表示し、誤操作を防止します。
  - 削除処理中はボタンを無効化し、ローディング表示に切り替えます。
  - 削除後は分析画面が自動的に更新され、最新の内容が表示されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->