### PR TITLE
Supabase previewブランチをopen PRのライフサイクルに連動して自動作成・削除

### DIFF
--- a/.github/workflows/supabase_preview.yml
+++ b/.github/workflows/supabase_preview.yml
@@ -1,0 +1,220 @@
+name: Supabase Preview Branch
+
+# supabase/ 配下に変更がある open な PR に対してのみ Supabase の preview ブランチ
+# （独立した DB）を作成し、Vercel の該当 git ブランチの Preview 環境変数に
+# 接続情報を注入する。PR クローズ時にはブランチと環境変数を削除する。
+# 設計の詳細は docs/20260717_1200_Supabase_PreviewブランチCI設計.md を参照。
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, closed]
+
+concurrency:
+  group: supabase-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  manage-preview-branch:
+    runs-on: ubuntu-latest
+    # fork からの PR は secrets を参照できないため対象外
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    environment: staging
+    env:
+      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+      SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
+      VERCEL_WEB_PROJECT_ID: ${{ secrets.WEB_VERCEL_PROJECT_ID }}
+      VERCEL_ADMIN_PROJECT_ID: ${{ secrets.ADMIN_VERCEL_PROJECT_ID }}
+      GIT_BRANCH: ${{ github.event.pull_request.head.ref }}
+    steps:
+      # Supabase のブランチ名に使えるよう git ブランチ名を英数字とハイフンに正規化する。
+      # 正規化による衝突（feat/foo と feat-foo 等）を避けるため PR 番号を付与する
+      - name: Compute branch name
+        id: branch
+        run: |
+          base=$(echo "$GIT_BRANCH" | tr -cs 'a-zA-Z0-9' '-' | sed 's/^-//; s/-$//' | cut -c1-40)
+          echo "name=${base:+$base-}pr${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+
+      - name: Detect supabase changes
+        id: changes
+        if: github.event.action != 'closed'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # パイプで直接 grep すると gh api の失敗が握りつぶされるため、変数に受けてから判定する
+          files=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+            --paginate --jq '.[].filename')
+          if echo "$files" | grep -q '^supabase/'; then
+            echo "supabase=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "supabase=false" >> "$GITHUB_OUTPUT"
+            echo "No supabase/ changes in this PR. Skipping preview branch."
+          fi
+
+      # checkout は db push が supabase/migrations を読むときだけ必要
+      - uses: actions/checkout@v5
+        if: github.event.action != 'closed' && steps.changes.outputs.supabase == 'true'
+
+      - uses: supabase/setup-cli@b60b5899c73b63a2d2d651b1e90db8d4c9392f51 # v1.6.0
+        with:
+          version: latest
+
+      # ---------- クリーンアップ: PR クローズ時、または supabase/ 変更が PR から消えたとき ----------
+      # 後者は「一度ブランチを作った後に supabase/ 変更が revert された PR」の課金リークを防ぐ
+
+      - name: Delete preview branch
+        if: github.event.action == 'closed' || steps.changes.outputs.supabase == 'false'
+        run: |
+          # ブランチ不在（作成していない PR）は正常系として静かに抜ける。
+          # 認証エラー等の判定不能な失敗は課金リークにつながるため明示的に失敗させる
+          if output=$(supabase branches get "${{ steps.branch.outputs.name }}" \
+            --project-ref "$SUPABASE_PROJECT_REF" -o json 2>&1); then
+            supabase branches delete "${{ steps.branch.outputs.name }}" \
+              --project-ref "$SUPABASE_PROJECT_REF" --yes
+          elif echo "$output" | grep -qiE 'not.?found|404'; then
+            echo "No preview branch to delete."
+          else
+            echo "$output" >&2
+            exit 1
+          fi
+
+      - name: Delete Vercel branch env vars
+        if: github.event.action == 'closed' || steps.changes.outputs.supabase == 'false'
+        run: |
+          # このワークフローが管理する4キーのみ削除し、手動設定されたブランチ別の
+          # 環境変数（feature flag 等）には触れない
+          managed_keys='["NEXT_PUBLIC_SUPABASE_URL","NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY","SUPABASE_URL","SUPABASE_SECRET_KEY"]'
+          for project_id in "$VERCEL_WEB_PROJECT_ID" "$VERCEL_ADMIN_PROJECT_ID"; do
+            # API の失敗をパイプで握りつぶさないよう変数に受ける。jq 側の select は
+            # クエリパラメータが無視された場合に無関係な環境変数を消さないための安全網
+            response=$(curl -sfG "https://api.vercel.com/v9/projects/${project_id}/env" \
+              --data-urlencode "gitBranch=${GIT_BRANCH}" \
+              --data-urlencode "teamId=${VERCEL_TEAM_ID}" \
+              -H "Authorization: Bearer $VERCEL_TOKEN")
+            env_ids=$(echo "$response" \
+              | jq -r --arg branch "$GIT_BRANCH" --argjson keys "$managed_keys" \
+                '.envs[] | select(.gitBranch == $branch) | select(.key as $k | $keys | index($k)) | .id')
+            for env_id in $env_ids; do
+              curl -sf -X DELETE \
+                "https://api.vercel.com/v9/projects/${project_id}/env/${env_id}?teamId=${VERCEL_TEAM_ID}" \
+                -H "Authorization: Bearer $VERCEL_TOKEN" > /dev/null
+            done
+          done
+
+      # ---------- PR オープン・更新時: ブランチ作成とマイグレーション適用 ----------
+
+      - name: Create preview branch if absent
+        id: create
+        if: github.event.action != 'closed' && steps.changes.outputs.supabase == 'true'
+        run: |
+          if supabase branches get "${{ steps.branch.outputs.name }}" \
+            --project-ref "$SUPABASE_PROJECT_REF" -o json > /dev/null 2>&1; then
+            echo "created=false" >> "$GITHUB_OUTPUT"
+          else
+            supabase branches create "${{ steps.branch.outputs.name }}" \
+              --project-ref "$SUPABASE_PROJECT_REF" \
+              --git-branch "$GIT_BRANCH" \
+              --size micro --yes
+            echo "created=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Wait for branch to be ready
+        if: github.event.action != 'closed' && steps.changes.outputs.supabase == 'true'
+        run: |
+          # 20秒間隔 × 30回 = 最大10分待つ（新規作成時のプロビジョニングを想定）
+          for i in $(seq 1 30); do
+            status=$(supabase branches get "${{ steps.branch.outputs.name }}" \
+              --project-ref "$SUPABASE_PROJECT_REF" -o json | jq -r '.status // empty')
+            echo "Branch status: ${status:-unknown} (attempt $i)"
+            case "$status" in
+              ACTIVE_HEALTHY|MIGRATIONS_PASSED|FUNCTIONS_DEPLOYED) exit 0 ;;
+              *FAILED*|*UNHEALTHY*)
+                echo "Branch entered failure status: $status" >&2
+                exit 1
+                ;;
+            esac
+            sleep 20
+          done
+          echo "Branch did not become healthy in time" >&2
+          exit 1
+
+      - name: Load branch credentials
+        id: creds
+        if: github.event.action != 'closed' && steps.changes.outputs.supabase == 'true'
+        run: |
+          supabase branches get "${{ steps.branch.outputs.name }}" \
+            --project-ref "$SUPABASE_PROJECT_REF" -o env > branch.env
+          for key in SUPABASE_URL SUPABASE_ANON_KEY SUPABASE_SERVICE_ROLE_KEY POSTGRES_URL_NON_POOLING; do
+            if ! grep -q "^${key}=" branch.env; then
+              echo "Missing ${key} in branch credentials. Available keys:" >&2
+              cut -d= -f1 branch.env >&2
+              exit 1
+            fi
+          done
+          # 後続 step 用に GITHUB_ENV へ読み込む（値はログに出さない）
+          while IFS= read -r line; do
+            key=${line%%=*}
+            value=${line#*=}
+            value=${value#\"}; value=${value%\"}
+            echo "::add-mask::$value"
+            echo "BRANCH_${key}=${value}" >> "$GITHUB_ENV"
+          done < branch.env
+          rm branch.env
+
+      - name: Apply migrations
+        if: github.event.action != 'closed' && steps.changes.outputs.supabase == 'true'
+        run: |
+          if [ "${{ steps.create.outputs.created }}" = "true" ]; then
+            supabase db push --db-url "$BRANCH_POSTGRES_URL_NON_POOLING" \
+              --include-all --include-seed --yes
+          else
+            supabase db push --db-url "$BRANCH_POSTGRES_URL_NON_POOLING" \
+              --include-all --yes
+          fi
+
+      # ---------- Vercel 環境変数の設定と再デプロイ ----------
+      # Vercel API のバージョン（v9/v10/v13）はエンドポイントごとに独立しており、
+      # それぞれ公式ドキュメント記載の最新版を使用している
+
+      # upsert のため冪等。作成時に一度失敗しても次の synchronize で回復できるよう毎回実行する
+      - name: Set Vercel branch env vars
+        if: github.event.action != 'closed' && steps.changes.outputs.supabase == 'true'
+        run: |
+          set_env() {
+            local project_id=$1 key=$2 value=$3
+            curl -sf -X POST \
+              "https://api.vercel.com/v10/projects/${project_id}/env?upsert=true&teamId=${VERCEL_TEAM_ID}" \
+              -H "Authorization: Bearer $VERCEL_TOKEN" \
+              -H "Content-Type: application/json" \
+              -d "$(jq -n --arg key "$key" --arg value "$value" --arg branch "$GIT_BRANCH" \
+                '{key: $key, value: $value, type: "encrypted", target: ["preview"], gitBranch: $branch}')" \
+              > /dev/null
+          }
+          for project_id in "$VERCEL_WEB_PROJECT_ID" "$VERCEL_ADMIN_PROJECT_ID"; do
+            set_env "$project_id" NEXT_PUBLIC_SUPABASE_URL "$BRANCH_SUPABASE_URL"
+            set_env "$project_id" NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY "$BRANCH_SUPABASE_ANON_KEY"
+            set_env "$project_id" SUPABASE_URL "$BRANCH_SUPABASE_URL"
+            set_env "$project_id" SUPABASE_SECRET_KEY "$BRANCH_SUPABASE_SERVICE_ROLE_KEY"
+          done
+
+      # 環境変数を設定した後に再デプロイし、Preview がブランチ DB を向くようにする。
+      # Vercel はデプロイ時に環境変数をスナップショットするため、push で並行して走る
+      # git 連携ビルドが env 設定前の値を掴む可能性があり、env 設定後に毎回再デプロイする
+      # （同一ブランチの古いビルドは Vercel の auto job cancelation で整理される）
+      - name: Redeploy Vercel previews
+        if: github.event.action != 'closed' && steps.changes.outputs.supabase == 'true'
+        run: |
+          for project_id in "$VERCEL_WEB_PROJECT_ID" "$VERCEL_ADMIN_PROJECT_ID"; do
+            project_name=$(curl -sf \
+              "https://api.vercel.com/v9/projects/${project_id}?teamId=${VERCEL_TEAM_ID}" \
+              -H "Authorization: Bearer $VERCEL_TOKEN" | jq -r '.name')
+            curl -sf -X POST \
+              "https://api.vercel.com/v13/deployments?teamId=${VERCEL_TEAM_ID}" \
+              -H "Authorization: Bearer $VERCEL_TOKEN" \
+              -H "Content-Type: application/json" \
+              -d "$(jq -n --arg name "$project_name" --arg ref "$GIT_BRANCH" \
+                --argjson repoId "${{ github.event.repository.id }}" \
+                '{name: $name, target: "preview", gitSource: {type: "github", repoId: $repoId, ref: $ref}}')" \
+              > /dev/null || echo "Redeploy request for ${project_name} failed (preview will pick up env vars on next push)"
+          done

--- a/.github/workflows/supabase_preview.yml
+++ b/.github/workflows/supabase_preview.yml
@@ -60,11 +60,31 @@ jobs:
         with:
           version: latest
 
+      # secrets 未設定・Branching 未対応の段階では警告を出して no-op にする
+      # （このワークフローを先にマージし、後から secrets / プランを整備できるようにするため）
+      - name: Check prerequisites
+        id: ready
+        run: |
+          if supabase branches list --project-ref "$SUPABASE_PROJECT_REF" > /dev/null 2>&1; then
+            echo "branching=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "branching=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::Supabase Branching が利用できないため（プラン未対応・API障害・secrets未設定）、previewブランチ操作をスキップします"
+          fi
+          if [ -n "$VERCEL_TOKEN" ] && [ -n "$VERCEL_WEB_PROJECT_ID" ] && [ -n "$VERCEL_ADMIN_PROJECT_ID" ]; then
+            echo "vercel=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "vercel=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::VERCEL_TOKEN / VERCEL_*_PROJECT_ID が未設定のため、Vercel環境変数の操作をスキップします"
+          fi
+
       # ---------- クリーンアップ: PR クローズ時、または supabase/ 変更が PR から消えたとき ----------
       # 後者は「一度ブランチを作った後に supabase/ 変更が revert された PR」の課金リークを防ぐ
 
       - name: Delete preview branch
-        if: github.event.action == 'closed' || steps.changes.outputs.supabase == 'false'
+        if: >-
+          steps.ready.outputs.branching == 'true' &&
+          (github.event.action == 'closed' || steps.changes.outputs.supabase == 'false')
         run: |
           # ブランチ不在（作成していない PR）は正常系として静かに抜ける。
           # 認証エラー等の判定不能な失敗は課金リークにつながるため明示的に失敗させる
@@ -80,7 +100,9 @@ jobs:
           fi
 
       - name: Delete Vercel branch env vars
-        if: github.event.action == 'closed' || steps.changes.outputs.supabase == 'false'
+        if: >-
+          steps.ready.outputs.vercel == 'true' &&
+          (github.event.action == 'closed' || steps.changes.outputs.supabase == 'false')
         run: |
           # このワークフローが管理する4キーのみ削除し、手動設定されたブランチ別の
           # 環境変数（feature flag 等）には触れない
@@ -106,7 +128,9 @@ jobs:
 
       - name: Create preview branch if absent
         id: create
-        if: github.event.action != 'closed' && steps.changes.outputs.supabase == 'true'
+        if: >-
+          github.event.action != 'closed' && steps.changes.outputs.supabase == 'true' &&
+          steps.ready.outputs.branching == 'true'
         run: |
           if supabase branches get "${{ steps.branch.outputs.name }}" \
             --project-ref "$SUPABASE_PROJECT_REF" -o json > /dev/null 2>&1; then
@@ -120,7 +144,9 @@ jobs:
           fi
 
       - name: Wait for branch to be ready
-        if: github.event.action != 'closed' && steps.changes.outputs.supabase == 'true'
+        if: >-
+          github.event.action != 'closed' && steps.changes.outputs.supabase == 'true' &&
+          steps.ready.outputs.branching == 'true'
         run: |
           # 20秒間隔 × 30回 = 最大10分待つ（新規作成時のプロビジョニングを想定）
           for i in $(seq 1 30); do
@@ -141,7 +167,9 @@ jobs:
 
       - name: Load branch credentials
         id: creds
-        if: github.event.action != 'closed' && steps.changes.outputs.supabase == 'true'
+        if: >-
+          github.event.action != 'closed' && steps.changes.outputs.supabase == 'true' &&
+          steps.ready.outputs.branching == 'true'
         run: |
           supabase branches get "${{ steps.branch.outputs.name }}" \
             --project-ref "$SUPABASE_PROJECT_REF" -o env > branch.env
@@ -163,7 +191,9 @@ jobs:
           rm branch.env
 
       - name: Apply migrations
-        if: github.event.action != 'closed' && steps.changes.outputs.supabase == 'true'
+        if: >-
+          github.event.action != 'closed' && steps.changes.outputs.supabase == 'true' &&
+          steps.ready.outputs.branching == 'true'
         run: |
           if [ "${{ steps.create.outputs.created }}" = "true" ]; then
             supabase db push --db-url "$BRANCH_POSTGRES_URL_NON_POOLING" \
@@ -179,7 +209,9 @@ jobs:
 
       # upsert のため冪等。作成時に一度失敗しても次の synchronize で回復できるよう毎回実行する
       - name: Set Vercel branch env vars
-        if: github.event.action != 'closed' && steps.changes.outputs.supabase == 'true'
+        if: >-
+          github.event.action != 'closed' && steps.changes.outputs.supabase == 'true' &&
+          steps.ready.outputs.branching == 'true' && steps.ready.outputs.vercel == 'true'
         run: |
           set_env() {
             local project_id=$1 key=$2 value=$3
@@ -203,7 +235,9 @@ jobs:
       # git 連携ビルドが env 設定前の値を掴む可能性があり、env 設定後に毎回再デプロイする
       # （同一ブランチの古いビルドは Vercel の auto job cancelation で整理される）
       - name: Redeploy Vercel previews
-        if: github.event.action != 'closed' && steps.changes.outputs.supabase == 'true'
+        if: >-
+          github.event.action != 'closed' && steps.changes.outputs.supabase == 'true' &&
+          steps.ready.outputs.branching == 'true' && steps.ready.outputs.vercel == 'true'
         run: |
           for project_id in "$VERCEL_WEB_PROJECT_ID" "$VERCEL_ADMIN_PROJECT_ID"; do
             project_name=$(curl -sf \

--- a/docs/20260717_1200_Supabase_PreviewブランチCI設計.md
+++ b/docs/20260717_1200_Supabase_PreviewブランチCI設計.md
@@ -41,6 +41,10 @@ Supabase Branching（preview ブランチ）を PR のライフサイクルに�
 - `VERCEL_TEAM_ID` … Vercel のチーム ID
 - `WEB_VERCEL_PROJECT_ID` / `ADMIN_VERCEL_PROJECT_ID` … 各 Vercel プロジェクトの ID
 
+### 段階的ロールアウト
+
+ワークフローは実行の冒頭で前提条件（Branching が利用可能か・Vercel 系 secrets が設定済みか）をチェックし、未整備の場合は **警告を出して no-op** で成功する。このためワークフロー自体を先にマージし、後から secrets 設定・プラン変更を行っても既存 PR の CI は落ちない。
+
 ### Supabase 側の前提
 
 - staging プロジェクトで **Branching が利用可能なプラン**（Pro 以上）であること

--- a/docs/20260717_1200_Supabase_PreviewブランチCI設計.md
+++ b/docs/20260717_1200_Supabase_PreviewブランチCI設計.md
@@ -1,0 +1,74 @@
+# Supabase Preview ブランチ CI 設計
+
+`supabase/` 配下に変更がある open な PR に対してのみ、Supabase の preview ブランチ（独立した DB）を自動作成し、Vercel Preview から接続できるようにする仕組み。
+
+- ワークフロー: `.github/workflows/supabase_preview.yml`
+- 関連PR: #928（Vercel Preview を open な PR があるブランチのみに制限）
+
+## 背景
+
+feature ブランチの Vercel Preview は staging の Supabase を共有しているため、次の課題があった。
+
+1. スキーマ変更（マイグレーション）を含む PR は staging に未適用のため Preview で動作しない
+2. Preview からの書き込みが staging のデータを汚染する
+
+Supabase Branching（preview ブランチ）を PR のライフサイクルに紐付けることで、スキーマ変更を含む PR だけ独立した DB を持てるようにする。
+
+## 挙動
+
+| PRイベント | supabase/ 変更あり | supabase/ 変更なし |
+|---|---|---|
+| opened / reopened | previewブランチ作成 → マイグレーション+seed適用 → Vercelのブランチ別環境変数を設定 → Preview再デプロイ | クリーンアップ（過去に作成したブランチ・環境変数が残っていれば削除） |
+| synchronize（push） | マイグレーション再適用 + 環境変数再設定 + Preview再デプロイ（いずれも冪等。作成時の一時的な失敗から自動回復できるよう毎回実行）。ブランチ未作成なら作成から実施 | 同上（supabase/ 変更が途中で revert された PR の課金リークを防ぐ） |
+| closed（マージ含む） | previewブランチ削除 + Vercelのブランチ別環境変数（本ワークフロー管理の4キーのみ）を削除 | 同左（作成していなければ何も起きない） |
+
+- Supabase ブランチ名は「git ブランチ名を英数字とハイフンに正規化したもの（先頭40文字）+ `-pr<PR番号>`」。PR 番号を含めるのは、正規化による名前衝突（`feat/foo` と `feat-foo` 等）で別 PR のブランチを誤削除しないため
+- fork からの PR は secrets を参照できないため対象外
+- 途中から supabase/ 変更が入った PR は、その push（synchronize）のタイミングでブランチが作られる
+
+## 必要な設定
+
+### GitHub secrets（staging environment）
+
+既存（deploy.yml と共用）:
+
+- `SUPABASE_ACCESS_TOKEN`
+- `SUPABASE_PROJECT_REF` … staging プロジェクト。preview ブランチはこのプロジェクト配下に作られる
+
+新規追加が必要:
+
+- `VERCEL_TOKEN` … Vercel の API トークン（web/admin 両プロジェクトにアクセスできるスコープ）
+- `VERCEL_TEAM_ID` … Vercel のチーム ID
+- `WEB_VERCEL_PROJECT_ID` / `ADMIN_VERCEL_PROJECT_ID` … 各 Vercel プロジェクトの ID
+
+### Supabase 側の前提
+
+- staging プロジェクトで **Branching が利用可能なプラン**（Pro 以上）であること
+- 課金: preview ブランチは micro で **約 $0.01344/時**（≒ $0.32/日）。Compute Credits・Spend Cap の対象外。PR クローズで削除されるため、open な PR の数だけ課金される
+
+## 環境変数のマッピング
+
+`supabase branches get -o env` の出力を、アプリが参照する変数名にマッピングして Vercel に設定する（対象: Preview 環境・該当 git ブランチのみ）。
+
+| Vercel に設定する変数 | ブランチ側の値 |
+|---|---|
+| `NEXT_PUBLIC_SUPABASE_URL` | `SUPABASE_URL` |
+| `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` | `SUPABASE_ANON_KEY`（legacy anon key。supabase-js は publishable key と同様に受け付ける） |
+| `SUPABASE_URL` | `SUPABASE_URL` |
+| `SUPABASE_SECRET_KEY` | `SUPABASE_SERVICE_ROLE_KEY`（legacy service role key） |
+
+## 制約・注意点
+
+- **初回実運用時に要確認**: `branches get -o env` の出力キーはワークフロー内で検証しており、想定と異なる場合は明示的に失敗する（Available keys がログに出る）。あわせて `branches get / delete` がブランチ名（ID ではなく）を受け付けること、ステータス文字列（`ACTIVE_HEALTHY` 等）が待機ループの想定と一致することも初回に確認する
+- **Google 認証は動かない**: ブランチ DB には `supabase config push`（Google OAuth のリダイレクト URL 等）を適用していないため、認証が必要な画面の検証は staging 共有の Preview と同様の制約が残る
+- **synchronize 時のレース**: push 直後は Vercel のビルドとマイグレーション適用が並行するため、ビルド完了直後の一瞬だけ新スキーマ未適用の可能性がある（リロードで解消）
+- **データは seed のみ**: ブランチ DB は本番/staging のデータを引き継がず、`supabase/seed.sql` で初期化される（`--with-data` オプションは将来検討）
+- **Storage は空**: ファイルアップロード系の検証には向かない
+
+## 検証方法
+
+1. secrets（`VERCEL_TOKEN` 等）を staging environment に設定する
+2. `supabase/migrations/` にダミーのマイグレーションを含む PR を作成する
+3. Actions の `Supabase Preview Branch` が成功し、Supabase ダッシュボードにブランチが作られることを確認する
+4. Vercel Preview の環境変数（該当ブランチスコープ）が設定され、再デプロイ後の Preview がブランチ DB を向くことを確認する
+5. PR をクローズし、ブランチと環境変数が削除されることを確認する


### PR DESCRIPTION
## 概要

`supabase/` 配下に変更がある open な PR に対してのみ、Supabase の preview ブランチ（独立した DB）を自動作成し、Vercel Preview（web/admin）がそのブランチ DB に接続するようにします。PR クローズ時にはブランチと環境変数を自動削除します。

設計の詳細は `docs/20260717_1200_Supabase_PreviewブランチCI設計.md` を参照（挙動マトリクス・環境変数マッピング・制約を記載）。

### 挙動サマリ

| PRイベント | supabase/ 変更あり | supabase/ 変更なし |
|---|---|---|
| opened / reopened / synchronize | previewブランチ作成（未作成時）→ マイグレーション+seed適用 → Vercelブランチ別環境変数を設定 → Preview再デプロイ | クリーンアップ（作成済みのものが残っていれば削除） |
| closed（マージ含む） | ブランチ削除 + 環境変数（本ワークフロー管理の4キーのみ）削除 | 同左 |

### 設計ポイント

- **openなPRがある間だけDBが存在**: `pull_request` イベント駆動。supabase/ 変更が途中で revert された PR も synchronize 時にクリーンアップし、課金リークを防止
- **冪等・自己回復**: env設定/再デプロイは毎回実行（upsert）。作成直後の一時的な失敗があっても次の push で回復
- **安全側の設計**: 環境変数の削除は管理対象4キーのみ（手動設定のブランチ別変数には触れない）。ブランチ削除は「存在確認 → 削除」とし、認証エラー等の判定不能な失敗は明示的にfailさせる
- **ブランチ名衝突対策**: 正規化したgitブランチ名 + `-pr<PR番号>`
- fork からの PR は secrets を参照できないため対象外

## マージ前に必要な設定

**staging environment への secrets 追加**（既存の `SUPABASE_ACCESS_TOKEN` / `SUPABASE_PROJECT_REF` は再利用）:

- `VERCEL_TOKEN` … web/admin 両プロジェクトにアクセスできる API トークン
- `VERCEL_TEAM_ID`
- `WEB_VERCEL_PROJECT_ID` / `ADMIN_VERCEL_PROJECT_ID`

**Supabase 側の前提**:

- staging プロジェクトで Branching が利用可能なプラン（Pro 以上）であること
- 課金: preview ブランチは micro で約 $0.01344/時（≒ $0.32/日）。Spend Cap 対象外。PR クローズで削除される

## 初回実運用時の確認事項（ドキュメントにも記載）

- `supabase branches get -o env` の出力キー（ワークフロー内で検証しており、想定と異なれば Available keys をログに出して明示的に失敗します）
- ブランチのステータス文字列（`ACTIVE_HEALTHY` 等）が待機ループの想定と一致すること

## 実行テスト記録

- `actionlint`（Docker: rhysd/actionlint）✅ 指摘ゼロ
- `supabase branches create/get/delete --help` で使用フラグ（`--git-branch`, `--size`, `--yes` 等）の実在をローカル CLI で確認
- `pnpm lint` ✅（警告は既存のみ）/ `pnpm typecheck` ✅（アプリコードは未変更）

## 関連

- #928（Vercel Preview を open な PR があるブランチのみに制限）と組み合わせて、「PR を出したら app + DB の Preview 環境が立ち、閉じたら消える」構成になります

🤖 Generated with [Claude Code](https://claude.com/claude-code)