### PR TITLE
fix: Safari/iOS でふりがなのルビと漢字の間隔が広くなる問題を修正

### DIFF
--- a/web/src/lib/rubyful/styles.css
+++ b/web/src/lib/rubyful/styles.css
@@ -17,3 +17,16 @@ button .rubyful-rt,
 [data-slot="button"] .rubyful-rt {
   display: none;
 }
+
+/* Safari / iOS (WebKit) はルビ（rt）を本文ボックスの完全に外側へ積むため、
+   本文の字面上の余白にルビを食い込ませて配置する Chrome / Edge (Blink) と比べて
+   漢字とルビの間隔が広く見える（issue #187）。
+   WebKit のみが解釈する -webkit-hyphens を Safari/iOS 判定として使い、
+   ルビを下方へ 0.5em（ルビ文字サイズ基準）シフトして Blink の見た目に揃える。
+   なお Blink は ruby-text への transform を適用しないため二重適用は起きないが、
+   意図を明示するため @supports で WebKit に限定している */
+@supports (-webkit-hyphens: none) {
+  rt {
+    transform: translateY(0.5em);
+  }
+}

--- a/web/src/lib/rubyful/styles.css
+++ b/web/src/lib/rubyful/styles.css
@@ -21,11 +21,13 @@ button .rubyful-rt,
 /* Safari / iOS (WebKit) はルビ（rt）を本文ボックスの完全に外側へ積むため、
    本文の字面上の余白にルビを食い込ませて配置する Chrome / Edge (Blink) と比べて
    漢字とルビの間隔が広く見える（issue #187）。
-   WebKit のみが解釈する -webkit-hyphens を Safari/iOS 判定として使い、
+   WebKit 専有の -webkit-named-image() を Safari/iOS 判定として使い
+   （実測: WebKit=true / Blink=false / Gecko=false）、
    ルビを下方へ 0.5em（ルビ文字サイズ基準）シフトして Blink の見た目に揃える。
    なお Blink は ruby-text への transform を適用しないため二重適用は起きないが、
    意図を明示するため @supports で WebKit に限定している */
-@supports (-webkit-hyphens: none) {
+/* biome-ignore lint/correctness/noUnknownFunction: -webkit-named-image は WebKit 専有関数で、それ自体を Safari/iOS 判定に使っている */
+@supports (background: -webkit-named-image(i)) {
   rt {
     transform: translateY(0.5em);
   }


### PR DESCRIPTION
# 変更の概要
- Mac Safari / iOS（WebKit 系ブラウザ）でふりがな表示時に、漢字とルビの間隔が Chrome より広く見える問題を修正しました
- `web/src/lib/rubyful/styles.css` に WebKit 限定の 1 ルールを追加しています:
  ```css
  @supports (-webkit-hyphens: none) {
    rt {
      transform: translateY(0.5em);
    }
  }
  ```

# 変更の背景
- closes #187
- Playwright WebKit / Chromium で本番ページを実測したところ、原因はエンジンのルビ配置差でした:
  - **Blink（Chrome/Edge）はルビの箱を本文テキストボックスへ約 0.29em（本文フォント基準）食い込ませて配置**します（漢字の字面上の余白に収める。実測 gap = −7px @ 本文 24px）
  - **WebKit（Safari/iOS）は食い込みゼロで完全に外側へ積む**（実測 gap = 0px）ため、その差がそのまま「ルビが遠い」見た目になります
  - `rt { line-height: 1 }` は両エンジンとも配置に影響しないことを実測で確認済みです（無効果）
- 修正方式の根拠:
  - `-webkit-hyphens` は WebKit のみが解釈するため（実測: WebKit=true / Blink=false）、Safari/iOS 限定のゲートになります（iOS の Chrome も WebKit なので同様に適用されます）
  - Blink は ruby-text への transform を適用しないため（実測）、仮にゲートを通っても二重適用は起きませんが、意図を明示するため `@supports` で限定しています
  - `em` 指定のためフォントサイズに比例してスケールします（ヒーロー 24px・本文 15px の両方で実測確認）
  - transform は描画のみのシフトで行ボックスは変わらないため、前の行と衝突しません

# スクリーンショット

本番ページ（`https://gikai.team-mir.ai/`）に本 PR の CSS を注入し、Playwright WebKit / Chromium で撮影したものです。

| Safari (WebKit) 修正前 | Safari (WebKit) 修正後 |
|---|---|
| ![safari-before](https://raw.githubusercontent.com/yasumorishima/mirai-gikai/pr-187-screenshots/safari-before.png) | ![safari-after](https://raw.githubusercontent.com/yasumorishima/mirai-gikai/pr-187-screenshots/safari-after.png) |

Chrome（参考・本 PR で描画変化なし。ガードが効いていることも実測確認済み）:

![chrome-reference](https://raw.githubusercontent.com/yasumorishima/mirai-gikai/pr-187-screenshots/chrome-reference.png)

- [x] フロントエンドの変更なし / スクリーンショットを添付済み

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **スタイル**
  * Safari/iOS（WebKit）で、漢字とルビの間隔が広く見える表示差異を抑える調整を追加し、見え方を改善しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->