### PR TITLE
fix: Supabase previewブランチ操作に親プロジェクトrefを使用する

### DIFF
--- a/.github/workflows/supabase_preview.yml
+++ b/.github/workflows/supabase_preview.yml
@@ -21,7 +21,10 @@ jobs:
     environment: staging
     env:
       SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
-      SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
+      # ブランチ管理 API は親プロジェクト（main ブランチ）の ref に対して呼ぶ必要がある。
+      # 既存の SUPABASE_PROJECT_REF は staging「ブランチ」の ref（deploy.yml の link 用）
+      # のため、ここでは使わないこと（ブランチ ref に branches API を呼ぶと 403 になる）
+      SUPABASE_MAIN_PROJECT_REF: ${{ secrets.SUPABASE_MAIN_PROJECT_REF }}
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
       VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
       VERCEL_WEB_PROJECT_ID: ${{ secrets.WEB_VERCEL_PROJECT_ID }}
@@ -65,7 +68,7 @@ jobs:
       - name: Check prerequisites
         id: ready
         run: |
-          if supabase branches list --project-ref "$SUPABASE_PROJECT_REF" > /dev/null 2>&1; then
+          if supabase branches list --project-ref "$SUPABASE_MAIN_PROJECT_REF" > /dev/null 2>&1; then
             echo "branching=true" >> "$GITHUB_OUTPUT"
           else
             echo "branching=false" >> "$GITHUB_OUTPUT"
@@ -89,9 +92,9 @@ jobs:
           # ブランチ不在（作成していない PR）は正常系として静かに抜ける。
           # 認証エラー等の判定不能な失敗は課金リークにつながるため明示的に失敗させる
           if output=$(supabase branches get "${{ steps.branch.outputs.name }}" \
-            --project-ref "$SUPABASE_PROJECT_REF" -o json 2>&1); then
+            --project-ref "$SUPABASE_MAIN_PROJECT_REF" -o json 2>&1); then
             supabase branches delete "${{ steps.branch.outputs.name }}" \
-              --project-ref "$SUPABASE_PROJECT_REF" --yes
+              --project-ref "$SUPABASE_MAIN_PROJECT_REF" --yes
           elif echo "$output" | grep -qiE 'not.?found|404'; then
             echo "No preview branch to delete."
           else
@@ -133,11 +136,11 @@ jobs:
           steps.ready.outputs.branching == 'true'
         run: |
           if supabase branches get "${{ steps.branch.outputs.name }}" \
-            --project-ref "$SUPABASE_PROJECT_REF" -o json > /dev/null 2>&1; then
+            --project-ref "$SUPABASE_MAIN_PROJECT_REF" -o json > /dev/null 2>&1; then
             echo "created=false" >> "$GITHUB_OUTPUT"
           else
             supabase branches create "${{ steps.branch.outputs.name }}" \
-              --project-ref "$SUPABASE_PROJECT_REF" \
+              --project-ref "$SUPABASE_MAIN_PROJECT_REF" \
               --git-branch "$GIT_BRANCH" \
               --size micro --yes
             echo "created=true" >> "$GITHUB_OUTPUT"
@@ -151,7 +154,7 @@ jobs:
           # 20秒間隔 × 30回 = 最大10分待つ（新規作成時のプロビジョニングを想定）
           for i in $(seq 1 30); do
             status=$(supabase branches get "${{ steps.branch.outputs.name }}" \
-              --project-ref "$SUPABASE_PROJECT_REF" -o json | jq -r '.status // empty')
+              --project-ref "$SUPABASE_MAIN_PROJECT_REF" -o json | jq -r '.status // empty')
             echo "Branch status: ${status:-unknown} (attempt $i)"
             case "$status" in
               ACTIVE_HEALTHY|MIGRATIONS_PASSED|FUNCTIONS_DEPLOYED) exit 0 ;;
@@ -172,7 +175,7 @@ jobs:
           steps.ready.outputs.branching == 'true'
         run: |
           supabase branches get "${{ steps.branch.outputs.name }}" \
-            --project-ref "$SUPABASE_PROJECT_REF" -o env > branch.env
+            --project-ref "$SUPABASE_MAIN_PROJECT_REF" -o env > branch.env
           for key in SUPABASE_URL SUPABASE_ANON_KEY SUPABASE_SERVICE_ROLE_KEY POSTGRES_URL_NON_POOLING; do
             if ! grep -q "^${key}=" branch.env; then
               echo "Missing ${key} in branch credentials. Available keys:" >&2

--- a/docs/20260717_1200_Supabase_PreviewブランチCI設計.md
+++ b/docs/20260717_1200_Supabase_PreviewブランチCI設計.md
@@ -33,10 +33,10 @@ Supabase Branching（preview ブランチ）を PR のライフサイクルに�
 既存（deploy.yml と共用）:
 
 - `SUPABASE_ACCESS_TOKEN`
-- `SUPABASE_PROJECT_REF` … staging プロジェクト。preview ブランチはこのプロジェクト配下に作られる
 
 新規追加が必要:
 
+- `SUPABASE_MAIN_PROJECT_REF` … Supabase の**親プロジェクト（main ブランチ）の ref**。preview ブランチはこのプロジェクト配下（staging ブランチの兄弟）に作られる。既存の `SUPABASE_PROJECT_REF` は staging **ブランチ**の ref（deploy.yml の `supabase link` 用）であり、ブランチ ref に branches API を呼ぶと 403 になるため流用できない
 - `VERCEL_TOKEN` … Vercel の API トークン（web/admin 両プロジェクトにアクセスできるスコープ）
 - `VERCEL_TEAM_ID` … Vercel のチーム ID
 - `WEB_VERCEL_PROJECT_ID` / `ADMIN_VERCEL_PROJECT_ID` … 各 Vercel プロジェクトの ID
@@ -47,7 +47,8 @@ Supabase Branching（preview ブランチ）を PR のライフサイクルに�
 
 ### Supabase 側の前提
 
-- staging プロジェクトで **Branching が利用可能なプラン**（Pro 以上）であること
+- 本プロジェクトは「1つの Supabase プロジェクト + persistent ブランチ `staging`（develop に対応）」という Branching 前提の構成で運用されており、**Branching は有効化済み**（追加のプラン作業は不要）
+- preview ブランチは親プロジェクト配下に `staging` ブランチと並ぶ形で作られる（設定は main = 本番から複製、データは引き継がない）
 - 課金: preview ブランチは micro で **約 $0.01344/時**（≒ $0.32/日）。Compute Credits・Spend Cap の対象外。PR クローズで削除されるため、open な PR の数だけ課金される
 
 ## 環境変数のマッピング


### PR DESCRIPTION
## 概要

#929 のワークフローが実際には動かない問題の修正です。

## 原因

本プロジェクトのSupabaseは「1つのプロジェクト + persistent ブランチ `staging`」というBranching前提の構成で運用されており、staging environment の secret `SUPABASE_PROJECT_REF` には **stagingブランチのref** が入っています（deploy.yml の `supabase link` 用としては正しい）。

一方、ブランチ管理API（`supabase branches list/create/get/delete`）は**親プロジェクト（mainブランチ）のref**に対して呼ぶ必要があり、ブランチrefに対して呼ぶと403が返ります。実際にCLIで確認しました：

- `branches create --project-ref <stagingブランチref>` → 403（privileges error）
- `branches list --project-ref <親プロジェクトref>` → 成功（main / staging の2ブランチが見える）

このため #929 のワークフローは前提チェック（`branches list`）が常に失敗し、「Branching利用不可」の警告付きno-opになり続けます。

## 対応

- ブランチ操作に使うrefを新しい secret `SUPABASE_MAIN_PROJECT_REF`（親プロジェクトのref）に切り替え。既存の `SUPABASE_PROJECT_REF` は deploy.yml 用にそのまま
- 設計ドキュメントを実際の構成（Branchingは有効化済み・previewブランチはstagingブランチの兄弟として作られる）に合わせて更新

## マージ前に必要な設定

staging environment に secret を1つ追加してください：

```bash
gh secret set SUPABASE_MAIN_PROJECT_REF --env staging --repo team-mirai/mirai-gikai
```

値はSupabaseの親プロジェクト（mainブランチ）のref。`supabase projects list` またはダッシュボードのmainブランチ表示時のURLで確認できます。

## 検証

- `actionlint` ✅ 指摘ゼロ
- 上記の403 → 親refで成功、をローカルCLIで実証済み（このrefの取り違えが唯一の失敗原因であることを確認）
- 全体のE2E検証は、本PRマージ + secret設定後に supabase/ 変更を含むテストPRで実施予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)