### PR TITLE
fix: AIチャットモーダルの読み上げとフォーカス制御を改善

### DIFF
--- a/web/src/features/chat/client/components/chat-button.test.tsx
+++ b/web/src/features/chat/client/components/chat-button.test.tsx
@@ -1,0 +1,138 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom/vitest";
+import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createRef } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ChatButton, type ChatButtonRef } from "./chat-button";
+
+const useChatMock = vi.hoisted(() => vi.fn());
+const usePathnameMock = vi.hoisted(() => vi.fn());
+const chatWindowMock = vi.hoisted(() => ({
+  props: null as null | {
+    disableAutoFocus: boolean;
+    isOpen: boolean;
+    onClose: () => void;
+    returnFocusRef: { current: HTMLElement | null };
+  },
+}));
+
+vi.mock("@ai-sdk/react", () => ({ useChat: useChatMock }));
+vi.mock("next/navigation", () => ({ usePathname: usePathnameMock }));
+vi.mock("next/image", () => ({
+  default: ({ alt }: { alt: string }) => <span role="img" aria-label={alt} />,
+}));
+vi.mock("./chat-window", () => ({
+  ChatWindow: (props: {
+    disableAutoFocus: boolean;
+    isOpen: boolean;
+    onClose: () => void;
+    returnFocusRef: { current: HTMLElement | null };
+  }) => {
+    chatWindowMock.props = props;
+    return (
+      <div data-testid="chat-window" data-open={props.isOpen}>
+        <button type="button" onClick={props.onClose}>
+          チャットを閉じる
+        </button>
+      </div>
+    );
+  },
+}));
+
+function renderChatButton(ref = createRef<ChatButtonRef>()) {
+  const result = render(
+    <ChatButton
+      difficultyLevel="normal"
+      pageContext={{ type: "home" }}
+      ref={ref}
+    />
+  );
+  return { ...result, ref };
+}
+
+beforeEach(() => {
+  chatWindowMock.props = null;
+  usePathnameMock.mockReturnValue("/bills/1");
+  vi.spyOn(globalThis.crypto, "randomUUID").mockReturnValue(
+    "00000000-0000-4000-8000-000000000001"
+  );
+});
+
+describe("ChatButton", () => {
+  it("トリガーの開閉状態とフォーカス復帰先をChatWindowへ渡す", async () => {
+    const user = userEvent.setup();
+    useChatMock.mockReturnValue({
+      messages: [],
+      sendMessage: vi.fn(),
+      status: "ready",
+    });
+    renderChatButton();
+
+    const trigger = screen.getByRole("button", {
+      name: "議案について質問する",
+    });
+    expect(trigger).toHaveAttribute("aria-haspopup", "dialog");
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+    expect(chatWindowMock.props?.returnFocusRef.current).toBe(trigger);
+
+    await user.click(trigger);
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByTestId("chat-window")).toHaveAttribute(
+      "data-open",
+      "true"
+    );
+
+    await user.click(screen.getByRole("button", { name: "チャットを閉じる" }));
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("本文選択から開くと質問を送信し、閉じた後は通常のフォーカスに戻す", async () => {
+    const user = userEvent.setup();
+    const sendMessage = vi.fn();
+    useChatMock.mockReturnValue({
+      messages: [],
+      sendMessage,
+      status: "ready",
+    });
+    const { ref } = renderChatButton();
+
+    act(() => ref.current?.openWithText("選択した本文"));
+
+    expect(sendMessage).toHaveBeenCalledWith({
+      text: "「選択した本文」について教えてください。",
+      metadata: {
+        billContext: undefined,
+        difficultyLevel: "normal",
+        hasInterviewConfig: undefined,
+        pageContext: { type: "home" },
+        sessionId: "00000000-0000-4000-8000-000000000001",
+      },
+    });
+    expect(chatWindowMock.props?.disableAutoFocus).toBe(true);
+    expect(chatWindowMock.props?.isOpen).toBe(true);
+
+    act(() => chatWindowMock.props?.onClose());
+    await user.click(
+      screen.getByRole("button", { name: "議案について質問する" })
+    );
+
+    expect(chatWindowMock.props?.disableAutoFocus).toBe(false);
+    expect(chatWindowMock.props?.isOpen).toBe(true);
+  });
+
+  it("AI応答中は本文選択から新しい質問を送信しない", () => {
+    const sendMessage = vi.fn();
+    useChatMock.mockReturnValue({
+      messages: [],
+      sendMessage,
+      status: "streaming",
+    });
+    const { ref } = renderChatButton();
+
+    act(() => ref.current?.openWithText("選択した本文"));
+
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(chatWindowMock.props?.isOpen).toBe(false);
+  });
+});

--- a/web/src/features/chat/client/components/chat-button.tsx
+++ b/web/src/features/chat/client/components/chat-button.tsx
@@ -8,8 +8,10 @@ import {
   useEffect,
   useImperativeHandle,
   useMemo,
+  useRef,
   useState,
 } from "react";
+import { Button } from "@/components/ui/button";
 import type { BillWithContent } from "@/features/bills/shared/types";
 import { ChatWindow } from "./chat-window";
 
@@ -45,6 +47,7 @@ export const ChatButton = forwardRef<ChatButtonRef, ChatButtonProps>(
     const [isCompact, setIsCompact] = useState(false);
     const [showText, setShowText] = useState(true);
     const [openedWithText, setOpenedWithText] = useState(false);
+    const chatTriggerRef = useRef<HTMLButtonElement>(null);
     const pathname = usePathname();
 
     // Chat state をここで管理することで、モーダルが閉じても状態が保持される
@@ -118,8 +121,10 @@ export const ChatButton = forwardRef<ChatButtonRef, ChatButtonProps>(
               transitionDuration: `${ANIMATION_DURATION.SIZE_TRANSITION}ms`,
             }}
           >
-            <button
+            <Button
+              ref={chatTriggerRef}
               type="button"
+              variant="ghost"
               onClick={() => setIsOpen(true)}
               className={`relative bg-white rounded-[50px] hover:opacity-90 flex items-center w-full py-2 transition-all ease-in-out ${
                 isCompact
@@ -130,6 +135,8 @@ export const ChatButton = forwardRef<ChatButtonRef, ChatButtonProps>(
                 transitionDuration: `${ANIMATION_DURATION.SIZE_TRANSITION}ms`,
               }}
               aria-label="議案について質問する"
+              aria-haspopup="dialog"
+              aria-expanded={isOpen}
             >
               <span
                 className={`text-mirai-text-placeholder text-sm font-medium leading-[1.5em] tracking-[0.01em] ${
@@ -160,7 +167,7 @@ export const ChatButton = forwardRef<ChatButtonRef, ChatButtonProps>(
                   />
                 </div>
               )}
-            </button>
+            </Button>
           </div>
         </div>
 
@@ -176,6 +183,7 @@ export const ChatButton = forwardRef<ChatButtonRef, ChatButtonProps>(
           }}
           pageContext={pageContext}
           disableAutoFocus={openedWithText}
+          returnFocusRef={chatTriggerRef}
           sessionId={sessionId}
         />
       </>

--- a/web/src/features/chat/client/components/chat-window.test.tsx
+++ b/web/src/features/chat/client/components/chat-window.test.tsx
@@ -1,0 +1,304 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom/vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ComponentProps, FormEvent, ReactNode } from "react";
+import { forwardRef } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ChatWindow } from "./chat-window";
+
+const testState = vi.hoisted(() => ({
+  isDesktop: false,
+  isPc: false,
+  scrollToBottom: vi.fn(),
+  viewportHeight: 640 as number | null,
+  mobileDialogProps: null as null | Record<string, unknown>,
+}));
+
+vi.mock("@/hooks/use-is-desktop", () => ({
+  useIsDesktop: () => testState.isDesktop,
+}));
+
+vi.mock("@/hooks/use-media-query", () => ({
+  useMediaQuery: () => testState.isPc,
+}));
+
+vi.mock("@/hooks/use-viewport-height", () => ({
+  useViewportHeight: () => testState.viewportHeight,
+}));
+
+vi.mock("use-stick-to-bottom", () => ({
+  useStickToBottomContext: () => ({
+    scrollToBottom: testState.scrollToBottom,
+  }),
+}));
+
+vi.mock("@/components/ai-elements/conversation", () => ({
+  Conversation: ({ children, ...props }: ComponentProps<"div">) => (
+    <div {...props}>{children}</div>
+  ),
+  ConversationContent: ({ children, ...props }: ComponentProps<"div">) => (
+    <div {...props}>{children}</div>
+  ),
+  ConversationScrollButton: () => null,
+}));
+
+vi.mock("@/components/ai-elements/prompt-input", () => ({
+  PromptInput: ({
+    children,
+    onSubmit,
+    ...props
+  }: ComponentProps<"form"> & {
+    onSubmit: (
+      message: { text?: string },
+      event: FormEvent<HTMLFormElement>
+    ) => void;
+  }) => (
+    <form
+      {...props}
+      onSubmit={(event) => {
+        event.preventDefault();
+        const formData = new FormData(event.currentTarget);
+        onSubmit({ text: String(formData.get("message") ?? "") }, event);
+      }}
+    >
+      {children}
+    </form>
+  ),
+  PromptInputBody: ({ children, ...props }: ComponentProps<"div">) => (
+    <div {...props}>{children}</div>
+  ),
+  PromptInputTextarea: forwardRef<
+    HTMLTextAreaElement,
+    ComponentProps<"textarea"> & { submitOnEnter?: boolean }
+  >(({ submitOnEnter: _submitOnEnter, ...props }, ref) => (
+    <textarea {...props} name="message" ref={ref} />
+  )),
+  PromptInputError: ({
+    error,
+    status,
+  }: {
+    error?: Error | null;
+    status?: string;
+  }) => (status === "error" && error ? <div>{error.message}</div> : null),
+  PromptInputHint: () => <div>回答確認の注意</div>,
+}));
+
+vi.mock("./mobile-chat-dialog", () => ({
+  CHAT_PANEL_RESPONSIVE_CLASSES:
+    "md:bottom-4 md:right-4 md:left-auto md:w-[450px] md:rounded-2xl",
+  MobileChatDialog: (props: {
+    children: ReactNode;
+    disableAutoFocus?: boolean;
+    initialFocusRef: { current: HTMLElement | null };
+    isOpen: boolean;
+    onClose: () => void;
+    returnFocusRef: { current: HTMLElement | null };
+    style?: React.CSSProperties;
+  }) => {
+    testState.mobileDialogProps = props;
+    if (!props.isOpen) {
+      return null;
+    }
+    return (
+      <div role="dialog" aria-label="モバイルAIチャット" style={props.style}>
+        <button type="button" onClick={props.onClose}>
+          閉じる
+        </button>
+        {props.children}
+      </div>
+    );
+  },
+}));
+
+vi.mock("./system-message", () => ({
+  SystemMessage: ({
+    isStreaming,
+    message,
+  }: {
+    isStreaming: boolean;
+    message: { id: string };
+  }) => (
+    <div data-testid={`system-${message.id}`} data-streaming={isStreaming} />
+  ),
+}));
+
+vi.mock("./user-message", () => ({
+  UserMessage: ({ message }: { message: { id: string } }) => (
+    <div data-testid={`user-${message.id}`} />
+  ),
+}));
+
+type ChatState = ReturnType<typeof import("@ai-sdk/react").useChat>;
+
+function createChatState(overrides: Record<string, unknown> = {}) {
+  return {
+    error: null,
+    messages: [],
+    sendMessage: vi.fn(),
+    status: "ready",
+    ...overrides,
+  } as unknown as ChatState;
+}
+
+function renderChatWindow(chatState = createChatState(), extraProps = {}) {
+  const returnFocusElement = document.createElement("button");
+  const returnFocusRef = { current: returnFocusElement };
+  const onClose = vi.fn();
+  const result = render(
+    <ChatWindow
+      chatState={chatState}
+      difficultyLevel="normal"
+      isOpen
+      onClose={onClose}
+      pageContext={{ type: "home" }}
+      returnFocusRef={returnFocusRef}
+      sessionId="session-1"
+      {...extraProps}
+    />
+  );
+  return { ...result, onClose, returnFocusRef };
+}
+
+beforeEach(() => {
+  testState.isDesktop = false;
+  testState.isPc = false;
+  testState.viewportHeight = 640;
+  testState.mobileDialogProps = null;
+  testState.scrollToBottom.mockReset();
+});
+
+describe("ChatWindow", () => {
+  it("モバイル表示で質問候補と入力内容を文脈付きで送信する", async () => {
+    const user = userEvent.setup();
+    const chatState = createChatState();
+    const sendMessage = chatState.sendMessage as ReturnType<typeof vi.fn>;
+    const { onClose, returnFocusRef } = renderChatWindow(chatState, {
+      disableAutoFocus: true,
+    });
+
+    const dialog = await screen.findByRole("dialog", {
+      name: "モバイルAIチャット",
+    });
+    expect(dialog).toHaveStyle({ maxHeight: "640px" });
+    expect(screen.getAllByRole("button", { name: /何|法案/ })).toHaveLength(3);
+
+    await user.click(
+      screen.getByRole("button", { name: "みらい議会って何？" })
+    );
+    expect(sendMessage).toHaveBeenCalledWith({
+      text: "みらい議会って何？",
+      metadata: {
+        billContext: undefined,
+        difficultyLevel: "normal",
+        hasInterviewConfig: undefined,
+        pageContext: { type: "home" },
+        sessionId: "session-1",
+      },
+    });
+
+    sendMessage.mockClear();
+    const textarea = screen.getByRole("textbox", {
+      name: "",
+    }) as HTMLTextAreaElement;
+    Object.defineProperty(textarea, "scrollHeight", {
+      configurable: true,
+      value: 72,
+    });
+    const form = textarea.closest("form");
+    expect(form).not.toBeNull();
+    fireEvent.submit(form as HTMLFormElement);
+    expect(sendMessage).not.toHaveBeenCalled();
+
+    fireEvent.change(textarea, { target: { value: "予算への影響は？" } });
+    expect(textarea).toHaveStyle({ height: "72px" });
+    await user.click(screen.getByRole("button", { name: "送信" }));
+
+    expect(sendMessage).toHaveBeenCalledWith({
+      text: "予算への影響は？",
+      metadata: {
+        billContext: undefined,
+        difficultyLevel: "normal",
+        hasInterviewConfig: undefined,
+        pageContext: { type: "home" },
+        sessionId: "session-1",
+      },
+    });
+    expect(textarea).toHaveValue("");
+    expect(testState.mobileDialogProps?.returnFocusRef).toBe(returnFocusRef);
+    expect(testState.mobileDialogProps?.disableAutoFocus).toBe(true);
+    expect(
+      (testState.mobileDialogProps?.initialFocusRef as { current: unknown })
+        .current
+    ).toBe(textarea);
+
+    await user.click(screen.getByRole("button", { name: "閉じる" }));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("PC表示ではモーダルではなく常設の補助領域をPortal表示する", async () => {
+    testState.isDesktop = true;
+    testState.isPc = true;
+
+    renderChatWindow(createChatState(), { isOpen: false });
+
+    expect(
+      await screen.findByRole("region", {
+        name: "国会や法案についてAIに質問する",
+      })
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("応答中は再送を止め、メッセージと進行状態を表示する", async () => {
+    testState.viewportHeight = null;
+    const chatState = createChatState({
+      messages: [
+        { id: "user-1", role: "user" },
+        { id: "assistant-1", role: "assistant" },
+      ],
+      status: "streaming",
+    });
+    const sendMessage = chatState.sendMessage as ReturnType<typeof vi.fn>;
+    const { rerender, returnFocusRef, onClose } = renderChatWindow(chatState, {
+      billContext: { id: "bill-1", name: "法案A" },
+    });
+
+    await screen.findByRole("dialog");
+    expect(testState.mobileDialogProps?.style).toBeUndefined();
+    expect(screen.getAllByRole("button", { name: /法案/ })).toHaveLength(2);
+    expect(screen.getByTestId("user-user-1")).toBeInTheDocument();
+    expect(screen.getByTestId("system-assistant-1")).toHaveAttribute(
+      "data-streaming",
+      "true"
+    );
+    expect(screen.getByText("回答確認の注意")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "送信" })).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "この法案のポイントは？" })
+    ).toBeDisabled();
+    await waitFor(() => expect(testState.scrollToBottom).toHaveBeenCalled());
+
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: "再送しない質問" } });
+    fireEvent.submit(textarea.closest("form") as HTMLFormElement);
+    expect(sendMessage).not.toHaveBeenCalled();
+
+    rerender(
+      <ChatWindow
+        billContext={{ id: "bill-1", name: "法案A" } as never}
+        chatState={createChatState({
+          messages: [{ id: "assistant-2", role: "assistant" }],
+          status: "submitted",
+        })}
+        difficultyLevel="normal"
+        isOpen
+        onClose={onClose}
+        returnFocusRef={returnFocusRef}
+        sessionId="session-1"
+      />
+    );
+
+    expect(await screen.findByText("考え中...")).toBeInTheDocument();
+  });
+});

--- a/web/src/features/chat/client/components/chat-window.tsx
+++ b/web/src/features/chat/client/components/chat-window.tsx
@@ -18,11 +18,15 @@ import {
   type PromptInputMessage,
   PromptInputTextarea,
 } from "@/components/ai-elements/prompt-input";
+import { Button } from "@/components/ui/button";
 import type { BillWithContent } from "@/features/bills/shared/types";
 import { useIsDesktop } from "@/hooks/use-is-desktop";
 import { useMediaQuery } from "@/hooks/use-media-query";
 import { useViewportHeight } from "@/hooks/use-viewport-height";
-import { MobileChatDialog } from "./mobile-chat-dialog";
+import {
+  CHAT_PANEL_RESPONSIVE_CLASSES,
+  MobileChatDialog,
+} from "./mobile-chat-dialog";
 import { SystemMessage } from "./system-message";
 import { UserMessage } from "./user-message";
 
@@ -251,8 +255,10 @@ export function ChatWindow({
               className={`!min-h-0 min-w-0 wrap-anywhere text-sm font-medium leading-[1.5em] tracking-[0.01em] placeholder:text-mirai-text-placeholder placeholder:font-medium placeholder:leading-[1.5em] placeholder:tracking-[0.01em] placeholder:no-underline border-none focus:ring-0 bg-transparent shadow-none !py-2 !px-0`}
             />
           </PromptInputBody>
-          <button
+          <Button
             type="submit"
+            variant="ghost"
+            size="icon"
             disabled={!input || isResponding}
             className="flex-shrink-0 w-10 h-10 disabled:opacity-50"
           >
@@ -263,7 +269,7 @@ export function ChatWindow({
               height={40}
               className="w-full h-full"
             />
-          </button>
+          </Button>
         </PromptInput>
         <PromptInputError status={status} error={error} />
         {messages.length > 0 && <PromptInputHint />}
@@ -281,7 +287,7 @@ export function ChatWindow({
     return createPortal(
       <section
         aria-label="国会や法案についてAIに質問する"
-        className="fixed inset-x-0 bottom-0 z-50 bg-white shadow-md rounded-t-2xl flex flex-col md:bottom-4 md:right-4 md:left-auto md:w-[450px] md:rounded-2xl pc:h-[70vh] xl:right-[calc(calc(100%-1180px)/2)]"
+        className={`fixed inset-x-0 bottom-0 z-50 bg-white shadow-md rounded-t-2xl flex flex-col pc:h-[70vh] xl:right-[calc(calc(100%-1180px)/2)] ${CHAT_PANEL_RESPONSIVE_CLASSES}`}
       >
         {chatPanelContent}
       </section>,

--- a/web/src/features/chat/client/components/chat-window.tsx
+++ b/web/src/features/chat/client/components/chat-window.tsx
@@ -1,8 +1,7 @@
 "use client";
 
-import { X } from "lucide-react";
 import Image from "next/image";
-import type { ChangeEvent } from "react";
+import type { ChangeEvent, RefObject } from "react";
 import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { useStickToBottomContext } from "use-stick-to-bottom";
@@ -21,7 +20,9 @@ import {
 } from "@/components/ai-elements/prompt-input";
 import type { BillWithContent } from "@/features/bills/shared/types";
 import { useIsDesktop } from "@/hooks/use-is-desktop";
+import { useMediaQuery } from "@/hooks/use-media-query";
 import { useViewportHeight } from "@/hooks/use-viewport-height";
+import { MobileChatDialog } from "./mobile-chat-dialog";
 import { SystemMessage } from "./system-message";
 import { UserMessage } from "./user-message";
 
@@ -42,6 +43,7 @@ interface ChatWindowProps {
     }>;
   };
   disableAutoFocus?: boolean;
+  returnFocusRef: RefObject<HTMLElement | null>;
   sessionId: string;
 }
 
@@ -161,12 +163,14 @@ export function ChatWindow({
   onClose,
   pageContext,
   disableAutoFocus = false,
+  returnFocusRef,
   sessionId,
 }: ChatWindowProps) {
   const [input, setInput] = useState("");
   const [isMounted, setIsMounted] = useState(false);
   const { messages, sendMessage, status, error } = chatState;
   const isDesktop = useIsDesktop();
+  const isPc = useMediaQuery("(min-width: 1000px)");
   const viewportHeight = useViewportHeight();
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
@@ -175,13 +179,6 @@ export function ChatWindow({
   useEffect(() => {
     setIsMounted(true);
   }, []);
-
-  // チャットが開かれたときにinputにフォーカス（disableAutoFocusがfalseの場合のみ）
-  useEffect(() => {
-    if (isOpen && textareaRef.current && !disableAutoFocus) {
-      textareaRef.current?.focus();
-    }
-  }, [isOpen, disableAutoFocus]);
 
   // Auto-resize textarea based on content
   const handleInputChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
@@ -217,94 +214,59 @@ export function ChatWindow({
     setInput("");
   };
 
-  const chatContent = (
+  const chatPanelContent = (
     <>
-      {/* オーバーレイ（1400px未満でのみ表示） */}
-      {isOpen && (
-        <button
-          type="button"
-          className="fixed inset-0 z-40 bg-black/50 transition-opacity cursor-default pc:hidden"
-          onClick={onClose}
-          aria-label="モーダルを閉じる"
-        />
-      )}
+      {/* メッセージエリア（スクロール可能） */}
+      <Conversation className="flex-1 min-h-0">
+        <ConversationContent className="p-0 flex flex-col gap-3 pc:pt-6 pb-2 px-6">
+          <ChatMessages
+            billContext={billContext}
+            hasInterviewConfig={hasInterviewConfig}
+            difficultyLevel={difficultyLevel}
+            messages={messages}
+            sendMessage={sendMessage}
+            status={status}
+            pageContext={pageContext}
+            sessionId={sessionId}
+          />
+        </ConversationContent>
+        <ConversationScrollButton />
+      </Conversation>
 
-      {/* チャットウィンドウ */}
-      <div
-        // xlサイズでは、横幅1180px（メイン + チャット）の中央寄せにする
-        className={`fixed inset-x-0 bottom-0 z-50
-          bg-white shadow-md rounded-t-2xl flex flex-col
-          md:bottom-4 md:right-4 md:left-auto md:w-[450px] md:rounded-2xl
-					pc:visible pc:opacity-100 h-[80vh] pc:h-[70vh]
-          xl:right-[calc(calc(100%-1180px)/2)]
-					${isOpen ? "visible opacity-100" : "invisible opacity-0 pc:visible pc:opacity-100"}
-				`}
-        style={
-          viewportHeight && !isDesktop
-            ? { maxHeight: `${viewportHeight}px` }
-            : undefined
-        }
-      >
-        <button
-          type="button"
-          className="pc:hidden self-end p-2 m-2 hover:bg-gray-100 rounded-full"
-          onClick={onClose}
-          aria-label="モーダルを閉じる"
+      {/* 入力エリア（固定下部） */}
+      <div className="px-6 pb-4 pt-2">
+        <PromptInput
+          onSubmit={handleSubmit}
+          className="flex items-end gap-2.5 py-2 pl-6 pr-4 bg-white rounded-[50px] border-mirai-gradient divide-y-0"
         >
-          <X className="h-5 w-5" />
-        </button>
-        {/* メッセージエリア（スクロール可能） */}
-        <Conversation className="flex-1 min-h-0">
-          <ConversationContent className="p-0 flex flex-col gap-3 pc:pt-6 pb-2 px-6">
-            <ChatMessages
-              billContext={billContext}
-              hasInterviewConfig={hasInterviewConfig}
-              difficultyLevel={difficultyLevel}
-              messages={messages}
-              sendMessage={sendMessage}
-              status={status}
-              pageContext={pageContext}
-              sessionId={sessionId}
+          <PromptInputBody className="flex-1">
+            <PromptInputTextarea
+              ref={textareaRef}
+              onChange={handleInputChange}
+              value={input}
+              placeholder="わからないことをAIに質問する"
+              rows={1}
+              submitOnEnter={isDesktop}
+              // min-w-0, wrap-anywhere が無いと長文で親幅を押し広げてしまう
+              className={`!min-h-0 min-w-0 wrap-anywhere text-sm font-medium leading-[1.5em] tracking-[0.01em] placeholder:text-mirai-text-placeholder placeholder:font-medium placeholder:leading-[1.5em] placeholder:tracking-[0.01em] placeholder:no-underline border-none focus:ring-0 bg-transparent shadow-none !py-2 !px-0`}
             />
-          </ConversationContent>
-          <ConversationScrollButton />
-        </Conversation>
-
-        {/* 入力エリア（固定下部） */}
-        <div className="px-6 pb-4 pt-2">
-          <PromptInput
-            onSubmit={handleSubmit}
-            className="flex items-end gap-2.5 py-2 pl-6 pr-4 bg-white rounded-[50px] border-mirai-gradient divide-y-0"
+          </PromptInputBody>
+          <button
+            type="submit"
+            disabled={!input || isResponding}
+            className="flex-shrink-0 w-10 h-10 disabled:opacity-50"
           >
-            <PromptInputBody className="flex-1">
-              <PromptInputTextarea
-                ref={textareaRef}
-                onChange={handleInputChange}
-                value={input}
-                placeholder="わからないことをAIに質問する"
-                rows={1}
-                submitOnEnter={isDesktop}
-                // min-w-0, wrap-anywhere が無いと長文で親幅を押し広げてしまう
-                className={`!min-h-0 min-w-0 wrap-anywhere text-sm font-medium leading-[1.5em] tracking-[0.01em] placeholder:text-mirai-text-placeholder placeholder:font-medium placeholder:leading-[1.5em] placeholder:tracking-[0.01em] placeholder:no-underline border-none focus:ring-0 bg-transparent shadow-none !py-2 !px-0`}
-              />
-            </PromptInputBody>
-            <button
-              type="submit"
-              disabled={!input || isResponding}
-              className="flex-shrink-0 w-10 h-10 disabled:opacity-50"
-            >
-              <Image
-                src="/icons/send-button-icon.svg"
-                alt="送信"
-                width={40}
-                height={40}
-                className="w-full h-full"
-              />
-            </button>
-          </PromptInput>
-          <PromptInputError status={status} error={error} />
-          {messages.length > 0 && <PromptInputHint />}
-        </div>
+            <Image
+              src="/icons/send-button-icon.svg"
+              alt="送信"
+              width={40}
+              height={40}
+              className="w-full h-full"
+            />
+          </button>
+        </PromptInput>
+        <PromptInputError status={status} error={error} />
+        {messages.length > 0 && <PromptInputHint />}
       </div>
     </>
   );
@@ -314,6 +276,33 @@ export function ChatWindow({
     return null;
   }
 
-  // チャットのストリーミング表示がルビ機能と競合して表示がおかしくなるため、body直下に移動してルビ機能の影響を受けないようにする
-  return createPortal(chatContent, document.body);
+  // PCでは常設の補助領域、モバイルでは背景を操作不能にするモーダルとして扱う
+  if (isPc) {
+    return createPortal(
+      <section
+        aria-label="国会や法案についてAIに質問する"
+        className="fixed inset-x-0 bottom-0 z-50 bg-white shadow-md rounded-t-2xl flex flex-col md:bottom-4 md:right-4 md:left-auto md:w-[450px] md:rounded-2xl pc:h-[70vh] xl:right-[calc(calc(100%-1180px)/2)]"
+      >
+        {chatPanelContent}
+      </section>,
+      document.body
+    );
+  }
+
+  return (
+    <MobileChatDialog
+      disableAutoFocus={disableAutoFocus}
+      initialFocusRef={textareaRef}
+      isOpen={isOpen}
+      onClose={onClose}
+      returnFocusRef={returnFocusRef}
+      style={
+        viewportHeight && !isDesktop
+          ? { maxHeight: `${viewportHeight}px` }
+          : undefined
+      }
+    >
+      {chatPanelContent}
+    </MobileChatDialog>
+  );
 }

--- a/web/src/features/chat/client/components/mobile-chat-dialog.test.tsx
+++ b/web/src/features/chat/client/components/mobile-chat-dialog.test.tsx
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom/vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useRef, useState } from "react";
+import { beforeAll, describe, expect, it } from "vitest";
+import { MobileChatDialog } from "./mobile-chat-dialog";
+
+beforeAll(() => {
+  if (!Element.prototype.hasPointerCapture) {
+    Element.prototype.hasPointerCapture = () => false;
+  }
+  if (!Element.prototype.setPointerCapture) {
+    Element.prototype.setPointerCapture = () => {};
+  }
+  if (!Element.prototype.releasePointerCapture) {
+    Element.prototype.releasePointerCapture = () => {};
+  }
+});
+
+function TestChatDialog({ disableAutoFocus = false }) {
+  const [isOpen, setIsOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  return (
+    <>
+      <button ref={triggerRef} type="button" onClick={() => setIsOpen(true)}>
+        AIに質問する
+      </button>
+      <main>背景コンテンツ</main>
+      <MobileChatDialog
+        disableAutoFocus={disableAutoFocus}
+        initialFocusRef={inputRef}
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        returnFocusRef={triggerRef}
+      >
+        <label>
+          質問
+          <input ref={inputRef} />
+        </label>
+      </MobileChatDialog>
+    </>
+  );
+}
+
+describe("MobileChatDialog", () => {
+  it("開くと名前付きモーダルになり、入力欄へフォーカスする", async () => {
+    const user = userEvent.setup();
+    render(<TestChatDialog />);
+
+    await user.click(screen.getByRole("button", { name: "AIに質問する" }));
+
+    expect(
+      screen.getByRole("dialog", {
+        name: "国会や法案についてAIに質問する",
+      })
+    ).toHaveAttribute("aria-modal", "true");
+    expect(
+      screen.getByText("背景コンテンツ").closest('[aria-hidden="true"]')
+    ).not.toBeNull();
+    await waitFor(() => {
+      expect(screen.getByRole("textbox", { name: "質問" })).toHaveFocus();
+    });
+  });
+
+  it("フォーカスをダイアログ内に保ち、Escで閉じて起点へ戻す", async () => {
+    const user = userEvent.setup();
+    render(<TestChatDialog />);
+
+    const trigger = screen.getByRole("button", { name: "AIに質問する" });
+    await user.click(trigger);
+
+    const input = screen.getByRole("textbox", { name: "質問" });
+    await waitFor(() => expect(input).toHaveFocus());
+
+    await user.tab();
+    expect(
+      screen.getByRole("button", { name: "AIチャットを閉じる" })
+    ).toHaveFocus();
+    await user.tab();
+    expect(input).toHaveFocus();
+
+    await user.keyboard("{Escape}");
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+      expect(trigger).toHaveFocus();
+      expect(
+        screen.getByText("背景コンテンツ").closest('[aria-hidden="true"]')
+      ).toBeNull();
+    });
+  });
+
+  it("本文選択から開いた場合は閉じるボタンを最初の操作先にする", async () => {
+    const user = userEvent.setup();
+    render(<TestChatDialog disableAutoFocus />);
+
+    await user.click(screen.getByRole("button", { name: "AIに質問する" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "AIチャットを閉じる" })
+      ).toHaveFocus();
+    });
+  });
+});

--- a/web/src/features/chat/client/components/mobile-chat-dialog.tsx
+++ b/web/src/features/chat/client/components/mobile-chat-dialog.tsx
@@ -6,6 +6,9 @@ import type { CSSProperties, ReactNode, RefObject } from "react";
 import { useRef } from "react";
 import { Button } from "@/components/ui/button";
 
+export const CHAT_PANEL_RESPONSIVE_CLASSES =
+  "md:bottom-4 md:right-4 md:left-auto md:w-[450px] md:rounded-2xl";
+
 interface MobileChatDialogProps {
   children: ReactNode;
   disableAutoFocus?: boolean;
@@ -16,6 +19,9 @@ interface MobileChatDialogProps {
   style?: CSSProperties;
 }
 
+/**
+ * モバイル表示のチャットを、背景から隔離されたフォーカス管理付きダイアログとして表示する。
+ */
 export function MobileChatDialog({
   children,
   disableAutoFocus = false,
@@ -41,7 +47,7 @@ export function MobileChatDialog({
         <DialogPrimitive.Content
           aria-describedby={undefined}
           aria-modal="true"
-          className="fixed inset-x-0 bottom-0 z-50 h-[80vh] bg-white shadow-md rounded-t-2xl flex flex-col outline-none md:bottom-4 md:right-4 md:left-auto md:w-[450px] md:rounded-2xl"
+          className={`fixed inset-x-0 bottom-0 z-50 h-[80vh] bg-white shadow-md rounded-t-2xl flex flex-col outline-none ${CHAT_PANEL_RESPONSIVE_CLASSES}`}
           style={style}
           onOpenAutoFocus={(event) => {
             event.preventDefault();

--- a/web/src/features/chat/client/components/mobile-chat-dialog.tsx
+++ b/web/src/features/chat/client/components/mobile-chat-dialog.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
+import type { CSSProperties, ReactNode, RefObject } from "react";
+import { useRef } from "react";
+import { Button } from "@/components/ui/button";
+
+interface MobileChatDialogProps {
+  children: ReactNode;
+  disableAutoFocus?: boolean;
+  initialFocusRef: RefObject<HTMLElement | null>;
+  isOpen: boolean;
+  onClose: () => void;
+  returnFocusRef: RefObject<HTMLElement | null>;
+  style?: CSSProperties;
+}
+
+export function MobileChatDialog({
+  children,
+  disableAutoFocus = false,
+  initialFocusRef,
+  isOpen,
+  onClose,
+  returnFocusRef,
+  style,
+}: MobileChatDialogProps) {
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+
+  return (
+    <DialogPrimitive.Root
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) {
+          onClose();
+        }
+      }}
+    >
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Overlay className="fixed inset-0 z-40 bg-black/50" />
+        <DialogPrimitive.Content
+          aria-describedby={undefined}
+          aria-modal="true"
+          className="fixed inset-x-0 bottom-0 z-50 h-[80vh] bg-white shadow-md rounded-t-2xl flex flex-col outline-none md:bottom-4 md:right-4 md:left-auto md:w-[450px] md:rounded-2xl"
+          style={style}
+          onOpenAutoFocus={(event) => {
+            event.preventDefault();
+            if (disableAutoFocus) {
+              closeButtonRef.current?.focus();
+              return;
+            }
+            initialFocusRef.current?.focus();
+          }}
+          onCloseAutoFocus={(event) => {
+            event.preventDefault();
+            returnFocusRef.current?.focus();
+          }}
+        >
+          <DialogPrimitive.Title className="sr-only">
+            国会や法案についてAIに質問する
+          </DialogPrimitive.Title>
+          <DialogPrimitive.Close asChild>
+            <Button
+              ref={closeButtonRef}
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="self-end m-2"
+              aria-label="AIチャットを閉じる"
+            >
+              <X className="h-5 w-5" />
+            </Button>
+          </DialogPrimitive.Close>
+          {children}
+        </DialogPrimitive.Content>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
+  );
+}


### PR DESCRIPTION
## 概要

モバイル版AIチャットで、ポップアップを開いてもフォーカスが背後へ移動できる状態を確認したため、表示状態と読み上げ・キーボード操作を一致させる改善を行いました。

調査・修正には [information-accessibility-skill](https://github.com/Nagi-Inaba/information-accessibility-skill) を使用しています。

## 変更内容

- モバイル版AIチャットを名前付きのモーダルダイアログとして公開
- 開いている間、背後のコンテンツをアクセシビリティツリーとフォーカス順から隔離
- Tab / Shift+Tab のフォーカストラップと Escape で閉じる操作を追加
- 閉じた後、フォーカスを「議案について質問する」ボタンへ復帰
- 通常起動では入力欄、本文選択からの起動では閉じるボタンへ初期フォーカス
- 1000px以上の常設チャットは、モーダルではなく名前付きの補助領域として従来表示を維持
- トリガーへ `aria-haspopup="dialog"` と開閉状態を追加

## テスト

- ✅ 変更4ファイルの Biome format / lint
- ✅ 全ワークスペースの typecheck
- ✅ Webテスト全件
- ✅ 新規回帰テスト3件
  - 名前付きモーダルと初期フォーカス
  - 背景の読み上げ対象除外
  - フォーカストラップ、Escape、起点への復帰
- ✅ 独立コードレビュー（指摘なし）

## 既存環境由来の未完了項目

- ルートの `pnpm lint` は、変更外の既存ファイル約1,000件のCRLF/LF整形差分で失敗（変更4ファイルは合格）
- 全ワークスペーステストは、Windowsのパス区切りを想定していない既存の `admin/src/lib/routes.test.ts` 2件のみ失敗（Webテストは全件合格）
- ローカル実画面はSupabase未起動のためトップページが500となり、差分版スクリーンショットは未取得
- 本番ビルドは必要なSupabase環境変数・データ環境がないため完了確認できず

## 実機確認で見たい点

- iPhone / Safari / VoiceOverで、開いた直後にチャット内へ移動すること
- 左右スワイプで背後の本文へ抜けないこと
- 閉じた後に起点ボタンへ戻ること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - モバイルチャットをダイアログ形式で表示し、開閉時のフォーカス移動とキーボード操作を改善しました。
  - ダイアログを閉じた際、起点となったチャットボタンへフォーカスが戻るようになりました。
  - PCとモバイルで最適化されたチャット表示に対応しました。
  - チャットボタンとダイアログのアクセシビリティ属性を強化しました。

- **テスト**
  - チャットの表示、送信、フォーカス制御、キーボード操作、応答中の状態を検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->