### PR TITLE
fix: Supabase CLI v2.106.0 以降で pnpm seed が permission denied になる問題を修正

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -30,10 +30,10 @@ jobs:
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@b60b5899c73b63a2d2d651b1e90db8d4c9392f51 # v1.6.0
         with:
-          # v2.106.0 で secret key ロールの table GRANT 挙動が変わり、global setup の
-          # `diet_sessions` select が permission denied で落ちるため、直前の安定版に固定する。
-          # latest に戻す場合は tests/supabase/setup.ts が通ることを確認すること。
-          version: 2.105.0
+          # v2.106.0 の auto_expose_new_tables 変更による権限エラーは、
+          # supabase/migrations/20260719090000_grant_service_role_privileges_on_public_schema.sql
+          # の明示 GRANT で恒久対応済みのため latest を使用する (#878)
+          version: latest
 
       - name: Start Supabase
         run: supabase start -x studio,imgproxy,logflare,vector,realtime,edge-runtime,supavisor,inbucket

--- a/supabase/migrations/20260719090000_grant_service_role_privileges_on_public_schema.sql
+++ b/supabase/migrations/20260719090000_grant_service_role_privileges_on_public_schema.sql
@@ -1,0 +1,42 @@
+-- Supabase CLI v2.106.0 以降でのローカル開発権限エラーへの対応 (#878)
+--
+-- CLI v2.106.0 の breaking change により `[api].auto_expose_new_tables` が
+-- 未設定時 false となり、ローカルの start / db reset で public スキーマの
+-- オブジェクトへの Data API 権限（anon / authenticated / service_role への
+-- 自動 GRANT）が付与されなくなった。
+-- そのため `pnpm db:reset` 後の `pnpm seed`（secret key = service_role）が
+-- "permission denied for table tags" で失敗する。
+--
+-- 公式が案内する恒久対応は「アクセスすべきロールへ明示的に GRANT する」こと。
+-- 本プロジェクトの public スキーマへのアクセスは全てサーバーサイド
+-- （secret key = service_role）経由のため（AGENTS.md「RLSとアクセスパターン」）、
+-- service_role のみに付与し、anon / authenticated / public からは明示的に
+-- REVOKE して deny-by-default を権限レイヤーでも保証する。
+-- （GRANT は他ロールの既存権限を削除しないため、旧仕様で自動付与された
+--   環境に残る anon / authenticated への権限はここで明示的に取り除く）
+
+-- 既存オブジェクト: anon / authenticated / public から取り除く
+revoke all on all tables in schema public from public, anon, authenticated;
+revoke all on all sequences in schema public from public, anon, authenticated;
+revoke all on all functions in schema public from public, anon, authenticated;
+
+-- 既存オブジェクト: service_role へ付与
+grant usage on schema public to service_role;
+grant all on all tables in schema public to service_role;
+grant all on all sequences in schema public to service_role;
+grant execute on all functions in schema public to service_role;
+
+-- 今後のマイグレーション（postgres ロールで実行）で作成されるオブジェクト:
+-- anon / authenticated / public への自動付与を止め、service_role のみ自動付与
+alter default privileges in schema public revoke all on tables from public, anon, authenticated;
+alter default privileges in schema public revoke all on sequences from public, anon, authenticated;
+alter default privileges in schema public revoke execute on functions from public, anon, authenticated;
+alter default privileges in schema public grant all on tables to service_role;
+alter default privileges in schema public grant all on sequences to service_role;
+alter default privileges in schema public grant execute on functions to service_role;
+
+-- 例外: is_admin() は storage.objects の RLS ポリシー評価（サムネイル
+-- アップロード時に authenticated として実行）とクライアントからの RPC で
+-- anon / authenticated からも実行されるため、EXECUTE を再付与する
+-- （tests/supabase/db-function/is-admin.test.ts が この挙動を検証している）
+grant execute on function public.is_admin() to anon, authenticated;


### PR DESCRIPTION
## 概要

Supabase CLI v2.106.0 以降で `pnpm db:reset` 後の `pnpm seed` が `permission denied for table tags` で失敗する問題（#878）を修正します。

Fixes #878

## 原因

CLI v2.106.0 の breaking change により、`[api].auto_expose_new_tables` が未設定時 `false` になりました。これによりローカルの start / db reset で public スキーマのテーブル・シーケンス・関数への Data API 権限（anon / authenticated / service_role への自動 GRANT）が付与されなくなり、secret key（= service_role）で接続する seed が権限エラーになります。

CLI v2.109.1 環境での再現時、`tags` テーブルに対する service_role の権限は `TRUNCATE, REFERENCES, TRIGGER` のみで、SELECT / INSERT / UPDATE / DELETE が欠落していました。関数も同様で、明示 GRANT のない関数は service_role から EXECUTE できない状態でした（CI が 2.105.0 に固定されているのはこのためです → `.github/workflows/integration_test.yml` のコメント参照）。

## 対応

CLI リリースノートが案内する恒久対応（アクセスすべきロールへの明示 GRANT）に従い、マイグレーションを追加しました。

- 既存の全テーブル・シーケンスへの `GRANT ALL`、全関数への `GRANT EXECUTE` を **service_role のみ** に付与
- `ALTER DEFAULT PRIVILEGES` で今後のマイグレーションで作成されるオブジェクトにも自動付与
- **anon / authenticated / public からは明示的に REVOKE**（CodeRabbit 指摘反映）。GRANT は他ロールの既存権限を削除しないため、旧仕様で自動付与された環境に残る権限を取り除き、deny-by-default（AGENTS.md「RLSとアクセスパターン」）を権限レイヤーでも保証します
- **例外は `is_admin()` のみ**: storage.objects の RLS ポリシー評価（サムネイルアップロード時に authenticated として実行）と RPC で anon / authenticated から呼ばれるため EXECUTE を再付与。CREATE POLICY で参照される public 関数が他にないことは全マイグレーションを機械的に確認済み
- 既存マイグレーションの意図的な REVOKE（`get_admin_users` など）と同じ方向の変更のため影響ありません
- あわせて CI の Supabase CLI 固定（2.105.0）を解除し latest に戻しました

## 検証（CLI v2.109.1 = latest で実施）

1. **再現確認（修正前）**: `npx supabase db reset` → `pnpm seed` が issue と同一の `permission denied for table tags` で失敗
2. **修正後**: `db reset` → `pnpm seed` 全件成功（tags / bills / interview 系すべて）。`tags` の grants 実測は postgres / service_role のみ（anon / authenticated はゼロ）
3. **将来のマイグレーションへの効果**: 本マイグレーションより後のタイムスタンプでダミーテーブル・シーケンス・関数を作成する検証用マイグレーションを流したところ、service_role にテーブル DML（SELECT/INSERT/UPDATE/DELETE 等）と関数 EXECUTE が自動付与されることを確認（anon / authenticated には付与されない）
4. **integration tests**: `pnpm test:integration` 全パス
   - tests/supabase: 30 files / 176 tests passed
   - tests/mcp: 7 files / 62 tests passed
   - web: 25 files / 141 tests passed

## 補足

- スキーマ（テーブル定義・関数シグネチャ）は変更していないため、`supabase.types.ts` の再生成差分はありません
- `config.toml` の `auto_expose_new_tables = true` による回避は deprecated（2026-10-30 削除予定）のため採用していません
