### PR TITLE
Vercel: PRを出しているfeature branchのPreviewデプロイを有効化

### DIFF
--- a/admin/vercel.json
+++ b/admin/vercel.json
@@ -5,5 +5,6 @@
       "main": false,
       "develop": false
     }
-  }
+  },
+  "ignoreCommand": "node ../scripts/vercel-ignore-build.mjs"
 }

--- a/admin/vercel.json
+++ b/admin/vercel.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "git": {
-    "deploymentEnabled": false
+    "deploymentEnabled": {
+      "main": false,
+      "develop": false
+    }
   }
 }

--- a/scripts/vercel-ignore-build.mjs
+++ b/scripts/vercel-ignore-build.mjs
@@ -1,0 +1,55 @@
+// Vercel Ignored Build Step から実行されるスクリプト。
+// exit 0 = ビルドをスキップ / exit 1 = ビルドを続行する仕様。
+// https://vercel.com/docs/project-configuration/vercel-json#ignorecommand
+//
+// feature ブランチは open な PR があるときだけ Preview をビルドする。
+// main / develop の git 連携ビルドは deploymentEnabled で無効化済みだが、
+// deploy.yml の Deploy Hook 経由のビルドでも ignoreCommand が評価される場合に
+// 本番 / staging のビルドを止めないよう、常に続行する。
+// 判定不能なケース（環境変数欠落・GitHub API のレート制限やエラー）は
+// 安全側（ビルド続行）に倒す。
+
+const branch = process.env.VERCEL_GIT_COMMIT_REF ?? "";
+const owner = process.env.VERCEL_GIT_REPO_OWNER ?? "";
+const repo = process.env.VERCEL_GIT_REPO_SLUG ?? "";
+
+function build(reason) {
+  console.log(`Proceeding with build: ${reason}`);
+  process.exit(1);
+}
+
+function skip(reason) {
+  console.log(`Skipping build: ${reason}`);
+  process.exit(0);
+}
+
+if (branch === "main" || branch === "develop") {
+  build(`branch "${branch}" deploys via deploy hook`);
+}
+
+if (!branch || !owner || !repo) {
+  build("missing VERCEL_GIT_* environment variables");
+}
+
+try {
+  const url = `https://api.github.com/repos/${owner}/${repo}/pulls?state=open&per_page=1&head=${owner}:${encodeURIComponent(branch)}`;
+  const headers = { accept: "application/vnd.github+json" };
+  // 無認証だと 60 req/h/IP のレート制限があるため、Vercel の環境変数に
+  // GITHUB_TOKEN が設定されていれば認証付きで呼ぶ（未設定でも動作する）。
+  if (process.env.GITHUB_TOKEN) {
+    headers.authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+  }
+  const res = await fetch(url, { headers });
+  const pulls = await res.json();
+
+  if (!Array.isArray(pulls)) {
+    const body = JSON.stringify(pulls).slice(0, 200);
+    build(`unexpected GitHub API response (status ${res.status}): ${body}`);
+  } else if (pulls.length > 0) {
+    build(`open PR found for branch "${branch}"`);
+  } else {
+    skip(`no open PR for branch "${branch}"`);
+  }
+} catch (error) {
+  build(`GitHub API request failed (${error})`);
+}

--- a/web/vercel.json
+++ b/web/vercel.json
@@ -5,5 +5,6 @@
       "main": false,
       "develop": false
     }
-  }
+  },
+  "ignoreCommand": "node ../scripts/vercel-ignore-build.mjs"
 }

--- a/web/vercel.json
+++ b/web/vercel.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "git": {
-    "deploymentEnabled": false
+    "deploymentEnabled": {
+      "main": false,
+      "develop": false
+    }
   }
 }


### PR DESCRIPTION
## 概要

feature branchに対して、**openなPRがあるときだけ**Vercelのブランチ別Preview環境が自動で立ち上がるようにします。

### 変更内容

1. **`web/vercel.json` / `admin/vercel.json`**: `git.deploymentEnabled` を全ブランチ無効（`false`）からブランチ別指定に変更し、`ignoreCommand` を追加
   ```json
   "git": {
     "deploymentEnabled": {
       "main": false,
       "develop": false
     }
   },
   "ignoreCommand": "node ../scripts/vercel-ignore-build.mjs"
   ```
2. **`scripts/vercel-ignore-build.mjs`（新規）**: Ignored Build Step から実行され、GitHub API で「該当ブランチをheadとするopenなPR」の有無を確認。なければビルドをスキップ（exit 0）、あれば続行（exit 1）

## 挙動

| ブランチ | git連携ビルド | 備考 |
|---|---|---|
| main / develop | 無効（`deploymentEnabled: false`） | 既存の `.github/workflows/deploy.yml`（マイグレーション → Deploy Hook）を維持。Deploy Hook経由ビルドで `ignoreCommand` が評価された場合もスクリプトが無条件で続行するため安全 |
| feature branch（openなPRあり） | Previewビルド実行 | [Vercelの仕様](https://vercel.com/docs/project-configuration/git-configuration#git.deploymentenabled)で列挙外ブランチはデフォルト有効 → `ignoreCommand` がPR有無で絞り込み |
| feature branch（PRなし） | スキップ | pushしてもビルドされない。PRを開いた後の次のpushからPreviewが作られる |

## 設計メモ

- **fail-open**: GitHub APIのエラー・レート制限・環境変数欠落時はビルド続行に倒します（最悪でも「PRなしブランチがビルドされる」だけで、必要なビルドが落ちることはない）
- **レート制限対策**: 無認証は60req/h/IPのため、VercelのプロジェクトにENV `GITHUB_TOKEN` を設定すれば認証付きで呼びます（未設定でも動作）
- feature branchのPreviewはVercelのPreview環境変数（staging Supabase）を使用します。スキーマ変更を含むブランチはstagingに未適用のためPreviewで動かない場合があります（Supabase Branching導入は別途検討）

## 実行テスト記録

- スクリプトを実GitHub APIに対してローカル実行し、3ケースを確認:
  - openなPRがあるブランチ（`vercel-branch-preview`）→ exit 1（ビルド続行）
  - PRのないブランチ → exit 0（スキップ）
  - `main` / `develop` → exit 1（無条件で続行）
- `pnpm lint` ✅ / `pnpm typecheck` ✅ / `pnpm build` ✅
- `pnpm test` — webの16件のERR_REQUIRE_ESMエラー（html-encoding-sniffer起因）はdevelop上でも同様に発生するローカル環境起因の既存事象で、本変更（設定＋ワークスペース外スクリプト）とは無関係

## 前提

- web/admin両方のVercelプロジェクトでGitHubリポジトリが接続されていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)
