### PR TITLE
オープンデータAPIと開発者向けドキュメントページを追加

### DIFF
--- a/.github/workflows/supabase_preview.yml
+++ b/.github/workflows/supabase_preview.yml
@@ -151,21 +151,20 @@ jobs:
           github.event.action != 'closed' && steps.changes.outputs.supabase == 'true' &&
           steps.ready.outputs.branching == 'true'
         run: |
+          # `branches get` の出力に status フィールドは無い（接続情報のみ）ため、
+          # 後続ステップが実際に必要とする接続情報が取得できることを準備完了とみなす。
           # 20秒間隔 × 30回 = 最大10分待つ（新規作成時のプロビジョニングを想定）
           for i in $(seq 1 30); do
-            status=$(supabase branches get "${{ steps.branch.outputs.name }}" \
-              --project-ref "$SUPABASE_MAIN_PROJECT_REF" -o json | jq -r '.status // empty')
-            echo "Branch status: ${status:-unknown} (attempt $i)"
-            case "$status" in
-              ACTIVE_HEALTHY|MIGRATIONS_PASSED|FUNCTIONS_DEPLOYED) exit 0 ;;
-              *FAILED*|*UNHEALTHY*)
-                echo "Branch entered failure status: $status" >&2
-                exit 1
-                ;;
-            esac
+            if supabase branches get "${{ steps.branch.outputs.name }}" \
+              --project-ref "$SUPABASE_MAIN_PROJECT_REF" -o env 2>/dev/null \
+              | grep -q '^POSTGRES_URL_NON_POOLING=.'; then
+              echo "Branch credentials available (attempt $i)"
+              exit 0
+            fi
+            echo "Waiting for branch to be ready (attempt $i)"
             sleep 20
           done
-          echo "Branch did not become healthy in time" >&2
+          echo "Branch did not become ready in time" >&2
           exit 1
 
       - name: Load branch credentials

--- a/.github/workflows/supabase_preview.yml
+++ b/.github/workflows/supabase_preview.yml
@@ -151,20 +151,27 @@ jobs:
           github.event.action != 'closed' && steps.changes.outputs.supabase == 'true' &&
           steps.ready.outputs.branching == 'true'
         run: |
-          # `branches get` の出力に status フィールドは無い（接続情報のみ）ため、
-          # 後続ステップが実際に必要とする接続情報が取得できることを準備完了とみなす。
-          # 20秒間隔 × 30回 = 最大10分待つ（新規作成時のプロビジョニングを想定）
+          # 20秒間隔 × 30回 = 最大10分待つ（新規作成時のプロビジョニングを想定）。
+          # 注意: `branches get` の JSON は接続情報のみで status を含まないため、
+          # status は `branches list` からブランチ名で引く（PR #934 の初回実運用で判明）
           for i in $(seq 1 30); do
-            if supabase branches get "${{ steps.branch.outputs.name }}" \
-              --project-ref "$SUPABASE_MAIN_PROJECT_REF" -o env 2>/dev/null \
-              | grep -q '^POSTGRES_URL_NON_POOLING=.'; then
-              echo "Branch credentials available (attempt $i)"
-              exit 0
-            fi
-            echo "Waiting for branch to be ready (attempt $i)"
+            status=$(supabase branches list \
+              --project-ref "$SUPABASE_MAIN_PROJECT_REF" -o json \
+              | jq -r --arg name "${{ steps.branch.outputs.name }}" \
+                'try ([.[] | select(.name == $name)][0].status) // empty')
+            echo "Branch status: ${status:-unknown} (attempt $i)"
+            case "$status" in
+              ACTIVE_HEALTHY|MIGRATIONS_PASSED|FUNCTIONS_DEPLOYED) exit 0 ;;
+              *FAILED*|*UNHEALTHY*)
+                echo "Branch entered failure status: $status" >&2
+                exit 1
+                ;;
+            esac
             sleep 20
           done
-          echo "Branch did not become ready in time" >&2
+          # 調査用にブランチ一覧の生出力を残してから失敗させる
+          supabase branches list --project-ref "$SUPABASE_MAIN_PROJECT_REF" -o json || true
+          echo "Branch did not become healthy in time" >&2
           exit 1
 
       - name: Load branch credentials
@@ -175,7 +182,7 @@ jobs:
         run: |
           supabase branches get "${{ steps.branch.outputs.name }}" \
             --project-ref "$SUPABASE_MAIN_PROJECT_REF" -o env > branch.env
-          for key in SUPABASE_URL SUPABASE_ANON_KEY SUPABASE_SERVICE_ROLE_KEY POSTGRES_URL_NON_POOLING; do
+          for key in SUPABASE_URL SUPABASE_ANON_KEY SUPABASE_SERVICE_ROLE_KEY POSTGRES_URL; do
             if ! grep -q "^${key}=" branch.env; then
               echo "Missing ${key} in branch credentials. Available keys:" >&2
               cut -d= -f1 branch.env >&2
@@ -197,11 +204,13 @@ jobs:
           github.event.action != 'closed' && steps.changes.outputs.supabase == 'true' &&
           steps.ready.outputs.branching == 'true'
         run: |
+          # POSTGRES_URL_NON_POOLING（直接接続）は IPv6 必須で GitHub Actions の
+          # ランナーから到達できないため、IPv4 対応の pooler 経由（POSTGRES_URL）を使う
           if [ "${{ steps.create.outputs.created }}" = "true" ]; then
-            supabase db push --db-url "$BRANCH_POSTGRES_URL_NON_POOLING" \
+            supabase db push --db-url "$BRANCH_POSTGRES_URL" \
               --include-all --include-seed --yes
           else
-            supabase db push --db-url "$BRANCH_POSTGRES_URL_NON_POOLING" \
+            supabase db push --db-url "$BRANCH_POSTGRES_URL" \
               --include-all --yes
           fi
 

--- a/docs/20260717_1200_Supabase_PreviewブランチCI設計.md
+++ b/docs/20260717_1200_Supabase_PreviewブランチCI設計.md
@@ -64,7 +64,8 @@ Supabase Branching（preview ブランチ）を PR のライフサイクルに�
 
 ## 制約・注意点
 
-- **初回実運用時に要確認**: `branches get -o env` の出力キーはワークフロー内で検証しており、想定と異なる場合は明示的に失敗する（Available keys がログに出る）。あわせて `branches get / delete` がブランチ名（ID ではなく）を受け付けること、ステータス文字列（`ACTIVE_HEALTHY` 等）が待機ループの想定と一致することも初回に確認する
+- **初回実運用時に要確認**: `branches get -o env` の出力キーはワークフロー内で検証しており、想定と異なる場合は明示的に失敗する（Available keys がログに出る）。あわせて `branches get / delete` がブランチ名（ID ではなく）を受け付けることも初回に確認する
+- **待機ループは接続情報ベース**: `branches get` の出力に status フィールドは存在しない（初回実運用 #934 で確認）ため、準備完了は「接続情報（`POSTGRES_URL_NON_POOLING`）が取得できること」で判定する
 - **Google 認証は動かない**: ブランチ DB には `supabase config push`（Google OAuth のリダイレクト URL 等）を適用していないため、認証が必要な画面の検証は staging 共有の Preview と同様の制約が残る
 - **synchronize 時のレース**: push 直後は Vercel のビルドとマイグレーション適用が並行するため、ビルド完了直後の一瞬だけ新スキーマ未適用の可能性がある（リロードで解消）
 - **データは seed のみ**: ブランチ DB は本番/staging のデータを引き継がず、`supabase/seed.sql` で初期化される（`--with-data` オプションは将来検討）

--- a/docs/20260717_1200_Supabase_PreviewブランチCI設計.md
+++ b/docs/20260717_1200_Supabase_PreviewブランチCI設計.md
@@ -64,8 +64,9 @@ Supabase Branching（preview ブランチ）を PR のライフサイクルに�
 
 ## 制約・注意点
 
-- **初回実運用時に要確認**: `branches get -o env` の出力キーはワークフロー内で検証しており、想定と異なる場合は明示的に失敗する（Available keys がログに出る）。あわせて `branches get / delete` がブランチ名（ID ではなく）を受け付けることも初回に確認する
-- **待機ループは接続情報ベース**: `branches get` の出力に status フィールドは存在しない（初回実運用 #934 で確認）ため、準備完了は「接続情報（`POSTGRES_URL_NON_POOLING`）が取得できること」で判定する
+- **初回実運用時に要確認**: `branches get -o env` の出力キーはワークフロー内で検証しており、想定と異なる場合は明示的に失敗する（Available keys がログに出る）。`branches get / delete` がブランチ名（ID ではなく）を受け付けることは初回実運用（PR #934）で確認済み
+- **`branches get` の JSON に status は含まれない**: `branches get -o json` が返すのは接続情報のみ。ブランチの status（`ACTIVE_HEALTHY` 等）は `branches list -o json` からブランチ名で引く必要がある（初回実運用で待機ループが `unknown` のままタイムアウトした原因。修正済み）
+- **マイグレーション適用は pooler 経由（`POSTGRES_URL`）**: 直接接続の `POSTGRES_URL_NON_POOLING` は IPv6 必須で GitHub Actions のランナーから到達できない（`network is unreachable` で失敗。初回実運用で判明し修正済み）
 - **Google 認証は動かない**: ブランチ DB には `supabase config push`（Google OAuth のリダイレクト URL 等）を適用していないため、認証が必要な画面の検証は staging 共有の Preview と同様の制約が残る
 - **synchronize 時のレース**: push 直後は Vercel のビルドとマイグレーション適用が並行するため、ビルド完了直後の一瞬だけ新スキーマ未適用の可能性がある（リロードで解消）
 - **データは seed のみ**: ブランチ DB は本番/staging のデータを引き継がず、`supabase/seed.sql` で初期化される（`--with-data` オプションは将来検討）

--- a/packages/supabase/types/supabase.types.ts
+++ b/packages/supabase/types/supabase.types.ts
@@ -34,6 +34,24 @@ export type Database = {
   }
   public: {
     Tables: {
+      api_rate_limits: {
+        Row: {
+          key: string
+          request_count: number
+          window_start: string
+        }
+        Insert: {
+          key: string
+          request_count?: number
+          window_start: string
+        }
+        Update: {
+          key?: string
+          request_count?: number
+          window_start?: string
+        }
+        Relationships: []
+      }
       bill_contents: {
         Row: {
           bill_id: string
@@ -1130,6 +1148,27 @@ export type Database = {
         Args: { content: string }
         Returns: string
       }
+      find_open_data_interview_reports: {
+        Args: {
+          p_cursor_created_at?: string
+          p_cursor_id?: string
+          p_limit: number
+          p_min_public_reports: number
+        }
+        Returns: {
+          bill_id: string
+          bill_name: string
+          created_at: string
+          interview_session_id: string
+          opinions: Json
+          report_id: string
+          role: string
+          role_description: string
+          role_title: string
+          stance: string
+          summary: string
+        }[]
+      }
       find_public_reports_by_bill_id_ordered_by_reactions: {
         Args: {
           p_bill_id: string
@@ -1282,6 +1321,10 @@ export type Database = {
           question_id: string
           question_order: number
         }[]
+      }
+      increment_api_rate_limit: {
+        Args: { p_key: string; p_limit: number; p_window_start: string }
+        Returns: boolean
       }
       is_admin: { Args: never; Returns: boolean }
       mark_opinions_extracted: {
@@ -1515,3 +1558,4 @@ export const Constants = {
     },
   },
 } as const
+

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,13 +25,13 @@ importers:
         version: 2.13.1
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.18.8)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.8.1)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.13.3)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.9.0)
 
   admin:
     dependencies:
       '@ai-sdk/react':
         specifier: ^3.0.3
-        version: 3.0.3(react@19.1.2)(zod@4.1.12)
+        version: 3.0.3(react@19.1.2)(zod@4.4.3)
       '@dnd-kit/core':
         specifier: ^6.3.1
         version: 6.3.1(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
@@ -55,7 +55,7 @@ importers:
         version: link:../packages/topic-analysis-core
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
-        version: 1.29.0(zod@4.1.12)
+        version: 1.29.0(zod@4.4.3)
       '@opentelemetry/sdk-node':
         specifier: ^0.206.0
         version: 0.206.0(@opentelemetry/api@1.9.0)
@@ -97,7 +97,7 @@ importers:
         version: 0.5.19(tailwindcss@4.1.14)
       ai:
         specifier: ^6.0.3
-        version: 6.0.3(zod@4.1.12)
+        version: 6.0.33(zod@4.4.3)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -109,13 +109,13 @@ importers:
         version: 9.15.1
       langfuse-vercel:
         specifier: ^3.38.5
-        version: 3.38.5(ai@6.0.3(zod@4.1.12))
+        version: 3.38.5(ai@6.0.33(zod@4.4.3))
       lucide-react:
         specifier: ^0.542.0
         version: 0.542.0(react@19.1.2)
       mcp-handler:
         specifier: ^1.1.0
-        version: 1.1.0(@modelcontextprotocol/sdk@1.29.0(zod@4.1.12))(next@15.5.9(@opentelemetry/api@1.9.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2))
+        version: 1.1.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(next@15.5.9(@opentelemetry/api@1.9.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2))
       next:
         specifier: 15.5.9
         version: 15.5.9(@opentelemetry/api@1.9.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
@@ -145,10 +145,10 @@ importers:
         version: 2.0.7(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
       tailwind-merge:
         specifier: ^3.3.1
-        version: 3.3.1
+        version: 3.5.0
       zod:
         specifier: ^4.1.12
-        version: 4.1.12
+        version: 4.4.3
     devDependencies:
       '@tailwindcss/postcss':
         specifier: ^4
@@ -208,10 +208,10 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.18.8)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.8.1)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.13.3)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.9.0)
       zod:
         specifier: ^4.1.12
-        version: 4.1.12
+        version: 4.4.3
 
   packages/supabase:
     dependencies:
@@ -239,7 +239,7 @@ importers:
         version: link:../supabase
       ai:
         specifier: ^6.0.3
-        version: 6.0.3(zod@4.1.12)
+        version: 6.0.33(zod@4.4.3)
       server-only:
         specifier: ^0.0.1
         version: 0.0.1
@@ -249,19 +249,19 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.18.8)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.8.1)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.13.3)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.9.0)
       zod:
         specifier: ^4.1.12
-        version: 4.1.12
+        version: 4.4.3
 
   web:
     dependencies:
       '@ai-sdk/openai':
         specifier: ^3.0.1
-        version: 3.0.1(zod@4.1.12)
+        version: 3.0.1(zod@4.4.3)
       '@ai-sdk/react':
         specifier: ^3.0.3
-        version: 3.0.3(react@19.1.2)(zod@4.1.12)
+        version: 3.0.3(react@19.1.2)(zod@4.4.3)
       '@mirai-gikai/shared':
         specifier: workspace:*
         version: link:../packages/shared
@@ -313,15 +313,18 @@ importers:
       '@radix-ui/react-use-controllable-state':
         specifier: ^1.2.2
         version: 1.2.2(@types/react@19.2.2)(react@19.1.2)
+      '@scalar/api-reference-react':
+        specifier: ^0.9.54
+        version: 0.9.54(nprogress@0.2.0)(react@19.1.2)(tailwindcss@4.1.14)(typescript@5.9.3)(zod@4.4.3)
       '@supabase/ssr':
         specifier: ^0.5.2
         version: 0.5.2(@supabase/supabase-js@2.74.0)
       '@vercel/speed-insights':
         specifier: ^1.2.0
-        version: 1.2.0(next@15.5.9(@opentelemetry/api@1.9.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2))(react@19.1.2)
+        version: 1.2.0(next@15.5.9(@opentelemetry/api@1.9.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2))(react@19.1.2)(vue@3.5.39(typescript@5.9.3))
       ai:
         specifier: ^6.0.3
-        version: 6.0.3(zod@4.1.12)
+        version: 6.0.33(zod@4.4.3)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -339,7 +342,7 @@ importers:
         version: 3.38.5
       langfuse-vercel:
         specifier: ^3.38.5
-        version: 3.38.5(ai@6.0.3(zod@4.1.12))
+        version: 3.38.5(ai@6.0.33(zod@4.4.3))
       lucide-react:
         specifier: ^0.542.0
         version: 0.542.0(react@19.1.2)
@@ -384,7 +387,7 @@ importers:
         version: 1.3.0(@types/react@19.2.2)(react@19.1.2)
       tailwind-merge:
         specifier: ^3.3.1
-        version: 3.3.1
+        version: 3.5.0
       tokenlens:
         specifier: ^1.2.1
         version: 1.3.1
@@ -393,13 +396,13 @@ importers:
         version: 11.0.5
       unist-util-visit:
         specifier: ^5.0.0
-        version: 5.0.0
+        version: 5.1.0
       use-stick-to-bottom:
         specifier: ^1.1.1
         version: 1.1.1(react@19.1.2)
       zod:
         specifier: ^4.1.12
-        version: 4.1.12
+        version: 4.4.3
     devDependencies:
       '@next/third-parties':
         specifier: ^15.5.5
@@ -457,7 +460,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.28)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.8.1)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.28)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.9.0)
 
   worker:
     dependencies:
@@ -466,7 +469,7 @@ importers:
         version: link:../packages/topic-analysis-core
       ai:
         specifier: ^6.0.3
-        version: 6.0.3(zod@4.1.12)
+        version: 6.0.33(zod@4.4.3)
       tsx:
         specifier: ^4.19.1
         version: 4.20.6
@@ -486,6 +489,12 @@ packages:
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
+  '@ai-sdk/gateway@3.0.13':
+    resolution: {integrity: sha512-g7nE4PFtngOZNZSy1lOPpkC+FAiHxqBJXqyRMEG7NUrEVZlz5goBdtHg1YgWRJIX776JTXAmbOI5JreAKVAsVA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/gateway@3.0.2':
     resolution: {integrity: sha512-giJEg9ob45htbu3iautK+2kvplY2JnTj7ir4wZzYSQWvqGatWfBBfDuNCU5wSJt9BCGjymM5ZS9ziD42JGCZBw==}
     engines: {node: '>=18'}
@@ -504,8 +513,18 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/provider-utils@4.0.5':
+    resolution: {integrity: sha512-Ow/X/SEkeExTTc1x+nYLB9ZHK2WUId8+9TlkamAx7Tl9vxU+cKzWx2dwjgMHeCN6twrgwkLrrtqckQeO4mxgVA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/provider@3.0.0':
     resolution: {integrity: sha512-m9ka3ptkPQbaHHZHqDXDF9C9B5/Mav0KTdky1k2HZ3/nrW2t1AgObxIVPyGDWQNS9FXT/FS6PIoSjpcP/No8rQ==}
+    engines: {node: '>=18'}
+
+  '@ai-sdk/provider@3.0.2':
+    resolution: {integrity: sha512-HrEmNt/BH/hkQ7zpi2o6N3k1ZR1QTb7z85WYhYygiTxOQuaml4CMtHCWRbric5WPU+RNsYI7r1EpyVQMKO1pYw==}
     engines: {node: '>=18'}
 
   '@ai-sdk/react@3.0.3':
@@ -513,6 +532,12 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       react: ^18 || ~19.0.1 || ~19.1.2 || ^19.2.1
+
+  '@ai-sdk/vue@3.0.33':
+    resolution: {integrity: sha512-czM9Js3a7f+Eo35gjEYEeJYUoPvMg5Dfi4bOLyDBghLqn0gaVg8yTmTaSuHCg+3K/+1xPjyXd4+2XcQIohWWiQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      vue: ^3.3.4
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -542,16 +567,16 @@ packages:
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-string-parser@7.27.1':
-    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-validator-identifier@7.28.5':
-    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/parser@7.29.0':
-    resolution: {integrity: sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==}
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -559,8 +584,8 @@ packages:
     resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/types@7.29.0':
-    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
 
   '@bcoe/v8-coverage@1.0.2':
@@ -645,6 +670,42 @@ packages:
 
   '@chevrotain/utils@11.0.3':
     resolution: {integrity: sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ==}
+
+  '@codemirror/autocomplete@6.20.3':
+    resolution: {integrity: sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==}
+
+  '@codemirror/commands@6.10.4':
+    resolution: {integrity: sha512-Ryk9y9T0FFVF0cUGhAknveAyUOl/A1qReTFi+qPKtOh2Z9F4AUBz3XOrYD4ZEgZirdugVzHvd/2/Wcwy5OliTg==}
+
+  '@codemirror/lang-css@6.3.1':
+    resolution: {integrity: sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==}
+
+  '@codemirror/lang-html@6.4.11':
+    resolution: {integrity: sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw==}
+
+  '@codemirror/lang-javascript@6.2.5':
+    resolution: {integrity: sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==}
+
+  '@codemirror/lang-json@6.0.2':
+    resolution: {integrity: sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ==}
+
+  '@codemirror/lang-xml@6.1.0':
+    resolution: {integrity: sha512-3z0blhicHLfwi2UgkZYRPioSgVTo9PV5GP5ducFH6FaHy0IAJRg+ixj5gTR1gnT/glAIC8xv4w2VL1LoZfs+Jg==}
+
+  '@codemirror/lang-yaml@6.1.3':
+    resolution: {integrity: sha512-AZ8DJBuXGVHybpBQhmZtgew5//4hv3tdkXnr3vDmOUMJRuB6vn/uuwtmTOTlqEaQFg3hQSVeA90NmvIQyUV6FQ==}
+
+  '@codemirror/language@6.12.4':
+    resolution: {integrity: sha512-1q4PaT+o6PbgpkJt4Q8Fv5XJxTy4FUZ4MWETtyiDw3J0Pyr9E2vqcKL+k9wcvjNTIsauxvE7OfmWj3FRPHQ76A==}
+
+  '@codemirror/lint@6.9.7':
+    resolution: {integrity: sha512-28/+iWLYxKxsvGYhSYL7zaCZqLz5+FFFDq9tVsvGv9kv8RY4fFAchJ5WX9M3YrrRlTIsECjsXPqeNgnSmNP2dg==}
+
+  '@codemirror/state@6.7.1':
+    resolution: {integrity: sha512-9QzNDgE4EYDnAHfrTlR2lwiPciiOymLtwKK+8yHQzCc7GXhAP9xdEbEJFy2IWB1j9UGUl9BsgMmTo/ImA02T7A==}
+
+  '@codemirror/view@6.43.6':
+    resolution: {integrity: sha512-EVunGSYN1wz1p75WY1s3Xg7t3i8Yol0kGZGizNdX9BUFgMFILYVe8/u6EVpo7Ff5PwbZuILb4QAq7IZoKzIEQA==}
 
   '@csstools/color-helpers@6.0.2':
     resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
@@ -1038,6 +1099,9 @@ packages:
   '@floating-ui/utils@0.2.10':
     resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
 
+  '@floating-ui/vue@1.1.9':
+    resolution: {integrity: sha512-BfNqNW6KA83Nexspgb9DZuz578R7HT8MZw1CfK9I6Ah4QReNWEJsXWHN+SdmOVLNGmTPDi+fDT535Df5PzMLbQ==}
+
   '@grpc/grpc-js@1.14.0':
     resolution: {integrity: sha512-N8Jx6PaYzcTRNzirReJCtADVoq4z7+1KQ4E70jTg/koQiMoUSN1kbNjPOqpPbhMFhfU1/l7ixspPl8dNY+FoUg==}
     engines: {node: '>=12.10.0'}
@@ -1046,6 +1110,18 @@ packages:
     resolution: {integrity: sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==}
     engines: {node: '>=6'}
     hasBin: true
+
+  '@headlessui/tailwindcss@0.2.2':
+    resolution: {integrity: sha512-xNe42KjdyA4kfUKLLPGzME9zkH7Q3rOZ5huFihWNWOQFxnItxPB3/67yBI8/qBfY8nwBRx5GHn4VprsoluVMGw==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      tailwindcss: ^3.0 || ^4.0
+
+  '@headlessui/vue@1.7.23':
+    resolution: {integrity: sha512-JzdCNqurrtuu0YW6QaDtR2PIYCKPUWq28csDyMvN4zmGccmE7lz40Is6hc3LA4HFeCI7sekZ/PQMTNmn9I/4Wg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      vue: ^3.2.0
 
   '@hono/node-server@1.19.14':
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
@@ -1204,6 +1280,12 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@internationalized/date@3.12.2':
+    resolution: {integrity: sha512-FY1Y+H64NDs+HAF6omlnWxm3mEpfgaCSWtL5l551ZZfImA+kGjPFgrnJrGjH6lfmLL0g8Z/mBu1R3kufeCp6Jw==}
+
+  '@internationalized/number@3.6.7':
+    resolution: {integrity: sha512-3ji1fcrT+FPAK86UqEhB/psHixYo6niWPJtt7+qRaYFynt/BaJG8GhAPimtWUpEiVSTq8ZM8L5psMxGquiB/Vg==}
+
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
@@ -1234,6 +1316,36 @@ packages:
 
   '@js-sdsl/ordered-map@4.4.2':
     resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
+
+  '@lezer/common@1.5.2':
+    resolution: {integrity: sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==}
+
+  '@lezer/css@1.3.4':
+    resolution: {integrity: sha512-N+tn9tej2hPvyKgHEApMOQfHczDJCwxrRFS3SPn9QjYN+uwHvEDnCgKRrb3mxDYxRS8sKMM8fhC3+lc04Abz5Q==}
+
+  '@lezer/highlight@1.2.3':
+    resolution: {integrity: sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==}
+
+  '@lezer/html@1.3.13':
+    resolution: {integrity: sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==}
+
+  '@lezer/javascript@1.5.4':
+    resolution: {integrity: sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==}
+
+  '@lezer/json@1.0.3':
+    resolution: {integrity: sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ==}
+
+  '@lezer/lr@1.4.10':
+    resolution: {integrity: sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==}
+
+  '@lezer/xml@1.0.6':
+    resolution: {integrity: sha512-CdDwirL0OEaStFue/66ZmFSeppuL6Dwjlk8qk153mSQwiSH/Dlri4GNymrNWnUmPl2Um7QfV1FO9KFUyX3Twww==}
+
+  '@lezer/yaml@1.0.4':
+    resolution: {integrity: sha512-2lrrHqxalACEbxIbsjhqGpSW8kWpUKuY6RHgnSAFZa6qK62wvnPxA8hGOwOoDbwHcOFs5M4o27mjGu+P7TvBmw==}
+
+  '@marijn/find-cluster-break@1.0.3':
+    resolution: {integrity: sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA==}
 
   '@mermaid-js/parser@0.6.3':
     resolution: {integrity: sha512-lnjOhe7zyHjc+If7yT4zoedx2vo4sHaTmtkl1+or8BRTnCtDmcTpAjpzDSfCZrshM5bCoz0GyidzadJAH1xobA==}
@@ -1470,6 +1582,9 @@ packages:
   '@opentelemetry/semantic-conventions@1.37.0':
     resolution: {integrity: sha512-JD6DerIKdJGmRp4jQyX5FlrQjA4tjOw1cvfsPAZXfOOEErMUHjPcPSICS+6WnM0nB0efSFARh0KAZss+bvExOA==}
     engines: {node: '>=14'}
+
+  '@phosphor-icons/core@2.1.1':
+    resolution: {integrity: sha512-v4ARvrip4qBCImOE5rmPUylOEK4iiED9ZyKjcvzuezqMaiRASCHKcRIuvvxL/twvLpkfnEODCOJp5dM4eZilxQ==}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -2019,6 +2134,13 @@ packages:
     peerDependencies:
       '@redis/client': ^1.0.0
 
+  '@replit/codemirror-css-color-picker@6.3.0':
+    resolution: {integrity: sha512-19biDANghUm7Fz7L1SNMIhK48tagaWuCOHj4oPPxc7hxPGkTVY2lU/jVZ8tsbTKQPVG7BO2CBDzs7CBwb20t4A==}
+    peerDependencies:
+      '@codemirror/language': ^6.0.0
+      '@codemirror/state': ^6.0.0
+      '@codemirror/view': ^6.0.0
+
   '@rollup/rollup-android-arm-eabi@4.52.4':
     resolution: {integrity: sha512-BTm2qKNnWIQ5auf4deoetINJm2JzvihvGb9R6K/ETwKLql/Bb3Eg2H1FBp1gUb4YGbydMA3jcmQTR73q7J+GAA==}
     cpu: [arm]
@@ -2139,6 +2261,107 @@ packages:
     resolution: {integrity: sha512-bf9PtUa0u8IXDVxzRToFQKsNCRz9qLYfR/MpECxl4mRoWYjAeFjgxj1XdZr2M/GNVpT05p+LgQOHopYDlUu6/w==}
     cpu: [x64]
     os: [win32]
+
+  '@scalar/agent-chat@0.12.18':
+    resolution: {integrity: sha512-auIe3JYVm6jgoT7pa4Za+lrLFnEa3CDb4ncZA9aAYztti8C6qSFGn8nBrAtm/RarljhPTYZg5dhqeXJ7zyOu7w==}
+    engines: {node: '>=22'}
+
+  '@scalar/api-client@3.13.3':
+    resolution: {integrity: sha512-m+5/L71PTk474VGl7daD+7Ue2DeQA/BPsXoWJAXzDTtOR7orySlktZ9WiaI3CbZZkjiukaICaOb9AvMotDOmIQ==}
+    engines: {node: '>=22'}
+
+  '@scalar/api-reference-react@0.9.54':
+    resolution: {integrity: sha512-DE2a4+IPX/f4rzrXHFfMObNaXEm65JNiyHHDTk4wghetc37jA1Zxb1y/P1P/YURAjiLFNVnPdoqy2pJtZiZYFg==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+
+  '@scalar/api-reference@1.62.5':
+    resolution: {integrity: sha512-6VZhjtXiYygWrh6llwg/pnKN7S4eWqINOGt2Fu7TQkCdNUKwZEq7/XiOTqzZvGp/1Uu60ne/9nJK+UbQTSVpBg==}
+    engines: {node: '>=22'}
+
+  '@scalar/asyncapi-upgrader@0.1.2':
+    resolution: {integrity: sha512-h6NUhsctrhucrbO2XHWbTXp9EWt7eL5vvlsooUEw2bB014KSPd41JrBQ6t0h/dFdmhwxdbBI7Hmg9eZa/mlCXA==}
+    engines: {node: '>=22'}
+
+  '@scalar/blocks@0.1.4':
+    resolution: {integrity: sha512-L6fN2azd56pQK0VN7YTPpgKXGFlATOJmIdTFfr8+G74ZAhpNifGa/6jtNe9gsfwCYW5TYu+yhbGy62Jd8MLhSg==}
+    engines: {node: '>=22'}
+
+  '@scalar/code-highlight@0.4.1':
+    resolution: {integrity: sha512-pnr8gbQuvSXu4fcPPNkFNjAxxMWiJLffN57lRgVN3FCk+Q8hKHWWT01ulAT1/0Kg3/VmgtObrMHhX2qYnpM9+g==}
+    engines: {node: '>=22'}
+
+  '@scalar/components@0.27.6':
+    resolution: {integrity: sha512-jXTv2VgYn7/13yCAGKtc/26LCnrQSULGjcnP0LasJDqkVKDdRm1StHDG5iRniqrIzS21gJ6YcNGokksdLIrgQw==}
+    engines: {node: '>=22'}
+
+  '@scalar/helpers@0.9.0':
+    resolution: {integrity: sha512-M34CLRCttqC1bXthI/QSzQj0s5C6nrU2PFWf/vOT3RpycbiGDGQbqR+5RfFzpOIQvRqbHfNdcRbeiZBw+vCbkQ==}
+    engines: {node: '>=22'}
+
+  '@scalar/icons@0.7.3':
+    resolution: {integrity: sha512-5uSUvumj6yJEAZT7/MKpgrkNl76waDXUpu0kUBBFJ83GhZirBIK+Z9SktShEvJT0+rk/j9Zaer3BHoEhYwAEBQ==}
+    engines: {node: '>=22'}
+
+  '@scalar/json-magic@0.12.17':
+    resolution: {integrity: sha512-Vw2nrUDIjhvMP6vxFtkiiFlabJ6SyTtfn1BsOxgnr1hIB+/rkngMguiDzl5em21VjyfFGIoADia+QWKM2hdcdA==}
+    engines: {node: '>=22'}
+
+  '@scalar/oas-utils@0.19.4':
+    resolution: {integrity: sha512-ne/Pio9NaTQTjAeJ0B7OXWNIy4ziJmMoeKRzmEvXLXJC15iDI3vJZzQJOOldg5MPVEIqHxC0NWICrwKB6nMERA==}
+    engines: {node: '>=22'}
+
+  '@scalar/openapi-types@0.9.1':
+    resolution: {integrity: sha512-gkGhSkxSzADaBiNg+ZAbJuwj+ZUmzP2Pg9CWZ7ZP+0fck2WjPeDDM7aAbouAm0aQQMF9xBjSPXSA9a/qTHYaTw==}
+    engines: {node: '>=22'}
+
+  '@scalar/openapi-upgrader@0.2.9':
+    resolution: {integrity: sha512-D5b0rGLLZgmkO9mdW2j/ND1KBlH1u3RCpr87HPxv9P9ZSr6PtM5iLqFOJq0ACiaHjY2mikCrxgDmnUEhTzRpHQ==}
+    engines: {node: '>=22'}
+
+  '@scalar/schemas@0.7.2':
+    resolution: {integrity: sha512-6Ble6WcbiKgD3ypIva+wgZv1qIClmeEjXA6jrOo1bKpYUu6sh4e89LZxDK+LULa2jQl/2O5GEaa6aZ0ImlpkHg==}
+    engines: {node: '>=22'}
+
+  '@scalar/sidebar@0.9.29':
+    resolution: {integrity: sha512-Xyq7hnkeABWYLdQ0QhxuK7EpwBKkCItyTCidmX2j8xeKw1/b/RWE95co5P09GtkjHs1g+ePU/P919WaSn80+CA==}
+    engines: {node: '>=22'}
+
+  '@scalar/snippetz@0.9.21':
+    resolution: {integrity: sha512-0XFKdiKh5OnBxnK/NCBxaXpva53MRpvW4o6T2SMEUd+/xVa4Xmz7oHCHoq2g86+uY4bmepG1kZ0ndapyQjg/vw==}
+    engines: {node: '>=22'}
+
+  '@scalar/themes@0.16.2':
+    resolution: {integrity: sha512-4mAn7z2W5/ASi1OF06dqf04xjxTHnMzESC2E+qVMukJsEsV4kDlYSIfm/g5hwWxhqWsBMjorF9Dtlqd0ycJ92g==}
+    engines: {node: '>=22'}
+
+  '@scalar/typebox@0.1.3':
+    resolution: {integrity: sha512-lU055AUccECZMIfGA0z/C1StYmboAYIPJLDFBzOO81yXBi35Pxdq+I4fWX6iUZ8qcoHneiLGk9jAUM1rA93iEg==}
+
+  '@scalar/types@0.16.2':
+    resolution: {integrity: sha512-QAlCtDVRsX/UV1N9ctLqPsKQy84eceFf4dMnTZM0JhaRfwS/Ovwp8oFf3POSpqQILNiqLFZLE6IV6p/5rNoAag==}
+    engines: {node: '>=22'}
+
+  '@scalar/use-codemirror@0.14.12':
+    resolution: {integrity: sha512-m+0tmVOHZVAybbcNEizR3m9RYOLtU59AStRkk29J5qaW4J+tsjrz4BDMceeTpoVawL/lxp2vDvQR+w/gKC3miQ==}
+    engines: {node: '>=22'}
+
+  '@scalar/use-hooks@0.4.7':
+    resolution: {integrity: sha512-8zajxhnKMJuO1HF36y8TeVuSIol2pueYdRvITZTEY8TuRbnwxrvJZk25II7YpxGMORAEDr0bwNF88Dr+QUfw1w==}
+    engines: {node: '>=22'}
+
+  '@scalar/use-toasts@0.10.2':
+    resolution: {integrity: sha512-1iHQFbDXv0YQRp13aa63S5EcTJ5K8T0ocnLxk+nziloPrLjKt6jdRt6vOHsLSv5sm9kFKcVKNQTQgialmKCOGA==}
+    engines: {node: '>=22'}
+
+  '@scalar/validation@0.6.0':
+    resolution: {integrity: sha512-tpmmG+/xRE2Kn9RpflU3AIyZv08v10+E1ZrJCx7z6+/91zHVxy0M73kC1LT4/8PbYNt85ywyC8+n+D99JdMcGA==}
+    engines: {node: '>=20'}
+
+  '@scalar/workspace-store@0.55.3':
+    resolution: {integrity: sha512-qqSSq8OSxx582h/DSgMYH68iqzp+M8c9B+YGB7/qi5ZQK3TzazeCM1BVakkSbFYvD+X4FanV4V4x/aAhjv6MfQ==}
+    engines: {node: '>=22'}
 
   '@shikijs/core@3.13.0':
     resolution: {integrity: sha512-3P8rGsg2Eh2qIHekwuQjzWhKI4jV97PhvYjYUzGqjvJfqdQPz+nMlfWahU24GZAyW1FxFI1sYjyhfh5CoLmIUA==}
@@ -2293,6 +2516,14 @@ packages:
     resolution: {integrity: sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==}
     peerDependencies:
       tailwindcss: '>=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1'
+
+  '@tanstack/virtual-core@3.17.3':
+    resolution: {integrity: sha512-8Np/TFELpI0ySuJoVmjvOrQYXH/8sTX0Biv9szhFhY39xOdAAY+smrMxjxOum/ux3eM8MUJQsEJ0/R0UpvC8dw==}
+
+  '@tanstack/vue-virtual@3.13.31':
+    resolution: {integrity: sha512-wZMEoSf852jQqaf3Ika1J7PiBae6341LNy/2CxmIyn0XKDQXMuK41wVX+xp6G0yx8jyR95Ef+Tdr13DK7mbJtQ==}
+    peerDependencies:
+      vue: ^2.7.0 || ^3.0.0
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -2452,6 +2683,9 @@ packages:
   '@types/geojson@7946.0.16':
     resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
+  '@types/har-format@1.2.16':
+    resolution: {integrity: sha512-fluxdy7ryD3MV6h8pTfTYpy/xQzCFC7m89nOH9y94cNqJ1mDIDPut7MnRHI3F6qRmh/cT2fUjG1MLdCNb4hE9A==}
+
   '@types/hast@2.3.10':
     resolution: {integrity: sha512-McWspRw8xx8J9HurkVBfYj0xKoE25tOFlHGdx4MJ5xORQrMGZNqJhVQWaIbm6Oyla5kYOXtDiopzKRJzEOkwJw==}
 
@@ -2472,6 +2706,9 @@ packages:
 
   '@types/node@22.18.8':
     resolution: {integrity: sha512-pAZSHMiagDR7cARo/cch1f3rXy0AEXwsVsVH09FcyeJVAzCnGgmYis7P3JidtTUjyadhTeSo8TgRPswstghDaw==}
+
+  '@types/node@24.13.3':
+    resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
 
   '@types/phoenix@1.6.6':
     resolution: {integrity: sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==}
@@ -2496,14 +2733,30 @@ packages:
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
+  '@types/web-bluetooth@0.0.20':
+    resolution: {integrity: sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow==}
+
+  '@types/web-bluetooth@0.0.21':
+    resolution: {integrity: sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==}
+
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
+
+  '@unhead/vue@2.1.15':
+    resolution: {integrity: sha512-SSByXfEjhzPn8gXdEdgpYqpLMPSkLUH2HVE0GxZfOtNsJ0GgOHQs0g9T67ZZ1z0kTELLKdtOtYrzrbv9+ffF7g==}
+    peerDependencies:
+      vue: '>=3.5.18'
 
   '@vercel/oidc@3.0.5':
     resolution: {integrity: sha512-fnYhv671l+eTTp48gB4zEsTW/YtRgRPnkI2nT7x6qw5rkI1Lq2hTmQIpHPgyThI0znLK+vX2n9XxKdXZ7BUbbw==}
+    engines: {node: '>= 20'}
+
+  '@vercel/oidc@3.1.0':
+    resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
     engines: {node: '>= 20'}
 
   '@vercel/speed-insights@1.2.0':
@@ -2572,6 +2825,99 @@ packages:
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
+  '@vue/compiler-core@3.5.39':
+    resolution: {integrity: sha512-16KBTEXAJCpDr0mwlw+AZyhu8iyC7R3S2vBwsI7QnWJU6X3WKc9VKeNEZpiMdZ569qWhz9574L3vV55qRL0Vtw==}
+
+  '@vue/compiler-dom@3.5.39':
+    resolution: {integrity: sha512-oQPigALqYbNxTNPvNgSOe+czwVExfbVF02lz8jP0S3AXJiu3jxYDygNUiqSep4ezzW8XgnubqH63My2A7JR/vg==}
+
+  '@vue/compiler-sfc@3.5.39':
+    resolution: {integrity: sha512-d0ki86iOyN8LoZPBmk5SJWNwHP19CnDDCfuo//+2WJa2g5Ke0Jay983PIBIcSSzldC68I8DrD5GrHV3OSDfodg==}
+
+  '@vue/compiler-ssr@3.5.39':
+    resolution: {integrity: sha512-Ce7/wvwMHai74bdszfXExdazFigYnlF9zgCmEQUcM1j0fOymlouZ7XilTYNo8oUjhlnjYOZbGrcYKuqjz89Ucw==}
+
+  '@vue/reactivity@3.5.39':
+    resolution: {integrity: sha512-TpsuBJ9gGlZa5d23XcM2y8EXanz9dZeVDQBXRwzy46ItgvM+rWpzs+UVM0wcRLxGvcav0HE5jz2gNL53xlRAog==}
+
+  '@vue/runtime-core@3.5.39':
+    resolution: {integrity: sha512-9GLtNyRvPAUMbX+7ono0RC2j0guo2LXVi8LvcmAooImACUKm0oFf0jjwbX8/H0AE/t1nxhAkn8RSl9PMCzzxZw==}
+
+  '@vue/runtime-dom@3.5.39':
+    resolution: {integrity: sha512-7Y6aAGboKcXAZ3ECuUy7RrS5yy2r47dhTp2SKaJmYxjopImaVFaNa5Ne66NwGovsrxVAl5S5rwc7m22UG7Lmww==}
+
+  '@vue/server-renderer@3.5.39':
+    resolution: {integrity: sha512-yZSakiAGw85rZfG7UM8akMnIF+FmeiNk47uvHf2nVBBSe+dIKUhZuZq9+XgJhbV3nS5Z4ALH23/MpXofW+mbcw==}
+    peerDependencies:
+      vue: 3.5.39
+
+  '@vue/shared@3.5.39':
+    resolution: {integrity: sha512-l1rrBtBfTnmxvtsvdQDXltUUy8S1Y+ZaqdfUzmAnJkTd8Z8rv5v/ytW+TKiqEOWyHPoqtPlNFSs0lhRmYVSHVA==}
+
+  '@vueuse/core@10.11.1':
+    resolution: {integrity: sha512-guoy26JQktXPcz+0n3GukWIy/JDNKti9v6VEMu6kV2sYBsWuGiTU8OWdg+ADfUbHg3/3DlqySDe7JmdHrktiww==}
+
+  '@vueuse/core@13.9.0':
+    resolution: {integrity: sha512-ts3regBQyURfCE2BcytLqzm8+MmLlo5Ln/KLoxDVcsZ2gzIwVNnQpQOL/UKV8alUqjSZOlpFZcRNsLRqj+OzyA==}
+    peerDependencies:
+      vue: ^3.5.0
+
+  '@vueuse/integrations@13.9.0':
+    resolution: {integrity: sha512-SDobKBbPIOe0cVL7QxMzGkuUGHvWTdihi9zOrrWaWUgFKe15cwEcwfWmgrcNzjT6kHnNmWuTajPHoIzUjYNYYQ==}
+    peerDependencies:
+      async-validator: ^4
+      axios: ^1
+      change-case: ^5
+      drauu: ^0.4
+      focus-trap: ^7
+      fuse.js: ^7
+      idb-keyval: ^6
+      jwt-decode: ^4
+      nprogress: ^0.2
+      qrcode: ^1.5
+      sortablejs: ^1
+      universal-cookie: ^7 || ^8
+      vue: ^3.5.0
+    peerDependenciesMeta:
+      async-validator:
+        optional: true
+      axios:
+        optional: true
+      change-case:
+        optional: true
+      drauu:
+        optional: true
+      focus-trap:
+        optional: true
+      fuse.js:
+        optional: true
+      idb-keyval:
+        optional: true
+      jwt-decode:
+        optional: true
+      nprogress:
+        optional: true
+      qrcode:
+        optional: true
+      sortablejs:
+        optional: true
+      universal-cookie:
+        optional: true
+
+  '@vueuse/metadata@10.11.1':
+    resolution: {integrity: sha512-IGa5FXd003Ug1qAZmyE8wF3sJ81xGLSqTqtQ6jaVfkeZ4i5kS2mwQF61yhVqojRnenVew5PldLyRgvdl4YYuSw==}
+
+  '@vueuse/metadata@13.9.0':
+    resolution: {integrity: sha512-1AFRvuiGphfF7yWixZa0KwjYH8ulyjDCC0aFgrGRz8+P4kvDFSdXLVfTk5xAN9wEuD1J6z4/myMoYbnHoX07zg==}
+
+  '@vueuse/shared@10.11.1':
+    resolution: {integrity: sha512-LHpC8711VFZlDaYUXEBbFBCQ7GS3dVU9mjOhhMhXP6txTV4EhYQg/KGnQuvt/sPAtoUKq7VVUnL6mVtFoL42sA==}
+
+  '@vueuse/shared@13.9.0':
+    resolution: {integrity: sha512-e89uuTLMh0U5cZ9iDpEI2senqPGfbPRTHM/0AaQkcxnpqjkZqDYP8rpfm7edOz8s+pOCOROEy1PIveSW8+fL5g==}
+    peerDependencies:
+      vue: ^3.5.0
+
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
@@ -2592,6 +2938,12 @@ packages:
 
   ai@6.0.3:
     resolution: {integrity: sha512-OOo+/C+sEyscoLnbY3w42vjQDICioVNyS+F+ogwq6O5RJL/vgWGuiLzFwuP7oHTeni/MkmX8tIge48GTdaV7QQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  ai@6.0.33:
+    resolution: {integrity: sha512-bVokbmy2E2QF6Efl+5hOJx5MRWoacZ/CZY/y1E+VcewknvGlgaiCzMu8Xgddz6ArFJjiMFNUPHKxAhIePE4rmg==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -2820,6 +3172,10 @@ packages:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
 
+  convert-hrtime@5.0.0:
+    resolution: {integrity: sha512-lOETlkIeYSJWcbbcvjRKGxVMXJR+8+OQb/mTPbA4ObPMytYIsUbuOE0Jzy60hjARYszq1id0j8KgVhC+WGZVTg==}
+    engines: {node: '>=12'}
+
   cookie-signature@1.2.2:
     resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
     engines: {node: '>=6.6.0'}
@@ -2837,6 +3193,9 @@ packages:
 
   cose-base@2.2.0:
     resolution: {integrity: sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==}
+
+  crelt@1.0.7:
+    resolution: {integrity: sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -2858,11 +3217,19 @@ packages:
     resolution: {integrity: sha512-Ml4fP2UT2K3CUBQnVlbdV/8aFDdlY69E+YnwJM+3VUWl08S3J8c8aRuJqCkD9Py8DHZ7zNNvsfKl8psocHZEFg==}
     engines: {node: '>=20'}
 
-  csstype@3.1.3:
-    resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
   csv-parse@6.1.0:
     resolution: {integrity: sha512-CEE+jwpgLn+MmtCpVcPtiCZpVtB6Z2OKPTr34pycYYoL7sxdOkXDdQ4lRiw6ioC0q6BLqhc6cKweCVvral8yhw==}
+
+  cva@1.0.0-beta.4:
+    resolution: {integrity: sha512-F/JS9hScapq4DBVQXcK85l9U91M6ePeXoBMSp7vypzShoefUBxjQTo3g3935PUHgQd+IW77DjbPRIxugy4/GCQ==}
+    peerDependencies:
+      typescript: '>= 4.5.5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   cytoscape-cose-bilkent@4.1.0:
     resolution: {integrity: sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==}
@@ -3046,6 +3413,9 @@ packages:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
 
+  defu@6.1.7:
+    resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
+
   delaunator@5.0.1:
     resolution: {integrity: sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==}
 
@@ -3135,6 +3505,10 @@ packages:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
     engines: {node: '>=18'}
@@ -3177,6 +3551,9 @@ packages:
 
   estree-util-is-identifier-name@3.0.0:
     resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
+
+  estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
@@ -3253,8 +3630,11 @@ packages:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
 
-  flatted@3.3.3:
-    resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
+  flatted@3.4.2:
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
+
+  focus-trap@7.8.0:
+    resolution: {integrity: sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==}
 
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
@@ -3279,6 +3659,14 @@ packages:
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  function-timeout@1.0.2:
+    resolution: {integrity: sha512-939eZS4gJ3htTHAldmyyuzlrD58P03fHG49v2JfFXbV6OhvZKRC9j2yAtdHw/zrp2zXHuv05zMIy40F0ge7spA==}
+    engines: {node: '>=18'}
+
+  fuse.js@7.4.2:
+    resolution: {integrity: sha512-LVbzjD4WA6UP5B1UnP8wuaXJiLnqMdM/E4fiJXTJ5haJ5b/MBNsK29h2fm6swEoQaVQjvYFWKLE2RanyZIoRVQ==}
+    engines: {node: '>=10'}
 
   gaxios@6.7.1:
     resolution: {integrity: sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==}
@@ -3307,6 +3695,10 @@ packages:
   get-nonce@1.0.1:
     resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
     engines: {node: '>=6'}
+
+  get-own-enumerable-keys@1.0.0:
+    resolution: {integrity: sha512-PKsK2FSrQCyxcGHsGrLDcK0lx+0Ke+6e8KFFozA9/fIQLhQzPaRvJFdcz7+Axg3jUH/Mq+NI4xa5u/UT2tQskA==}
+    engines: {node: '>=14.16'}
 
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
@@ -3347,6 +3739,10 @@ packages:
     resolution: {integrity: sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==}
     engines: {node: '>=14.0.0'}
 
+  guess-json-indent@3.0.1:
+    resolution: {integrity: sha512-LWZ3Vr8BG7DHE3TzPYFqkhjNRw4vYgFSsv2nfMuHklAlOfiy54/EwiDQuQfFVLxENCVv20wpbjfTayooQHrEhQ==}
+    engines: {node: '>=18.18.0'}
+
   hachure-fill@0.5.2:
     resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
 
@@ -3368,6 +3764,12 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hast-util-embedded@3.0.0:
+    resolution: {integrity: sha512-naH8sld4Pe2ep03qqULEtvYr7EjrLK2QHY8KJR6RJkTUjPGObe1vnx585uzem2hGra+s1q08DZZpfgDVYRbaXA==}
+
+  hast-util-format@1.1.0:
+    resolution: {integrity: sha512-yY1UDz6bC9rDvCWHpx12aIBGRG7krurX0p0Fm6pT547LwDIZZiNr8a+IHDogorAdreULSEzP82Nlv5SZkHZcjA==}
+
   hast-util-from-dom@5.0.1:
     resolution: {integrity: sha512-N+LqofjR2zuzTjCPzyDUdSshy4Ma6li7p/c3pA78uTwzFgENbgbUrm2ugwsOdcjI1muO+o6Dgzp9p8WHtn/39Q==}
 
@@ -3380,14 +3782,26 @@ packages:
   hast-util-from-parse5@8.0.3:
     resolution: {integrity: sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==}
 
+  hast-util-has-property@3.0.0:
+    resolution: {integrity: sha512-MNilsvEKLFpV604hwfhVStK0usFY/QmM5zX16bo7EjnAEGofr5YyI37kzopBlZJkHD4t887i+q/C8/tr5Q94cA==}
+
+  hast-util-is-body-ok-link@3.0.1:
+    resolution: {integrity: sha512-0qpnzOBLztXHbHQenVB8uNuxTnm/QBFUOmdOSsEn7GnBtyY07+ENTWVFBAnXd/zEgd9/SUG3lRY7hSIBWRgGpQ==}
+
   hast-util-is-element@3.0.0:
     resolution: {integrity: sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==}
+
+  hast-util-minify-whitespace@1.0.1:
+    resolution: {integrity: sha512-L96fPOVpnclQE0xzdWb/D12VT5FabA7SnZOUMtL1DbXmYiHJMXZvFkIZfiMmTCNJHUeO2K9UYNXoVyfz+QHuOw==}
 
   hast-util-parse-selector@2.2.5:
     resolution: {integrity: sha512-7j6mrk/qqkSehsM92wQjdIgWM2/BW61u/53G6xmC8i1OmEdKLHbk419QKQUjz6LglWsfqoiHmyMRkP1BGjecNQ==}
 
   hast-util-parse-selector@4.0.0:
     resolution: {integrity: sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==}
+
+  hast-util-phrasing@3.0.1:
+    resolution: {integrity: sha512-6h60VfI3uBQUxHqTyMymMZnEbNl1XmEGtOxxKYL7stY2o601COo62AWAYBQR9lZbYXYSBoxag8UpPRXK+9fqSQ==}
 
   hast-util-raw@9.1.0:
     resolution: {integrity: sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==}
@@ -3419,12 +3833,19 @@ packages:
   highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
 
+  highlight.js@11.11.1:
+    resolution: {integrity: sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==}
+    engines: {node: '>=12.0.0'}
+
   highlightjs-vue@1.0.0:
     resolution: {integrity: sha512-PDEfEF102G23vHmPhLyPboFCD+BkMGu+GuJe2d9/eH4FsCwvgBpnc9n0pGE+ffKdph38s6foEZiEjdgHdzp+IA==}
 
   hono@4.12.12:
     resolution: {integrity: sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==}
     engines: {node: '>=16.9.0'}
+
+  hookable@6.1.1:
+    resolution: {integrity: sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==}
 
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
@@ -3438,6 +3859,9 @@ packages:
 
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
+
+  html-whitespace-sensitive-tag-names@3.0.1:
+    resolution: {integrity: sha512-q+310vW8zmymYHALr1da4HyXUQ0zgiIwIicEfotYPWGN0OJVEN/58IJ3A4GBYcEq3LGAZqKb+ugvP0GNB9CEAA==}
 
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
@@ -3462,6 +3886,10 @@ packages:
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
+
+  identifier-regex@1.1.0:
+    resolution: {integrity: sha512-SLX4H/vtcYlYnL7XqnuJKHU7Z8517TgsW9nmQiGOgMCjQ8V/deLYu6bEmbGoXe7WMMhc9+EUGyFFneHja8KabA==}
+    engines: {node: '>=18'}
 
   import-in-the-middle@1.14.4:
     resolution: {integrity: sha512-eWjxh735SJLFJJDs5X82JQ2405OdJeAHDBnaoFCfdr5GVc7AWc9xU7KbrF+3Xd5F2ccP1aQFKtY+65X6EfKZ7A==}
@@ -3490,6 +3918,10 @@ packages:
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
+
+  is-absolute-url@4.0.1:
+    resolution: {integrity: sha512-/51/TKE88Lmm7Gc4/8btclNXWS+g50wXhYJq8HWIBAGUBnoAdRu1aXeh364t/O7wXDAcTJDP8PNuNKWUDWie+A==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   is-alphabetical@1.0.4:
     resolution: {integrity: sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==}
@@ -3527,9 +3959,17 @@ packages:
   is-hexadecimal@2.0.1:
     resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
 
+  is-identifier@1.1.0:
+    resolution: {integrity: sha512-NhOds0mDx9lJu+1lBRO0xbwFo5nobA7GCk/0e5xjr6+6XugX985+0OyGX35BNrTkPAsdLcIKg02HUQJOK8D8kw==}
+    engines: {node: '>=18'}
+
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
+
+  is-obj@3.0.0:
+    resolution: {integrity: sha512-IlsXEHOjtKhpN8r/tRFj2nDyTmHvcfNeu/nrRIcXE17ROeatXchkojffa1SpdqW4cr/Fj6QkEf/Gn4zf6KKvEQ==}
+    engines: {node: '>=12'}
 
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
@@ -3540,6 +3980,10 @@ packages:
 
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
+  is-regexp@3.1.0:
+    resolution: {integrity: sha512-rbku49cWloU5bSMI+zaRaXdQHXnthP6DZ/vLnfdSKyL4zUzuWnomtOEiZZOd+ioQ+avFo/qau3KPTc7Fjy1uPA==}
+    engines: {node: '>=12'}
 
   is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
@@ -3578,6 +4022,9 @@ packages:
   jose@6.2.2:
     resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
 
+  js-base64@3.8.1:
+    resolution: {integrity: sha512-5xVjhUZlHHeuO2W7w2rDFj/Kl1xLX+HjZxdOQwCsUOifl6UaoH1o1wsbsTMz+r0aeC7gCijvru02j6TfKZWzKg==}
+
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
@@ -3607,6 +4054,9 @@ packages:
 
   json-schema@0.4.0:
     resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
+
+  jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
 
   jwa@2.0.1:
     resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
@@ -3759,6 +4209,9 @@ packages:
   lowlight@1.20.0:
     resolution: {integrity: sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==}
 
+  lowlight@3.3.0:
+    resolution: {integrity: sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==}
+
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
@@ -3775,11 +4228,15 @@ packages:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
 
-  magic-string@0.30.19:
-    resolution: {integrity: sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==}
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   magicast@0.3.5:
     resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
+
+  make-asynchronous@1.1.0:
+    resolution: {integrity: sha512-ayF7iT+44LXdxJLTrTd3TLQpFDDvPCBxXxbv+pMUSuHA5Q8zyAfwkRP6aHHwNVFBUFWtxAHqwNJxF8vMZLAbVg==}
+    engines: {node: '>=18'}
 
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
@@ -3874,6 +4331,9 @@ packages:
 
   mermaid@11.12.0:
     resolution: {integrity: sha512-ZudVx73BwrMJfCFmSSJT84y6u5brEoV8DOItdHomNLz32uBjNrelm7mg95X7g+C6UoQH/W6mBLGDEDv73JdxBg==}
+
+  microdiff@1.5.0:
+    resolution: {integrity: sha512-Drq+/THMvDdzRYrK0oxJmOKiC24ayUV8ahrt8l3oRK51PWt6gdtrIGrlIH3pT/lFh1z93FbAcidtsHcWbnRz8Q==}
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
@@ -4018,8 +4478,8 @@ packages:
     resolution: {integrity: sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==}
     hasBin: true
 
-  nanoid@3.3.11:
-    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+  nanoid@3.3.15:
+    resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -4031,6 +4491,9 @@ packages:
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
+
+  neverpanic@0.0.8:
+    resolution: {integrity: sha512-vVdkelrLxaow/fdWDumzNBO+jwm6X8bxeLJc34THtpj70u0C5QBkcV6CRCu2X726km7XD45N0A3QtYCla4RvKw==}
 
   next-themes@0.4.6:
     resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
@@ -4111,6 +4574,14 @@ packages:
   oniguruma-to-es@4.3.3:
     resolution: {integrity: sha512-rPiZhzC3wXwE59YQMRDodUwwT9FZ9nNBwQQfsd1wfdtlKEyCdRV0avrTcSZ5xlIvGRVPd/cx6ZN45ECmS39xvg==}
 
+  p-event@6.0.1:
+    resolution: {integrity: sha512-Q6Bekk5wpzW5qIyUP4gdMEujObYstZl6DMMOSenwBvV0BlE5LkDwkjs5yHbZmdCEq2o4RJx4tE1vwxFVf2FG1w==}
+    engines: {node: '>=16.17'}
+
+  p-timeout@6.1.4:
+    resolution: {integrity: sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==}
+    engines: {node: '>=14.16'}
+
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
@@ -4122,6 +4593,10 @@ packages:
 
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
+
+  parse-ms@4.0.0:
+    resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
+    engines: {node: '>=18'}
 
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
@@ -4198,13 +4673,17 @@ packages:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
     engines: {node: ^10 || ^12 || >=14}
 
-  postcss@8.5.6:
-    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
+  postcss@8.5.16:
+    resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
     engines: {node: ^10 || ^12 || >=14}
 
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
+  pretty-ms@9.3.0:
+    resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
+    engines: {node: '>=18'}
 
   prismjs@1.27.0:
     resolution: {integrity: sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==}
@@ -4244,6 +4723,11 @@ packages:
 
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
+
+  radix-vue@1.9.17:
+    resolution: {integrity: sha512-mVCu7I2vXt1L2IUYHTt0sZMz7s1K2ZtqKeTIxG3yC5mMFfLBG4FtE1FDeRMpDd+Hhg/ybi9+iXmAP1ISREndoQ==}
+    peerDependencies:
+      vue: '>= 3.2.0'
 
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
@@ -4340,11 +4824,20 @@ packages:
   regex@6.0.1:
     resolution: {integrity: sha512-uorlqlzAKjKQZ5P+kTJr3eeJGSVroLKoHmquUj4zHWuR+hEyNqlXsSKlYYF5F4NI6nl7tWCs0apKJ0lmfsXAPA==}
 
+  rehype-external-links@3.0.0:
+    resolution: {integrity: sha512-yp+e5N9V3C6bwBeAC4n796kc86M4gJCdlVhiMTxIrJG5UHDMh+PJANf9heqORJbt1nrCbDwIlAZKjANIaVBbvw==}
+
+  rehype-format@5.0.1:
+    resolution: {integrity: sha512-zvmVru9uB0josBVpr946OR8ui7nJEdzZobwLOOqHb/OOD88W0Vk2SqLwoVOj0fM6IPCCO6TaV9CvQvJMWwukFQ==}
+
   rehype-harden@1.1.2:
     resolution: {integrity: sha512-58RSgd3BAYW/hULy6qvrLBIRe8qe5PElwEpRjrLilvhJ3N+Y6ptKAmy1CLIIyoMz7CMI30GqENhNXksJd5hGDg==}
 
   rehype-katex@7.0.1:
     resolution: {integrity: sha512-OiM2wrZ/wuhKkigASodFoo8wimG3H12LWQaH8qSPVJn9apWKFSH3YOCtbKpBorTVw/eI7cuT21XBbvwEswbIOA==}
+
+  rehype-parse@9.0.1:
+    resolution: {integrity: sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==}
 
   rehype-raw@7.0.0:
     resolution: {integrity: sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==}
@@ -4384,6 +4877,10 @@ packages:
   require-in-the-middle@8.0.0:
     resolution: {integrity: sha512-9s0pnM5tH8G4dSI3pms2GboYOs25LwOGnRMxN/Hx3TYT1K0rh6OjaWf4dI0DAQnMyaEXWoGVnSTPQasqwzTTAA==}
     engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
+
+  reserved-identifiers@1.2.0:
+    resolution: {integrity: sha512-yE7KUfFvaBFzGPs5H3Ops1RevfUEsDc5Iz65rOwWg4lE8HJSYtle77uul3+573457oHvBKuHYDl/xqUkKpEEdw==}
+    engines: {node: '>=18'}
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
@@ -4441,6 +4938,9 @@ packages:
 
   server-only@0.0.1:
     resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
+
+  set-cookie-parser@3.1.0:
+    resolution: {integrity: sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==}
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
@@ -4525,9 +5025,6 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
-  std-env@3.9.0:
-    resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
-
   streamdown@1.3.0:
     resolution: {integrity: sha512-vFZdoWKUeagzKwGGOcEqkV1fcgXOJOQqrNBor5/hbaAE/e/ULxZoIHHJJd5KEuaSddCM9KuYtIuZi3WSttXTEA==}
     peerDependencies:
@@ -4536,6 +5033,14 @@ packages:
   string-argv@0.3.2:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
     engines: {node: '>=0.6.19'}
+
+  string-byte-length@3.0.1:
+    resolution: {integrity: sha512-yJ8vP0HMwZ54CcA8S8mKoXbkezpZHANFtmafFo8lGxZThCQcAwRHjdFabuSLgOzxj9OFJcmssmiAvmcOK4O2Hw==}
+    engines: {node: '>=18.18.0'}
+
+  string-byte-slice@3.0.1:
+    resolution: {integrity: sha512-GWv2K4lYyd2+AhmKH3BV+OVx62xDX+99rSLfKpaqFiQU7uOMaUY1tDjdrRD4gsrCr9lTyjMgjna7tZcCOw+Smg==}
+    engines: {node: '>=18.18.0'}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -4551,6 +5056,10 @@ packages:
 
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
+  stringify-object@6.0.0:
+    resolution: {integrity: sha512-6f94vIED6vmJJfh3lyVsVWxCYSfI5uM+16ntED/Ql37XIyV6kj0mRAAiTeMMc/QLYIaizC3bUprQ8pQnDDrKfA==}
+    engines: {node: '>=20'}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -4570,6 +5079,9 @@ packages:
 
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
+  style-mod@4.1.3:
+    resolution: {integrity: sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==}
 
   style-to-js@1.1.17:
     resolution: {integrity: sha512-xQcBGDxJb6jjFCTzvQtfiPn6YvvP2O8U1MDIPNfJQlWMYfktPy+iGsHE7cssjs7y84d9fQaK4UF3RIJaAHSoYA==}
@@ -4593,6 +5105,10 @@ packages:
   stylis@4.3.6:
     resolution: {integrity: sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==}
 
+  super-regex@1.1.0:
+    resolution: {integrity: sha512-WHkws2ZflZe41zj6AolvvmaTrWds/VuyeYr9iPVv/oQeaIoVxMKaushfFWpOGDT+GuBrM/sVqF8KUCYQlSSTdQ==}
+    engines: {node: '>=18'}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -4602,11 +5118,23 @@ packages:
     peerDependencies:
       react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  swrv@1.2.0:
+    resolution: {integrity: sha512-lH/g4UcNyj+7lzK4eRGT4C68Q4EhQ6JtM9otPRIASfhhzfLWtbZPHcMuhuba7S9YVYuxkMUGImwMyGpfbkH07A==}
+    peerDependencies:
+      vue: '>=3.2.26 < 4'
+
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
-  tailwind-merge@3.3.1:
-    resolution: {integrity: sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g==}
+  tabbable@6.5.0:
+    resolution: {integrity: sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==}
+
+  tagged-tag@1.0.0:
+    resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
+    engines: {node: '>=20'}
+
+  tailwind-merge@3.5.0:
+    resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
 
   tailwindcss@4.1.14:
     resolution: {integrity: sha512-b7pCxjGO98LnxVkKjaZSDeNuljC4ueKUddjENJOADtubtdo8llTaJy7HwBMeLNSSo2N5QIAgklslK1+Ir8r6CA==}
@@ -4630,6 +5158,10 @@ packages:
   throttleit@2.1.0:
     resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
     engines: {node: '>=18'}
+
+  time-span@5.1.0:
+    resolution: {integrity: sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==}
+    engines: {node: '>=12'}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -4695,6 +5227,10 @@ packages:
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
+  truncate-json@3.0.1:
+    resolution: {integrity: sha512-QVsbr1WhGLq2F0oDyYbqtOXcf3gcnL8C9H5EX8bBwAr8ZWvWGJzukpPrDrWgJMrNtgDbo74BIjI4kJu3q2xQWw==}
+    engines: {node: '>=18.18.0'}
+
   ts-dedent@2.2.0:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
     engines: {node: '>=6.10'}
@@ -4709,6 +5245,14 @@ packages:
 
   tw-animate-css@1.4.0:
     resolution: {integrity: sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==}
+
+  type-fest@4.41.0:
+    resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
+    engines: {node: '>=16'}
+
+  type-fest@5.8.0:
+    resolution: {integrity: sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==}
+    engines: {node: '>=20'}
 
   type-is@2.0.1:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
@@ -4725,9 +5269,15 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  undici-types@7.18.2:
+    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
   undici@7.22.0:
     resolution: {integrity: sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==}
     engines: {node: '>=20.18.1'}
+
+  unhead@2.1.15:
+    resolution: {integrity: sha512-MCt5T90mCWyr3Z6pUCdM9lVRXoMoVBlL7z7U4CYVIiaDiuzad/UCfLuMqz5MeNmpZUgoBCQnrucJimU7EZR+XA==}
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
@@ -4750,8 +5300,8 @@ packages:
   unist-util-visit-parents@6.0.1:
     resolution: {integrity: sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==}
 
-  unist-util-visit@5.0.0:
-    resolution: {integrity: sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==}
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -4905,12 +5455,43 @@ packages:
   vscode-uri@3.0.8:
     resolution: {integrity: sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==}
 
+  vue-component-type-helpers@3.3.7:
+    resolution: {integrity: sha512-Skkhw9agYSgsWqv7bxSOGJZa9SaiJbZVGdXuFWnrzKaQYHnw9qbjD630rw6RyMqDbp54nfLCLw5SZA55if7JLg==}
+
+  vue-demi@0.14.10:
+    resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
+    engines: {node: '>=12'}
+    hasBin: true
+    peerDependencies:
+      '@vue/composition-api': ^1.0.0-rc.1
+      vue: ^3.0.0-0 || ^2.6.0
+    peerDependenciesMeta:
+      '@vue/composition-api':
+        optional: true
+
+  vue-sonner@1.3.2:
+    resolution: {integrity: sha512-UbZ48E9VIya3ToiRHAZUbodKute/z/M1iT8/3fU8zEbwBRE11AKuHikssv18LMk2gTTr6eMQT4qf6JoLHWuj/A==}
+
+  vue@3.5.39:
+    resolution: {integrity: sha512-xmZCYabFGcirU8r0fTuvl/LICc1OU620rnqepaJDL/a141ZigkG7AyaxQLdqJ02ZRYzWe6YPaDHeQx7MfknQfA==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  w3c-keyname@2.2.8:
+    resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
+
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
 
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
+
+  web-worker@1.5.0:
+    resolution: {integrity: sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -4989,8 +5570,8 @@ packages:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
     engines: {node: '>=18'}
 
-  yaml@2.8.1:
-    resolution: {integrity: sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==}
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
     hasBin: true
 
@@ -5007,8 +5588,8 @@ packages:
     peerDependencies:
       zod: ^3.25.28 || ^4
 
-  zod@4.1.12:
-    resolution: {integrity: sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==}
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -5019,37 +5600,64 @@ snapshots:
 
   '@adobe/css-tools@4.4.4': {}
 
-  '@ai-sdk/gateway@3.0.2(zod@4.1.12)':
+  '@ai-sdk/gateway@3.0.13(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.2
+      '@ai-sdk/provider-utils': 4.0.5(zod@4.4.3)
+      '@vercel/oidc': 3.1.0
+      zod: 4.4.3
+
+  '@ai-sdk/gateway@3.0.2(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.0
-      '@ai-sdk/provider-utils': 4.0.1(zod@4.1.12)
+      '@ai-sdk/provider-utils': 4.0.1(zod@4.4.3)
       '@vercel/oidc': 3.0.5
-      zod: 4.1.12
+      zod: 4.4.3
 
-  '@ai-sdk/openai@3.0.1(zod@4.1.12)':
+  '@ai-sdk/openai@3.0.1(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.0
-      '@ai-sdk/provider-utils': 4.0.1(zod@4.1.12)
-      zod: 4.1.12
+      '@ai-sdk/provider-utils': 4.0.1(zod@4.4.3)
+      zod: 4.4.3
 
-  '@ai-sdk/provider-utils@4.0.1(zod@4.1.12)':
+  '@ai-sdk/provider-utils@4.0.1(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.0
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.0.6
-      zod: 4.1.12
+      zod: 4.4.3
+
+  '@ai-sdk/provider-utils@4.0.5(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.2
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.6
+      zod: 4.4.3
 
   '@ai-sdk/provider@3.0.0':
     dependencies:
       json-schema: 0.4.0
 
-  '@ai-sdk/react@3.0.3(react@19.1.2)(zod@4.1.12)':
+  '@ai-sdk/provider@3.0.2':
     dependencies:
-      '@ai-sdk/provider-utils': 4.0.1(zod@4.1.12)
-      ai: 6.0.3(zod@4.1.12)
+      json-schema: 0.4.0
+
+  '@ai-sdk/react@3.0.3(react@19.1.2)(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider-utils': 4.0.1(zod@4.4.3)
+      ai: 6.0.3(zod@4.4.3)
       react: 19.1.2
       swr: 2.3.6(react@19.1.2)
       throttleit: 2.1.0
+    transitivePeerDependencies:
+      - zod
+
+  '@ai-sdk/vue@3.0.33(vue@3.5.39(typescript@5.9.3))(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider-utils': 4.0.5(zod@4.4.3)
+      ai: 6.0.33(zod@4.4.3)
+      swrv: 1.2.0(vue@3.5.39(typescript@5.9.3))
+      vue: 3.5.39(typescript@5.9.3)
     transitivePeerDependencies:
       - zod
 
@@ -5087,24 +5695,24 @@ snapshots:
 
   '@babel/code-frame@7.29.0':
     dependencies:
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-validator-identifier': 7.29.7
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
-  '@babel/helper-string-parser@7.27.1': {}
+  '@babel/helper-string-parser@7.29.7': {}
 
-  '@babel/helper-validator-identifier@7.28.5': {}
+  '@babel/helper-validator-identifier@7.29.7': {}
 
-  '@babel/parser@7.29.0':
+  '@babel/parser@7.29.7':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@babel/runtime@7.28.4': {}
 
-  '@babel/types@7.29.0':
+  '@babel/types@7.29.7':
     dependencies:
-      '@babel/helper-string-parser': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
 
   '@bcoe/v8-coverage@1.0.2': {}
 
@@ -5165,6 +5773,100 @@ snapshots:
   '@chevrotain/types@11.0.3': {}
 
   '@chevrotain/utils@11.0.3': {}
+
+  '@codemirror/autocomplete@6.20.3':
+    dependencies:
+      '@codemirror/language': 6.12.4
+      '@codemirror/state': 6.7.1
+      '@codemirror/view': 6.43.6
+      '@lezer/common': 1.5.2
+
+  '@codemirror/commands@6.10.4':
+    dependencies:
+      '@codemirror/language': 6.12.4
+      '@codemirror/state': 6.7.1
+      '@codemirror/view': 6.43.6
+      '@lezer/common': 1.5.2
+
+  '@codemirror/lang-css@6.3.1':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/language': 6.12.4
+      '@codemirror/state': 6.7.1
+      '@lezer/common': 1.5.2
+      '@lezer/css': 1.3.4
+
+  '@codemirror/lang-html@6.4.11':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/lang-css': 6.3.1
+      '@codemirror/lang-javascript': 6.2.5
+      '@codemirror/language': 6.12.4
+      '@codemirror/state': 6.7.1
+      '@codemirror/view': 6.43.6
+      '@lezer/common': 1.5.2
+      '@lezer/css': 1.3.4
+      '@lezer/html': 1.3.13
+
+  '@codemirror/lang-javascript@6.2.5':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/language': 6.12.4
+      '@codemirror/lint': 6.9.7
+      '@codemirror/state': 6.7.1
+      '@codemirror/view': 6.43.6
+      '@lezer/common': 1.5.2
+      '@lezer/javascript': 1.5.4
+
+  '@codemirror/lang-json@6.0.2':
+    dependencies:
+      '@codemirror/language': 6.12.4
+      '@lezer/json': 1.0.3
+
+  '@codemirror/lang-xml@6.1.0':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/language': 6.12.4
+      '@codemirror/state': 6.7.1
+      '@codemirror/view': 6.43.6
+      '@lezer/common': 1.5.2
+      '@lezer/xml': 1.0.6
+
+  '@codemirror/lang-yaml@6.1.3':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/language': 6.12.4
+      '@codemirror/state': 6.7.1
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+      '@lezer/yaml': 1.0.4
+
+  '@codemirror/language@6.12.4':
+    dependencies:
+      '@codemirror/state': 6.7.1
+      '@codemirror/view': 6.43.6
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+      style-mod: 4.1.3
+
+  '@codemirror/lint@6.9.7':
+    dependencies:
+      '@codemirror/state': 6.7.1
+      '@codemirror/view': 6.43.6
+      crelt: 1.0.7
+
+  '@codemirror/state@6.7.1':
+    dependencies:
+      '@marijn/find-cluster-break': 1.0.3
+
+  '@codemirror/view@6.43.6':
+    dependencies:
+      '@codemirror/state': 6.7.1
+      crelt: 1.0.7
+      style-mod: 4.1.3
+      w3c-keyname: 2.2.8
 
   '@csstools/color-helpers@6.0.2': {}
 
@@ -5393,6 +6095,15 @@ snapshots:
 
   '@floating-ui/utils@0.2.10': {}
 
+  '@floating-ui/vue@1.1.9(vue@3.5.39(typescript@5.9.3))':
+    dependencies:
+      '@floating-ui/dom': 1.7.4
+      '@floating-ui/utils': 0.2.10
+      vue-demi: 0.14.10(vue@3.5.39(typescript@5.9.3))
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - vue
+
   '@grpc/grpc-js@1.14.0':
     dependencies:
       '@grpc/proto-loader': 0.8.0
@@ -5404,6 +6115,15 @@ snapshots:
       long: 5.3.2
       protobufjs: 7.5.4
       yargs: 17.7.2
+
+  '@headlessui/tailwindcss@0.2.2(tailwindcss@4.1.14)':
+    dependencies:
+      tailwindcss: 4.1.14
+
+  '@headlessui/vue@1.7.23(vue@3.5.39(typescript@5.9.3))':
+    dependencies:
+      '@tanstack/vue-virtual': 3.13.31(vue@3.5.39(typescript@5.9.3))
+      vue: 3.5.39(typescript@5.9.3)
 
   '@hono/node-server@1.19.14(hono@4.12.12)':
     dependencies:
@@ -5518,6 +6238,14 @@ snapshots:
   '@img/sharp-win32-x64@0.34.4':
     optional: true
 
+  '@internationalized/date@3.12.2':
+    dependencies:
+      '@swc/helpers': 0.5.15
+
+  '@internationalized/number@3.6.7':
+    dependencies:
+      '@swc/helpers': 0.5.15
+
   '@isaacs/cliui@8.0.2':
     dependencies:
       string-width: 5.1.2
@@ -5554,11 +6282,59 @@ snapshots:
 
   '@js-sdsl/ordered-map@4.4.2': {}
 
+  '@lezer/common@1.5.2': {}
+
+  '@lezer/css@1.3.4':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/highlight@1.2.3':
+    dependencies:
+      '@lezer/common': 1.5.2
+
+  '@lezer/html@1.3.13':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/javascript@1.5.4':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/json@1.0.3':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/lr@1.4.10':
+    dependencies:
+      '@lezer/common': 1.5.2
+
+  '@lezer/xml@1.0.6':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/yaml@1.0.4':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@marijn/find-cluster-break@1.0.3': {}
+
   '@mermaid-js/parser@0.6.3':
     dependencies:
       langium: 3.3.1
 
-  '@modelcontextprotocol/sdk@1.29.0(zod@4.1.12)':
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
       '@hono/node-server': 1.19.14(hono@4.12.12)
       ajv: 8.18.0
@@ -5575,8 +6351,8 @@ snapshots:
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
-      zod: 4.1.12
-      zod-to-json-schema: 3.25.2(zod@4.1.12)
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -5838,6 +6614,8 @@ snapshots:
       '@opentelemetry/sdk-trace-base': 2.1.0(@opentelemetry/api@1.9.0)
 
   '@opentelemetry/semantic-conventions@1.37.0': {}
+
+  '@phosphor-icons/core@2.1.1': {}
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -6394,6 +7172,12 @@ snapshots:
     dependencies:
       '@redis/client': 1.6.1
 
+  '@replit/codemirror-css-color-picker@6.3.0(@codemirror/language@6.12.4)(@codemirror/state@6.7.1)(@codemirror/view@6.43.6)':
+    dependencies:
+      '@codemirror/language': 6.12.4
+      '@codemirror/state': 6.7.1
+      '@codemirror/view': 6.43.6
+
   '@rollup/rollup-android-arm-eabi@4.52.4':
     optional: true
 
@@ -6459,6 +7243,355 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.52.4':
     optional: true
+
+  '@scalar/agent-chat@0.12.18(nprogress@0.2.0)(tailwindcss@4.1.14)(typescript@5.9.3)(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/vue': 3.0.33(vue@3.5.39(typescript@5.9.3))(zod@4.4.3)
+      '@scalar/api-client': 3.13.3(nprogress@0.2.0)(tailwindcss@4.1.14)(typescript@5.9.3)
+      '@scalar/components': 0.27.6(tailwindcss@4.1.14)(typescript@5.9.3)
+      '@scalar/helpers': 0.9.0
+      '@scalar/icons': 0.7.3(typescript@5.9.3)
+      '@scalar/json-magic': 0.12.17
+      '@scalar/openapi-types': 0.9.1
+      '@scalar/schemas': 0.7.2
+      '@scalar/themes': 0.16.2
+      '@scalar/types': 0.16.2
+      '@scalar/use-toasts': 0.10.2(typescript@5.9.3)
+      '@scalar/validation': 0.6.0
+      '@scalar/workspace-store': 0.55.3(typescript@5.9.3)
+      '@vueuse/core': 13.9.0(vue@3.5.39(typescript@5.9.3))
+      ai: 6.0.33(zod@4.4.3)
+      js-base64: 3.8.1
+      neverpanic: 0.0.8
+      truncate-json: 3.0.1
+      vue: 3.5.39(typescript@5.9.3)
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - async-validator
+      - axios
+      - change-case
+      - drauu
+      - idb-keyval
+      - jwt-decode
+      - nprogress
+      - qrcode
+      - sortablejs
+      - supports-color
+      - tailwindcss
+      - typescript
+      - universal-cookie
+      - zod
+
+  '@scalar/api-client@3.13.3(nprogress@0.2.0)(tailwindcss@4.1.14)(typescript@5.9.3)':
+    dependencies:
+      '@headlessui/tailwindcss': 0.2.2(tailwindcss@4.1.14)
+      '@headlessui/vue': 1.7.23(vue@3.5.39(typescript@5.9.3))
+      '@scalar/blocks': 0.1.4(tailwindcss@4.1.14)(typescript@5.9.3)
+      '@scalar/components': 0.27.6(tailwindcss@4.1.14)(typescript@5.9.3)
+      '@scalar/helpers': 0.9.0
+      '@scalar/icons': 0.7.3(typescript@5.9.3)
+      '@scalar/oas-utils': 0.19.4(typescript@5.9.3)
+      '@scalar/openapi-types': 0.9.1
+      '@scalar/sidebar': 0.9.29(tailwindcss@4.1.14)(typescript@5.9.3)
+      '@scalar/snippetz': 0.9.21
+      '@scalar/themes': 0.16.2
+      '@scalar/typebox': 0.1.3
+      '@scalar/types': 0.16.2
+      '@scalar/use-codemirror': 0.14.12(typescript@5.9.3)
+      '@scalar/use-hooks': 0.4.7(typescript@5.9.3)
+      '@scalar/use-toasts': 0.10.2(typescript@5.9.3)
+      '@scalar/workspace-store': 0.55.3(typescript@5.9.3)
+      '@vueuse/core': 13.9.0(vue@3.5.39(typescript@5.9.3))
+      '@vueuse/integrations': 13.9.0(focus-trap@7.8.0)(fuse.js@7.4.2)(nprogress@0.2.0)(vue@3.5.39(typescript@5.9.3))
+      focus-trap: 7.8.0
+      fuse.js: 7.4.2
+      js-base64: 3.8.1
+      jsonc-parser: 3.3.1
+      nanoid: 5.1.6
+      pretty-ms: 9.3.0
+      radix-vue: 1.9.17(vue@3.5.39(typescript@5.9.3))
+      set-cookie-parser: 3.1.0
+      vue: 3.5.39(typescript@5.9.3)
+      yaml: 2.9.0
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - async-validator
+      - axios
+      - change-case
+      - drauu
+      - idb-keyval
+      - jwt-decode
+      - nprogress
+      - qrcode
+      - sortablejs
+      - supports-color
+      - tailwindcss
+      - typescript
+      - universal-cookie
+
+  '@scalar/api-reference-react@0.9.54(nprogress@0.2.0)(react@19.1.2)(tailwindcss@4.1.14)(typescript@5.9.3)(zod@4.4.3)':
+    dependencies:
+      '@scalar/api-reference': 1.62.5(nprogress@0.2.0)(tailwindcss@4.1.14)(typescript@5.9.3)(zod@4.4.3)
+      '@scalar/types': 0.16.2
+      react: 19.1.2
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - async-validator
+      - axios
+      - change-case
+      - drauu
+      - idb-keyval
+      - jwt-decode
+      - nprogress
+      - qrcode
+      - sortablejs
+      - supports-color
+      - tailwindcss
+      - typescript
+      - universal-cookie
+      - zod
+
+  '@scalar/api-reference@1.62.5(nprogress@0.2.0)(tailwindcss@4.1.14)(typescript@5.9.3)(zod@4.4.3)':
+    dependencies:
+      '@headlessui/vue': 1.7.23(vue@3.5.39(typescript@5.9.3))
+      '@scalar/agent-chat': 0.12.18(nprogress@0.2.0)(tailwindcss@4.1.14)(typescript@5.9.3)(zod@4.4.3)
+      '@scalar/api-client': 3.13.3(nprogress@0.2.0)(tailwindcss@4.1.14)(typescript@5.9.3)
+      '@scalar/blocks': 0.1.4(tailwindcss@4.1.14)(typescript@5.9.3)
+      '@scalar/code-highlight': 0.4.1
+      '@scalar/components': 0.27.6(tailwindcss@4.1.14)(typescript@5.9.3)
+      '@scalar/helpers': 0.9.0
+      '@scalar/icons': 0.7.3(typescript@5.9.3)
+      '@scalar/oas-utils': 0.19.4(typescript@5.9.3)
+      '@scalar/schemas': 0.7.2
+      '@scalar/sidebar': 0.9.29(tailwindcss@4.1.14)(typescript@5.9.3)
+      '@scalar/snippetz': 0.9.21
+      '@scalar/themes': 0.16.2
+      '@scalar/types': 0.16.2
+      '@scalar/use-hooks': 0.4.7(typescript@5.9.3)
+      '@scalar/use-toasts': 0.10.2(typescript@5.9.3)
+      '@scalar/validation': 0.6.0
+      '@scalar/workspace-store': 0.55.3(typescript@5.9.3)
+      '@unhead/vue': 2.1.15(vue@3.5.39(typescript@5.9.3))
+      '@vueuse/core': 13.9.0(vue@3.5.39(typescript@5.9.3))
+      fuse.js: 7.4.2
+      microdiff: 1.5.0
+      nanoid: 5.1.6
+      vue: 3.5.39(typescript@5.9.3)
+      yaml: 2.9.0
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - async-validator
+      - axios
+      - change-case
+      - drauu
+      - idb-keyval
+      - jwt-decode
+      - nprogress
+      - qrcode
+      - sortablejs
+      - supports-color
+      - tailwindcss
+      - typescript
+      - universal-cookie
+      - zod
+
+  '@scalar/asyncapi-upgrader@0.1.2':
+    dependencies:
+      '@scalar/helpers': 0.9.0
+
+  '@scalar/blocks@0.1.4(tailwindcss@4.1.14)(typescript@5.9.3)':
+    dependencies:
+      '@scalar/components': 0.27.6(tailwindcss@4.1.14)(typescript@5.9.3)
+      '@scalar/helpers': 0.9.0
+      '@scalar/icons': 0.7.3(typescript@5.9.3)
+      '@scalar/snippetz': 0.9.21
+      '@scalar/themes': 0.16.2
+      '@scalar/types': 0.16.2
+      '@scalar/workspace-store': 0.55.3(typescript@5.9.3)
+      '@types/har-format': 1.2.16
+      js-base64: 3.8.1
+      vue: 3.5.39(typescript@5.9.3)
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - supports-color
+      - tailwindcss
+      - typescript
+
+  '@scalar/code-highlight@0.4.1':
+    dependencies:
+      hast-util-to-text: 4.0.2
+      highlight.js: 11.11.1
+      lowlight: 3.3.0
+      rehype-external-links: 3.0.0
+      rehype-format: 5.0.1
+      rehype-parse: 9.0.1
+      rehype-raw: 7.0.0
+      rehype-sanitize: 6.0.0
+      rehype-stringify: 10.0.1
+      remark-gfm: 4.0.1
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@scalar/components@0.27.6(tailwindcss@4.1.14)(typescript@5.9.3)':
+    dependencies:
+      '@floating-ui/utils': 0.2.10
+      '@floating-ui/vue': 1.1.9(vue@3.5.39(typescript@5.9.3))
+      '@headlessui/tailwindcss': 0.2.2(tailwindcss@4.1.14)
+      '@headlessui/vue': 1.7.23(vue@3.5.39(typescript@5.9.3))
+      '@scalar/code-highlight': 0.4.1
+      '@scalar/helpers': 0.9.0
+      '@scalar/icons': 0.7.3(typescript@5.9.3)
+      '@scalar/themes': 0.16.2
+      '@scalar/use-hooks': 0.4.7(typescript@5.9.3)
+      '@vueuse/core': 13.9.0(vue@3.5.39(typescript@5.9.3))
+      cva: 1.0.0-beta.4(typescript@5.9.3)
+      radix-vue: 1.9.17(vue@3.5.39(typescript@5.9.3))
+      vue: 3.5.39(typescript@5.9.3)
+      vue-component-type-helpers: 3.3.7
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - supports-color
+      - tailwindcss
+      - typescript
+
+  '@scalar/helpers@0.9.0': {}
+
+  '@scalar/icons@0.7.3(typescript@5.9.3)':
+    dependencies:
+      '@phosphor-icons/core': 2.1.1
+      '@types/node': 24.13.3
+      chalk: 5.6.2
+      vue: 3.5.39(typescript@5.9.3)
+    transitivePeerDependencies:
+      - typescript
+
+  '@scalar/json-magic@0.12.17':
+    dependencies:
+      '@scalar/helpers': 0.9.0
+      pathe: 2.0.3
+      yaml: 2.9.0
+
+  '@scalar/oas-utils@0.19.4(typescript@5.9.3)':
+    dependencies:
+      '@scalar/helpers': 0.9.0
+      '@scalar/themes': 0.16.2
+      '@scalar/types': 0.16.2
+      '@scalar/workspace-store': 0.55.3(typescript@5.9.3)
+      flatted: 3.4.2
+      vue: 3.5.39(typescript@5.9.3)
+      yaml: 2.9.0
+    transitivePeerDependencies:
+      - typescript
+
+  '@scalar/openapi-types@0.9.1': {}
+
+  '@scalar/openapi-upgrader@0.2.9':
+    dependencies:
+      '@scalar/openapi-types': 0.9.1
+
+  '@scalar/schemas@0.7.2':
+    dependencies:
+      '@scalar/helpers': 0.9.0
+      '@scalar/validation': 0.6.0
+
+  '@scalar/sidebar@0.9.29(tailwindcss@4.1.14)(typescript@5.9.3)':
+    dependencies:
+      '@scalar/components': 0.27.6(tailwindcss@4.1.14)(typescript@5.9.3)
+      '@scalar/helpers': 0.9.0
+      '@scalar/icons': 0.7.3(typescript@5.9.3)
+      '@scalar/themes': 0.16.2
+      '@scalar/use-hooks': 0.4.7(typescript@5.9.3)
+      '@scalar/workspace-store': 0.55.3(typescript@5.9.3)
+      vue: 3.5.39(typescript@5.9.3)
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - supports-color
+      - tailwindcss
+      - typescript
+
+  '@scalar/snippetz@0.9.21':
+    dependencies:
+      '@scalar/helpers': 0.9.0
+      '@scalar/types': 0.16.2
+      js-base64: 3.8.1
+      stringify-object: 6.0.0
+
+  '@scalar/themes@0.16.2':
+    dependencies:
+      nanoid: 5.1.6
+
+  '@scalar/typebox@0.1.3': {}
+
+  '@scalar/types@0.16.2':
+    dependencies:
+      '@scalar/helpers': 0.9.0
+      nanoid: 5.1.6
+      type-fest: 5.8.0
+      zod: 4.4.3
+
+  '@scalar/use-codemirror@0.14.12(typescript@5.9.3)':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/commands': 6.10.4
+      '@codemirror/lang-css': 6.3.1
+      '@codemirror/lang-html': 6.4.11
+      '@codemirror/lang-json': 6.0.2
+      '@codemirror/lang-xml': 6.1.0
+      '@codemirror/lang-yaml': 6.1.3
+      '@codemirror/language': 6.12.4
+      '@codemirror/lint': 6.9.7
+      '@codemirror/state': 6.7.1
+      '@codemirror/view': 6.43.6
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@replit/codemirror-css-color-picker': 6.3.0(@codemirror/language@6.12.4)(@codemirror/state@6.7.1)(@codemirror/view@6.43.6)
+      vue: 3.5.39(typescript@5.9.3)
+    transitivePeerDependencies:
+      - typescript
+
+  '@scalar/use-hooks@0.4.7(typescript@5.9.3)':
+    dependencies:
+      '@scalar/use-toasts': 0.10.2(typescript@5.9.3)
+      '@scalar/validation': 0.6.0
+      '@vueuse/core': 13.9.0(vue@3.5.39(typescript@5.9.3))
+      cva: 1.0.0-beta.4(typescript@5.9.3)
+      tailwind-merge: 3.5.0
+      vue: 3.5.39(typescript@5.9.3)
+    transitivePeerDependencies:
+      - typescript
+
+  '@scalar/use-toasts@0.10.2(typescript@5.9.3)':
+    dependencies:
+      vue: 3.5.39(typescript@5.9.3)
+      vue-sonner: 1.3.2
+    transitivePeerDependencies:
+      - typescript
+
+  '@scalar/validation@0.6.0': {}
+
+  '@scalar/workspace-store@0.55.3(typescript@5.9.3)':
+    dependencies:
+      '@scalar/asyncapi-upgrader': 0.1.2
+      '@scalar/helpers': 0.9.0
+      '@scalar/json-magic': 0.12.17
+      '@scalar/openapi-upgrader': 0.2.9
+      '@scalar/schemas': 0.7.2
+      '@scalar/snippetz': 0.9.21
+      '@scalar/typebox': 0.1.3
+      '@scalar/types': 0.16.2
+      '@scalar/validation': 0.6.0
+      js-base64: 3.8.1
+      type-fest: 5.8.0
+      vue: 3.5.39(typescript@5.9.3)
+      yaml: 2.9.0
+    transitivePeerDependencies:
+      - typescript
 
   '@shikijs/core@3.13.0':
     dependencies:
@@ -6555,7 +7688,7 @@ snapshots:
       enhanced-resolve: 5.18.3
       jiti: 2.6.1
       lightningcss: 1.30.1
-      magic-string: 0.30.19
+      magic-string: 0.30.21
       source-map-js: 1.2.1
       tailwindcss: 4.1.14
 
@@ -6618,13 +7751,20 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.1.14
       '@tailwindcss/oxide': 4.1.14
-      postcss: 8.5.6
+      postcss: 8.5.16
       tailwindcss: 4.1.14
 
   '@tailwindcss/typography@0.5.19(tailwindcss@4.1.14)':
     dependencies:
       postcss-selector-parser: 6.0.10
       tailwindcss: 4.1.14
+
+  '@tanstack/virtual-core@3.17.3': {}
+
+  '@tanstack/vue-virtual@3.13.31(vue@3.5.39(typescript@5.9.3))':
+    dependencies:
+      '@tanstack/virtual-core': 3.17.3
+      vue: 3.5.39(typescript@5.9.3)
 
   '@testing-library/dom@10.4.1':
     dependencies:
@@ -6814,6 +7954,8 @@ snapshots:
 
   '@types/geojson@7946.0.16': {}
 
+  '@types/har-format@1.2.16': {}
+
   '@types/hast@2.3.10':
     dependencies:
       '@types/unist': 2.0.11
@@ -6838,6 +7980,10 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/node@24.13.3':
+    dependencies:
+      undici-types: 7.18.2
+
   '@types/phoenix@1.6.6': {}
 
   '@types/react-dom@19.2.1(@types/react@19.2.2)':
@@ -6850,7 +7996,7 @@ snapshots:
 
   '@types/react@19.2.2':
     dependencies:
-      csstype: 3.1.3
+      csstype: 3.2.3
 
   '@types/trusted-types@2.0.7':
     optional: true
@@ -6859,18 +8005,31 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
+  '@types/web-bluetooth@0.0.20': {}
+
+  '@types/web-bluetooth@0.0.21': {}
+
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 22.18.8
 
   '@ungap/structured-clone@1.3.0': {}
 
+  '@unhead/vue@2.1.15(vue@3.5.39(typescript@5.9.3))':
+    dependencies:
+      hookable: 6.1.1
+      unhead: 2.1.15
+      vue: 3.5.39(typescript@5.9.3)
+
   '@vercel/oidc@3.0.5': {}
 
-  '@vercel/speed-insights@1.2.0(next@15.5.9(@opentelemetry/api@1.9.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2))(react@19.1.2)':
+  '@vercel/oidc@3.1.0': {}
+
+  '@vercel/speed-insights@1.2.0(next@15.5.9(@opentelemetry/api@1.9.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2))(react@19.1.2)(vue@3.5.39(typescript@5.9.3))':
     optionalDependencies:
       next: 15.5.9(@opentelemetry/api@1.9.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
       react: 19.1.2
+      vue: 3.5.39(typescript@5.9.3)
 
   '@vitest/coverage-v8@3.2.4(vitest@3.2.4)':
     dependencies:
@@ -6882,12 +8041,12 @@ snapshots:
       istanbul-lib-report: 3.0.1
       istanbul-lib-source-maps: 5.0.6
       istanbul-reports: 3.2.0
-      magic-string: 0.30.19
+      magic-string: 0.30.21
       magicast: 0.3.5
       std-env: 3.10.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.28)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.8.1)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.28)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -6899,13 +8058,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.8.1))':
+  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
-      magic-string: 0.30.19
+      magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.8.1)
+      vite: 7.3.1(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.9.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -6920,7 +8079,7 @@ snapshots:
   '@vitest/snapshot@3.2.4':
     dependencies:
       '@vitest/pretty-format': 3.2.4
-      magic-string: 0.30.19
+      magic-string: 0.30.21
       pathe: 2.0.3
 
   '@vitest/spy@3.2.4':
@@ -6931,18 +8090,114 @@ snapshots:
     dependencies:
       '@vitest/utils': 3.2.4
       fflate: 0.8.2
-      flatted: 3.3.3
+      flatted: 3.4.2
       pathe: 2.0.3
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.18.8)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.8.1)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.13.3)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.9.0)
 
   '@vitest/utils@3.2.4':
     dependencies:
       '@vitest/pretty-format': 3.2.4
       loupe: 3.2.1
       tinyrainbow: 2.0.0
+
+  '@vue/compiler-core@3.5.39':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@vue/shared': 3.5.39
+      entities: 7.0.1
+      estree-walker: 2.0.2
+      source-map-js: 1.2.1
+
+  '@vue/compiler-dom@3.5.39':
+    dependencies:
+      '@vue/compiler-core': 3.5.39
+      '@vue/shared': 3.5.39
+
+  '@vue/compiler-sfc@3.5.39':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@vue/compiler-core': 3.5.39
+      '@vue/compiler-dom': 3.5.39
+      '@vue/compiler-ssr': 3.5.39
+      '@vue/shared': 3.5.39
+      estree-walker: 2.0.2
+      magic-string: 0.30.21
+      postcss: 8.5.16
+      source-map-js: 1.2.1
+
+  '@vue/compiler-ssr@3.5.39':
+    dependencies:
+      '@vue/compiler-dom': 3.5.39
+      '@vue/shared': 3.5.39
+
+  '@vue/reactivity@3.5.39':
+    dependencies:
+      '@vue/shared': 3.5.39
+
+  '@vue/runtime-core@3.5.39':
+    dependencies:
+      '@vue/reactivity': 3.5.39
+      '@vue/shared': 3.5.39
+
+  '@vue/runtime-dom@3.5.39':
+    dependencies:
+      '@vue/reactivity': 3.5.39
+      '@vue/runtime-core': 3.5.39
+      '@vue/shared': 3.5.39
+      csstype: 3.2.3
+
+  '@vue/server-renderer@3.5.39(vue@3.5.39(typescript@5.9.3))':
+    dependencies:
+      '@vue/compiler-ssr': 3.5.39
+      '@vue/shared': 3.5.39
+      vue: 3.5.39(typescript@5.9.3)
+
+  '@vue/shared@3.5.39': {}
+
+  '@vueuse/core@10.11.1(vue@3.5.39(typescript@5.9.3))':
+    dependencies:
+      '@types/web-bluetooth': 0.0.20
+      '@vueuse/metadata': 10.11.1
+      '@vueuse/shared': 10.11.1(vue@3.5.39(typescript@5.9.3))
+      vue-demi: 0.14.10(vue@3.5.39(typescript@5.9.3))
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - vue
+
+  '@vueuse/core@13.9.0(vue@3.5.39(typescript@5.9.3))':
+    dependencies:
+      '@types/web-bluetooth': 0.0.21
+      '@vueuse/metadata': 13.9.0
+      '@vueuse/shared': 13.9.0(vue@3.5.39(typescript@5.9.3))
+      vue: 3.5.39(typescript@5.9.3)
+
+  '@vueuse/integrations@13.9.0(focus-trap@7.8.0)(fuse.js@7.4.2)(nprogress@0.2.0)(vue@3.5.39(typescript@5.9.3))':
+    dependencies:
+      '@vueuse/core': 13.9.0(vue@3.5.39(typescript@5.9.3))
+      '@vueuse/shared': 13.9.0(vue@3.5.39(typescript@5.9.3))
+      vue: 3.5.39(typescript@5.9.3)
+    optionalDependencies:
+      focus-trap: 7.8.0
+      fuse.js: 7.4.2
+      nprogress: 0.2.0
+
+  '@vueuse/metadata@10.11.1': {}
+
+  '@vueuse/metadata@13.9.0': {}
+
+  '@vueuse/shared@10.11.1(vue@3.5.39(typescript@5.9.3))':
+    dependencies:
+      vue-demi: 0.14.10(vue@3.5.39(typescript@5.9.3))
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - vue
+
+  '@vueuse/shared@13.9.0(vue@3.5.39(typescript@5.9.3))':
+    dependencies:
+      vue: 3.5.39(typescript@5.9.3)
 
   accepts@2.0.0:
     dependencies:
@@ -6957,13 +8212,21 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  ai@6.0.3(zod@4.1.12):
+  ai@6.0.3(zod@4.4.3):
     dependencies:
-      '@ai-sdk/gateway': 3.0.2(zod@4.1.12)
+      '@ai-sdk/gateway': 3.0.2(zod@4.4.3)
       '@ai-sdk/provider': 3.0.0
-      '@ai-sdk/provider-utils': 4.0.1(zod@4.1.12)
+      '@ai-sdk/provider-utils': 4.0.1(zod@4.4.3)
       '@opentelemetry/api': 1.9.0
-      zod: 4.1.12
+      zod: 4.4.3
+
+  ai@6.0.33(zod@4.4.3):
+    dependencies:
+      '@ai-sdk/gateway': 3.0.13(zod@4.4.3)
+      '@ai-sdk/provider': 3.0.2
+      '@ai-sdk/provider-utils': 4.0.5(zod@4.4.3)
+      '@opentelemetry/api': 1.9.0
+      zod: 4.4.3
 
   ajv-formats@3.0.1(ajv@8.18.0):
     optionalDependencies:
@@ -7161,6 +8424,8 @@ snapshots:
 
   content-type@1.0.5: {}
 
+  convert-hrtime@5.0.0: {}
+
   cookie-signature@1.2.2: {}
 
   cookie@0.7.2: {}
@@ -7177,6 +8442,8 @@ snapshots:
   cose-base@2.2.0:
     dependencies:
       layout-base: 2.0.1
+
+  crelt@1.0.7: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -7200,9 +8467,15 @@ snapshots:
       css-tree: 3.1.0
       lru-cache: 11.2.6
 
-  csstype@3.1.3: {}
+  csstype@3.2.3: {}
 
   csv-parse@6.1.0: {}
+
+  cva@1.0.0-beta.4(typescript@5.9.3):
+    dependencies:
+      clsx: 2.1.1
+    optionalDependencies:
+      typescript: 5.9.3
 
   cytoscape-cose-bilkent@4.1.0(cytoscape@3.33.1):
     dependencies:
@@ -7409,6 +8682,8 @@ snapshots:
 
   deep-eql@5.0.2: {}
 
+  defu@6.1.7: {}
+
   delaunator@5.0.1:
     dependencies:
       robust-predicates: 3.0.2
@@ -7484,6 +8759,8 @@ snapshots:
       tapable: 2.3.0
 
   entities@6.0.1: {}
+
+  entities@7.0.1: {}
 
   environment@1.1.0: {}
 
@@ -7562,6 +8839,8 @@ snapshots:
   escape-string-regexp@5.0.0: {}
 
   estree-util-is-identifier-name@3.0.0: {}
+
+  estree-walker@2.0.2: {}
 
   estree-walker@3.0.3:
     dependencies:
@@ -7666,7 +8945,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  flatted@3.3.3: {}
+  flatted@3.4.2: {}
+
+  focus-trap@7.8.0:
+    dependencies:
+      tabbable: 6.5.0
 
   foreground-child@3.3.1:
     dependencies:
@@ -7683,6 +8966,10 @@ snapshots:
     optional: true
 
   function-bind@1.1.2: {}
+
+  function-timeout@1.0.2: {}
+
+  fuse.js@7.4.2: {}
 
   gaxios@6.7.1:
     dependencies:
@@ -7724,6 +9011,8 @@ snapshots:
       math-intrinsics: 1.1.0
 
   get-nonce@1.0.1: {}
+
+  get-own-enumerable-keys@1.0.0: {}
 
   get-proto@1.0.1:
     dependencies:
@@ -7773,6 +9062,8 @@ snapshots:
       - encoding
       - supports-color
 
+  guess-json-indent@3.0.1: {}
+
   hachure-fill@0.5.2: {}
 
   harden-react-markdown@1.1.2(react-markdown@10.1.0(@types/react@19.2.2)(react@19.1.2))(react@19.1.2):
@@ -7788,6 +9079,21 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  hast-util-embedded@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-is-element: 3.0.0
+
+  hast-util-format@1.1.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-embedded: 3.0.0
+      hast-util-minify-whitespace: 1.0.1
+      hast-util-phrasing: 3.0.1
+      hast-util-whitespace: 3.0.0
+      html-whitespace-sensitive-tag-names: 3.0.1
+      unist-util-visit-parents: 6.0.1
 
   hast-util-from-dom@5.0.1:
     dependencies:
@@ -7822,15 +9128,39 @@ snapshots:
       vfile-location: 5.0.3
       web-namespaces: 2.0.1
 
+  hast-util-has-property@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  hast-util-is-body-ok-link@3.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+
   hast-util-is-element@3.0.0:
     dependencies:
       '@types/hast': 3.0.4
+
+  hast-util-minify-whitespace@1.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-embedded: 3.0.0
+      hast-util-is-element: 3.0.0
+      hast-util-whitespace: 3.0.0
+      unist-util-is: 6.0.0
 
   hast-util-parse-selector@2.2.5: {}
 
   hast-util-parse-selector@4.0.0:
     dependencies:
       '@types/hast': 3.0.4
+
+  hast-util-phrasing@3.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-embedded: 3.0.0
+      hast-util-has-property: 3.0.0
+      hast-util-is-body-ok-link: 3.0.1
+      hast-util-is-element: 3.0.0
 
   hast-util-raw@9.1.0:
     dependencies:
@@ -7843,7 +9173,7 @@ snapshots:
       mdast-util-to-hast: 13.2.1
       parse5: 7.3.0
       unist-util-position: 5.0.0
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
       vfile: 6.0.3
       web-namespaces: 2.0.1
       zwitch: 2.0.4
@@ -7927,9 +9257,13 @@ snapshots:
 
   highlight.js@10.7.3: {}
 
+  highlight.js@11.11.1: {}
+
   highlightjs-vue@1.0.0: {}
 
   hono@4.12.12: {}
+
+  hookable@6.1.1: {}
 
   html-encoding-sniffer@6.0.0:
     dependencies:
@@ -7942,6 +9276,8 @@ snapshots:
   html-url-attributes@3.0.1: {}
 
   html-void-elements@3.0.0: {}
+
+  html-whitespace-sensitive-tag-names@3.0.1: {}
 
   http-errors@2.0.1:
     dependencies:
@@ -7975,6 +9311,10 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  identifier-regex@1.1.0:
+    dependencies:
+      reserved-identifiers: 1.2.0
+
   import-in-the-middle@1.14.4:
     dependencies:
       acorn: 8.15.0
@@ -7995,6 +9335,8 @@ snapshots:
   ip-address@10.1.0: {}
 
   ipaddr.js@1.9.1: {}
+
+  is-absolute-url@4.0.1: {}
 
   is-alphabetical@1.0.4: {}
 
@@ -8026,13 +9368,22 @@ snapshots:
 
   is-hexadecimal@2.0.1: {}
 
+  is-identifier@1.1.0:
+    dependencies:
+      identifier-regex: 1.1.0
+      super-regex: 1.1.0
+
   is-number@7.0.0: {}
+
+  is-obj@3.0.0: {}
 
   is-plain-obj@4.1.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
 
   is-promise@4.0.0: {}
+
+  is-regexp@3.1.0: {}
 
   is-stream@2.0.1: {}
 
@@ -8070,6 +9421,8 @@ snapshots:
   jiti@2.6.1: {}
 
   jose@6.2.2: {}
+
+  js-base64@3.8.1: {}
 
   js-tokens@10.0.0: {}
 
@@ -8114,6 +9467,8 @@ snapshots:
 
   json-schema@0.4.0: {}
 
+  jsonc-parser@3.3.1: {}
+
   jwa@2.0.1:
     dependencies:
       buffer-equal-constant-time: 1.0.1
@@ -8137,9 +9492,9 @@ snapshots:
     dependencies:
       mustache: 4.2.0
 
-  langfuse-vercel@3.38.5(ai@6.0.3(zod@4.1.12)):
+  langfuse-vercel@3.38.5(ai@6.0.33(zod@4.4.3)):
     dependencies:
-      ai: 6.0.3(zod@4.1.12)
+      ai: 6.0.33(zod@4.4.3)
       langfuse: 3.38.5
       langfuse-core: 3.38.5
 
@@ -8217,7 +9572,7 @@ snapshots:
       micromatch: 4.0.8
       pidtree: 0.6.0
       string-argv: 0.3.2
-      yaml: 2.8.1
+      yaml: 2.9.0
     transitivePeerDependencies:
       - supports-color
 
@@ -8263,6 +9618,12 @@ snapshots:
       fault: 1.0.4
       highlight.js: 10.7.3
 
+  lowlight@3.3.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      devlop: 1.1.0
+      highlight.js: 11.11.1
+
   lru-cache@10.4.3: {}
 
   lru-cache@11.2.6: {}
@@ -8273,15 +9634,21 @@ snapshots:
 
   lz-string@1.5.0: {}
 
-  magic-string@0.30.19:
+  magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   magicast@0.3.5:
     dependencies:
-      '@babel/parser': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
       source-map-js: 1.2.1
+
+  make-asynchronous@1.1.0:
+    dependencies:
+      p-event: 6.0.1
+      type-fest: 4.41.0
+      web-worker: 1.5.0
 
   make-dir@4.0.0:
     dependencies:
@@ -8293,9 +9660,9 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
-  mcp-handler@1.1.0(@modelcontextprotocol/sdk@1.29.0(zod@4.1.12))(next@15.5.9(@opentelemetry/api@1.9.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)):
+  mcp-handler@1.1.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(next@15.5.9(@opentelemetry/api@1.9.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)):
     dependencies:
-      '@modelcontextprotocol/sdk': 1.29.0(zod@4.1.12)
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
       chalk: 5.6.2
       commander: 11.1.0
       redis: 4.7.1
@@ -8453,7 +9820,7 @@ snapshots:
       micromark-util-sanitize-uri: 2.0.1
       trim-lines: 3.0.1
       unist-util-position: 5.0.0
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
       vfile: 6.0.3
 
   mdast-util-to-markdown@2.1.2:
@@ -8465,7 +9832,7 @@ snapshots:
       mdast-util-to-string: 4.0.0
       micromark-util-classify-character: 2.0.1
       micromark-util-decode-string: 2.0.1
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
       zwitch: 2.0.4
 
   mdast-util-to-string@4.0.0:
@@ -8504,6 +9871,8 @@ snapshots:
       uuid: 11.1.0
     transitivePeerDependencies:
       - supports-color
+
+  microdiff@1.5.0: {}
 
   micromark-core-commonmark@2.0.3:
     dependencies:
@@ -8750,11 +10119,13 @@ snapshots:
 
   mustache@4.2.0: {}
 
-  nanoid@3.3.11: {}
+  nanoid@3.3.15: {}
 
   nanoid@5.1.6: {}
 
   negotiator@1.0.0: {}
+
+  neverpanic@0.0.8: {}
 
   next-themes@0.4.6(react-dom@19.1.2(react@19.1.2))(react@19.1.2):
     dependencies:
@@ -8831,6 +10202,12 @@ snapshots:
       regex: 6.0.1
       regex-recursion: 6.0.2
 
+  p-event@6.0.1:
+    dependencies:
+      p-timeout: 6.1.4
+
+  p-timeout@6.1.4: {}
+
   package-json-from-dist@1.0.1: {}
 
   package-manager-detector@1.4.0: {}
@@ -8853,6 +10230,8 @@ snapshots:
       is-alphanumerical: 2.0.1
       is-decimal: 2.0.1
       is-hexadecimal: 2.0.1
+
+  parse-ms@4.0.0: {}
 
   parse5@7.3.0:
     dependencies:
@@ -8917,13 +10296,13 @@ snapshots:
 
   postcss@8.4.31:
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.15
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  postcss@8.5.6:
+  postcss@8.5.16:
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.15
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -8932,6 +10311,10 @@ snapshots:
       ansi-regex: 5.0.1
       ansi-styles: 5.2.0
       react-is: 17.0.2
+
+  pretty-ms@9.3.0:
+    dependencies:
+      parse-ms: 4.0.0
 
   prismjs@1.27.0: {}
 
@@ -8979,6 +10362,23 @@ snapshots:
 
   quansync@0.2.11: {}
 
+  radix-vue@1.9.17(vue@3.5.39(typescript@5.9.3)):
+    dependencies:
+      '@floating-ui/dom': 1.7.4
+      '@floating-ui/vue': 1.1.9(vue@3.5.39(typescript@5.9.3))
+      '@internationalized/date': 3.12.2
+      '@internationalized/number': 3.6.7
+      '@tanstack/vue-virtual': 3.13.31(vue@3.5.39(typescript@5.9.3))
+      '@vueuse/core': 10.11.1(vue@3.5.39(typescript@5.9.3))
+      '@vueuse/shared': 10.11.1(vue@3.5.39(typescript@5.9.3))
+      aria-hidden: 1.2.6
+      defu: 6.1.7
+      fast-deep-equal: 3.1.3
+      nanoid: 5.1.6
+      vue: 3.5.39(typescript@5.9.3)
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+
   range-parser@1.2.1: {}
 
   raw-body@3.0.2:
@@ -9021,7 +10421,7 @@ snapshots:
       remark-parse: 11.0.0
       remark-rehype: 11.1.2
       unified: 11.0.5
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
       vfile: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -9095,6 +10495,20 @@ snapshots:
     dependencies:
       regex-utilities: 2.3.0
 
+  rehype-external-links@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@ungap/structured-clone': 1.3.0
+      hast-util-is-element: 3.0.0
+      is-absolute-url: 4.0.1
+      space-separated-tokens: 2.0.2
+      unist-util-visit: 5.1.0
+
+  rehype-format@5.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-format: 1.1.0
+
   rehype-harden@1.1.2: {}
 
   rehype-katex@7.0.1:
@@ -9106,6 +10520,12 @@ snapshots:
       katex: 0.16.23
       unist-util-visit-parents: 6.0.1
       vfile: 6.0.3
+
+  rehype-parse@9.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-from-html: 2.0.3
+      unified: 11.0.5
 
   rehype-raw@7.0.0:
     dependencies:
@@ -9183,6 +10603,8 @@ snapshots:
       module-details-from-path: 1.0.4
     transitivePeerDependencies:
       - supports-color
+
+  reserved-identifiers@1.2.0: {}
 
   resolve-pkg-maps@1.0.0: {}
 
@@ -9280,6 +10702,8 @@ snapshots:
       - supports-color
 
   server-only@0.0.1: {}
+
+  set-cookie-parser@3.1.0: {}
 
   setprototypeof@1.2.0: {}
 
@@ -9397,8 +10821,6 @@ snapshots:
 
   std-env@3.10.0: {}
 
-  std-env@3.9.0: {}
-
   streamdown@1.3.0(@types/react@19.2.2)(react@19.1.2):
     dependencies:
       clsx: 2.1.1
@@ -9414,12 +10836,16 @@ snapshots:
       remark-gfm: 4.0.1
       remark-math: 6.0.0
       shiki: 3.13.0
-      tailwind-merge: 3.3.1
+      tailwind-merge: 3.5.0
     transitivePeerDependencies:
       - '@types/react'
       - supports-color
 
   string-argv@0.3.2: {}
+
+  string-byte-length@3.0.1: {}
+
+  string-byte-slice@3.0.1: {}
 
   string-width@4.2.3:
     dependencies:
@@ -9444,6 +10870,13 @@ snapshots:
       character-entities-html4: 2.1.0
       character-entities-legacy: 3.0.0
 
+  stringify-object@6.0.0:
+    dependencies:
+      get-own-enumerable-keys: 1.0.0
+      is-identifier: 1.1.0
+      is-obj: 3.0.0
+      is-regexp: 3.1.0
+
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -9462,6 +10895,8 @@ snapshots:
     dependencies:
       js-tokens: 9.0.1
 
+  style-mod@4.1.3: {}
+
   style-to-js@1.1.17:
     dependencies:
       style-to-object: 1.0.9
@@ -9477,6 +10912,12 @@ snapshots:
 
   stylis@4.3.6: {}
 
+  super-regex@1.1.0:
+    dependencies:
+      function-timeout: 1.0.2
+      make-asynchronous: 1.1.0
+      time-span: 5.1.0
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -9487,9 +10928,17 @@ snapshots:
       react: 19.1.2
       use-sync-external-store: 1.6.0(react@19.1.2)
 
+  swrv@1.2.0(vue@3.5.39(typescript@5.9.3)):
+    dependencies:
+      vue: 3.5.39(typescript@5.9.3)
+
   symbol-tree@3.2.4: {}
 
-  tailwind-merge@3.3.1: {}
+  tabbable@6.5.0: {}
+
+  tagged-tag@1.0.0: {}
+
+  tailwind-merge@3.5.0: {}
 
   tailwindcss@4.1.14: {}
 
@@ -9512,6 +10961,10 @@ snapshots:
   third-party-capital@1.0.20: {}
 
   throttleit@2.1.0: {}
+
+  time-span@5.1.0:
+    dependencies:
+      convert-hrtime: 5.0.0
 
   tinybench@2.9.0: {}
 
@@ -9565,6 +11018,12 @@ snapshots:
 
   trough@2.2.0: {}
 
+  truncate-json@3.0.1:
+    dependencies:
+      guess-json-indent: 3.0.1
+      string-byte-length: 3.0.1
+      string-byte-slice: 3.0.1
+
   ts-dedent@2.2.0: {}
 
   tslib@2.8.1: {}
@@ -9578,6 +11037,12 @@ snapshots:
 
   tw-animate-css@1.4.0: {}
 
+  type-fest@4.41.0: {}
+
+  type-fest@5.8.0:
+    dependencies:
+      tagged-tag: 1.0.0
+
   type-is@2.0.1:
     dependencies:
       content-type: 1.0.5
@@ -9590,7 +11055,13 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  undici-types@7.18.2: {}
+
   undici@7.22.0: {}
+
+  unhead@2.1.15:
+    dependencies:
+      hookable: 6.1.1
 
   unified@11.0.5:
     dependencies:
@@ -9618,7 +11089,7 @@ snapshots:
   unist-util-remove-position@5.0.0:
     dependencies:
       '@types/unist': 3.0.3
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
 
   unist-util-stringify-position@4.0.0:
     dependencies:
@@ -9629,7 +11100,7 @@ snapshots:
       '@types/unist': 3.0.3
       unist-util-is: 6.0.0
 
-  unist-util-visit@5.0.0:
+  unist-util-visit@5.1.0:
     dependencies:
       '@types/unist': 3.0.3
       unist-util-is: 6.0.0
@@ -9683,13 +11154,13 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-node@3.2.4(@types/node@20.19.28)(jiti@2.6.1)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.8.1):
+  vite-node@3.2.4(@types/node@20.19.28)(jiti@2.6.1)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.9.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.1(@types/node@20.19.28)(jiti@2.6.1)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.8.1)
+      vite: 7.3.1(@types/node@20.19.28)(jiti@2.6.1)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -9704,13 +11175,13 @@ snapshots:
       - tsx
       - yaml
 
-  vite-node@3.2.4(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.8.1):
+  vite-node@3.2.4(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.9.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.1(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.8.1)
+      vite: 7.3.1(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -9725,12 +11196,12 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.3.1(@types/node@20.19.28)(jiti@2.6.1)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.8.1):
+  vite@7.3.1(@types/node@20.19.28)(jiti@2.6.1)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.2
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
-      postcss: 8.5.6
+      postcss: 8.5.16
       rollup: 4.52.4
       tinyglobby: 0.2.15
     optionalDependencies:
@@ -9739,29 +11210,29 @@ snapshots:
       jiti: 2.6.1
       lightningcss: 1.30.1
       tsx: 4.20.6
-      yaml: 2.8.1
+      yaml: 2.9.0
 
-  vite@7.3.1(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.8.1):
+  vite@7.3.1(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.2
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
-      postcss: 8.5.6
+      postcss: 8.5.16
       rollup: 4.52.4
       tinyglobby: 0.2.15
     optionalDependencies:
-      '@types/node': 22.18.8
+      '@types/node': 24.13.3
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.30.1
       tsx: 4.20.6
-      yaml: 2.8.1
+      yaml: 2.9.0
 
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.19.28)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.8.1):
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.19.28)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.9.0):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.8.1))
+      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.9.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -9770,17 +11241,17 @@ snapshots:
       chai: 5.3.3
       debug: 4.4.3
       expect-type: 1.2.2
-      magic-string: 0.30.19
+      magic-string: 0.30.21
       pathe: 2.0.3
       picomatch: 4.0.3
-      std-env: 3.9.0
+      std-env: 3.10.0
       tinybench: 2.9.0
       tinyexec: 0.3.2
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.1(@types/node@20.19.28)(jiti@2.6.1)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.8.1)
-      vite-node: 3.2.4(@types/node@20.19.28)(jiti@2.6.1)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.8.1)
+      vite: 7.3.1(@types/node@20.19.28)(jiti@2.6.1)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.9.0)
+      vite-node: 3.2.4(@types/node@20.19.28)(jiti@2.6.1)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12
@@ -9801,11 +11272,11 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.18.8)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.8.1):
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.13.3)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.9.0):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.8.1))
+      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.9.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -9814,21 +11285,21 @@ snapshots:
       chai: 5.3.3
       debug: 4.4.3
       expect-type: 1.2.2
-      magic-string: 0.30.19
+      magic-string: 0.30.21
       pathe: 2.0.3
       picomatch: 4.0.3
-      std-env: 3.9.0
+      std-env: 3.10.0
       tinybench: 2.9.0
       tinyexec: 0.3.2
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.1(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.8.1)
-      vite-node: 3.2.4(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.8.1)
+      vite: 7.3.1(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.9.0)
+      vite-node: 3.2.4(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12
-      '@types/node': 22.18.8
+      '@types/node': 24.13.3
       '@vitest/ui': 3.2.4(vitest@3.2.4)
       jsdom: 28.1.0
     transitivePeerDependencies:
@@ -9862,11 +11333,33 @@ snapshots:
 
   vscode-uri@3.0.8: {}
 
+  vue-component-type-helpers@3.3.7: {}
+
+  vue-demi@0.14.10(vue@3.5.39(typescript@5.9.3)):
+    dependencies:
+      vue: 3.5.39(typescript@5.9.3)
+
+  vue-sonner@1.3.2: {}
+
+  vue@3.5.39(typescript@5.9.3):
+    dependencies:
+      '@vue/compiler-dom': 3.5.39
+      '@vue/compiler-sfc': 3.5.39
+      '@vue/runtime-dom': 3.5.39
+      '@vue/server-renderer': 3.5.39(vue@3.5.39(typescript@5.9.3))
+      '@vue/shared': 3.5.39
+    optionalDependencies:
+      typescript: 5.9.3
+
+  w3c-keyname@2.2.8: {}
+
   w3c-xmlserializer@5.0.0:
     dependencies:
       xml-name-validator: 5.0.0
 
   web-namespaces@2.0.1: {}
+
+  web-worker@1.5.0: {}
 
   webidl-conversions@3.0.1: {}
 
@@ -9930,7 +11423,7 @@ snapshots:
 
   yallist@5.0.0: {}
 
-  yaml@2.8.1: {}
+  yaml@2.9.0: {}
 
   yargs-parser@21.1.1: {}
 
@@ -9944,10 +11437,10 @@ snapshots:
       y18n: 5.0.8
       yargs-parser: 21.1.1
 
-  zod-to-json-schema@3.25.2(zod@4.1.12):
+  zod-to-json-schema@3.25.2(zod@4.4.3):
     dependencies:
-      zod: 4.1.12
+      zod: 4.4.3
 
-  zod@4.1.12: {}
+  zod@4.4.3: {}
 
   zwitch@2.0.4: {}

--- a/supabase/migrations/20260714100000_add_open_data_api_functions.sql
+++ b/supabase/migrations/20260714100000_add_open_data_api_functions.sql
@@ -1,0 +1,138 @@
+-- 公開データ取得API（オープンデータ）用の基盤
+-- 1. api_rate_limits: 固定ウィンドウ方式のレートリミットカウンタ
+-- 2. increment_api_rate_limit(): カウンタを原子的に加算し、制限内かを返す
+-- 3. find_open_data_interview_reports(): 二次利用許諾済み公開レポートをキーセットページネーションで返す
+
+-- ── レートリミットカウンタ ──────────────────────────────
+CREATE TABLE api_rate_limits (
+  key TEXT NOT NULL,
+  window_start TIMESTAMPTZ NOT NULL,
+  request_count INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (key, window_start)
+);
+
+ALTER TABLE api_rate_limits ENABLE ROW LEVEL SECURITY;
+
+COMMENT ON TABLE api_rate_limits IS '公開APIのレートリミットカウンタ（固定ウィンドウ）。keyは "ip:<addr>" や "global" 等の制限単位';
+
+CREATE OR REPLACE FUNCTION increment_api_rate_limit(
+  p_key TEXT,
+  p_window_start TIMESTAMPTZ,
+  p_limit INTEGER
+) RETURNS BOOLEAN
+LANGUAGE plpgsql
+SET search_path = public
+AS $$
+DECLARE
+  v_count INTEGER;
+BEGIN
+  INSERT INTO api_rate_limits (key, window_start, request_count)
+  VALUES (p_key, p_window_start, 1)
+  ON CONFLICT (key, window_start)
+  DO UPDATE SET request_count = api_rate_limits.request_count + 1
+  RETURNING request_count INTO v_count;
+
+  -- 過去ウィンドウを掃除（テーブル肥大を防ぐ）。
+  -- 新しいウィンドウ行を作った最初の呼び出しのみ実行し、同一ウィンドウ内の
+  -- 残り N-1 回の呼び出しで無駄な索引スキャンを繰り返さない
+  IF v_count = 1 THEN
+    -- 同一キーの過去ウィンドウ
+    DELETE FROM api_rate_limits
+    WHERE key = p_key AND window_start < p_window_start;
+    -- 二度と現れないキー（IPローテーション等）の行が永久に残らないよう、
+    -- 全キー横断で1時間より古いウィンドウも併せて掃除する
+    DELETE FROM api_rate_limits
+    WHERE window_start < p_window_start - INTERVAL '1 hour';
+  END IF;
+
+  RETURN v_count <= p_limit;
+END;
+$$;
+
+-- 時間ベースの掃除（上記の全キー横断 DELETE）用
+CREATE INDEX idx_api_rate_limits_window_start
+  ON api_rate_limits (window_start);
+
+COMMENT ON FUNCTION increment_api_rate_limit(TEXT, TIMESTAMPTZ, INTEGER) IS
+  'レートリミットカウンタを加算し、制限内なら true を返す（超過時 false）。ウィンドウ開始時刻はアプリ側で切り捨て計算して渡す';
+
+-- ── 公開データ取得 ──────────────────────────────────────
+-- 対象: ユーザー公開同意 × 管理者公開 × 二次利用許諾（is_data_reuse_consented）
+--       かつ 公開済み議案、かつ web と同じ k-匿名性ゲート
+--       （議案あたり公開レポート数 >= p_min_public_reports）を満たすもの。
+-- 並び: created_at DESC, id DESC のキーセットページネーション。
+CREATE OR REPLACE FUNCTION find_open_data_interview_reports(
+  p_min_public_reports INTEGER,
+  p_limit INTEGER,
+  p_cursor_created_at TIMESTAMPTZ DEFAULT NULL,
+  p_cursor_id UUID DEFAULT NULL
+) RETURNS TABLE (
+  report_id UUID,
+  bill_id UUID,
+  bill_name TEXT,
+  stance TEXT,
+  role TEXT,
+  role_title TEXT,
+  role_description TEXT,
+  summary TEXT,
+  opinions JSONB,
+  interview_session_id UUID,
+  created_at TIMESTAMPTZ
+)
+LANGUAGE sql
+STABLE
+SET search_path = public
+AS $$
+  WITH eligible_bills AS (
+    SELECT c.bill_id
+    FROM interview_report r
+    JOIN interview_sessions s ON s.id = r.interview_session_id
+    JOIN interview_configs c ON c.id = s.interview_config_id
+    JOIN bills b ON b.id = c.bill_id
+    WHERE r.is_public_by_admin
+      AND r.is_public_by_user
+      AND b.publish_status = 'published'
+    GROUP BY c.bill_id
+    HAVING COUNT(*) >= p_min_public_reports
+  )
+  SELECT
+    r.id AS report_id,
+    c.bill_id,
+    b.name AS bill_name,
+    r.stance::TEXT,
+    r.role::TEXT,
+    r.role_title,
+    r.role_description,
+    r.summary,
+    r.opinions,
+    r.interview_session_id,
+    r.created_at
+  FROM interview_report r
+  JOIN interview_sessions s ON s.id = r.interview_session_id
+  JOIN interview_configs c ON c.id = s.interview_config_id
+  JOIN bills b ON b.id = c.bill_id
+  WHERE c.bill_id IN (SELECT eligible_bills.bill_id FROM eligible_bills)
+    AND r.is_public_by_admin
+    AND r.is_public_by_user
+    AND r.is_data_reuse_consented
+    AND (
+      p_cursor_created_at IS NULL
+      OR (r.created_at, r.id) < (p_cursor_created_at, p_cursor_id)
+    )
+  ORDER BY r.created_at DESC, r.id DESC
+  LIMIT p_limit;
+$$;
+
+COMMENT ON FUNCTION find_open_data_interview_reports(INTEGER, INTEGER, TIMESTAMPTZ, UUID) IS
+  '公開データAPI用: 二次利用許諾済みの公開レポートを新しい順に返す。議案あたり公開レポート数が閾値未満の議案は除外（webのk-匿名性ゲートと同一基準）';
+
+-- 公開データAPIのフィルタ用（is_data_reuse_consented での絞り込みを高速化）
+CREATE INDEX idx_interview_report_data_reuse_public
+  ON interview_report (created_at DESC, id DESC)
+  WHERE is_public_by_admin AND is_public_by_user AND is_data_reuse_consented;
+
+-- k-匿名性ゲート（eligible_bills CTE）の集計用。二次利用許諾を条件に含めない
+-- 公開レポート集計のため、上の部分インデックスでは代替できない
+CREATE INDEX idx_interview_report_public_session
+  ON interview_report (interview_session_id)
+  WHERE is_public_by_admin AND is_public_by_user;

--- a/tests/supabase/db-function/bulk-publish-reports.test.ts
+++ b/tests/supabase/db-function/bulk-publish-reports.test.ts
@@ -1,10 +1,10 @@
-import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   adminClient,
-  createTestUser,
+  cleanupTestBill,
   cleanupTestUser,
   createTestBill,
-  cleanupTestBill,
+  createTestUser,
   type TestUser,
 } from "../utils";
 

--- a/tests/supabase/db-function/count-sessions-by-config-ids.test.ts
+++ b/tests/supabase/db-function/count-sessions-by-config-ids.test.ts
@@ -1,10 +1,10 @@
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
   adminClient,
-  createTestBill,
-  createTestUser,
   cleanupTestBill,
   cleanupTestUser,
+  createTestBill,
+  createTestUser,
 } from "../utils";
 
 describe("count_sessions_by_config_ids", () => {

--- a/tests/supabase/db-function/find-open-data-interview-reports.test.ts
+++ b/tests/supabase/db-function/find-open-data-interview-reports.test.ts
@@ -1,0 +1,213 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  adminClient,
+  cleanupTestBill,
+  cleanupTestUser,
+  createTestBill,
+  createTestUser,
+  type TestUser,
+} from "../utils";
+
+async function createTestInterviewConfig(billId: string) {
+  const { data, error } = await adminClient
+    .from("interview_configs")
+    .insert({
+      bill_id: billId,
+      status: "public",
+      name: `テスト設定 ${Date.now()}`,
+    })
+    .select()
+    .single();
+  if (error) throw new Error(`interview_config 作成失敗: ${error.message}`);
+  return data;
+}
+
+async function createTestSession(configId: string, userId: string) {
+  const { data, error } = await adminClient
+    .from("interview_sessions")
+    .insert({
+      interview_config_id: configId,
+      user_id: userId,
+      started_at: new Date().toISOString(),
+    })
+    .select()
+    .single();
+  if (error) throw new Error(`interview_session 作成失敗: ${error.message}`);
+  return data;
+}
+
+async function createTestReport(
+  sessionId: string,
+  overrides: Partial<{
+    is_public_by_user: boolean;
+    is_public_by_admin: boolean;
+    is_data_reuse_consented: boolean;
+    summary: string;
+    opinions: unknown;
+    created_at: string;
+  }> = {}
+) {
+  const { data, error } = await adminClient
+    .from("interview_report")
+    .insert({
+      interview_session_id: sessionId,
+      ...overrides,
+    })
+    .select()
+    .single();
+  if (error) throw new Error(`interview_report 作成失敗: ${error.message}`);
+  return data;
+}
+
+async function findOpenData(params: {
+  minPublicReports?: number;
+  limit?: number;
+  cursorCreatedAt?: string;
+  cursorId?: string;
+}) {
+  const { data, error } = await adminClient.rpc(
+    "find_open_data_interview_reports",
+    {
+      p_min_public_reports: params.minPublicReports ?? 1,
+      p_limit: params.limit ?? 100,
+      ...(params.cursorCreatedAt
+        ? { p_cursor_created_at: params.cursorCreatedAt }
+        : {}),
+      ...(params.cursorId ? { p_cursor_id: params.cursorId } : {}),
+    }
+  );
+  if (error) {
+    throw new Error(`find_open_data_interview_reports 失敗: ${error.message}`);
+  }
+  return data ?? [];
+}
+
+describe("find_open_data_interview_reports", () => {
+  let testUser: TestUser;
+  const billIds: string[] = [];
+
+  beforeEach(async () => {
+    testUser = await createTestUser();
+  });
+
+  afterEach(async () => {
+    for (const billId of billIds) {
+      await cleanupTestBill(billId);
+    }
+    billIds.length = 0;
+    await cleanupTestUser(testUser.id);
+  });
+
+  it("公開×二次利用許諾のレポートのみ返し、許諾なし・非公開は除外する", async () => {
+    const bill = await createTestBill({ publish_status: "published" });
+    billIds.push(bill.id);
+    const config = await createTestInterviewConfig(bill.id);
+
+    const consented = await createTestSession(config.id, testUser.id);
+    await createTestReport(consented.id, {
+      is_public_by_user: true,
+      is_public_by_admin: true,
+      is_data_reuse_consented: true,
+      summary: "許諾あり",
+      opinions: [{ title: "意見", content: "本文" }],
+    });
+
+    const notConsented = await createTestSession(config.id, testUser.id);
+    await createTestReport(notConsented.id, {
+      is_public_by_user: true,
+      is_public_by_admin: true,
+      is_data_reuse_consented: false,
+      summary: "許諾なし",
+    });
+
+    const notPublic = await createTestSession(config.id, testUser.id);
+    await createTestReport(notPublic.id, {
+      is_public_by_user: false,
+      is_public_by_admin: true,
+      is_data_reuse_consented: true,
+      summary: "非公開",
+    });
+
+    const rows = await findOpenData({});
+    const summaries = rows.map((r) => r.summary);
+
+    expect(summaries).toContain("許諾あり");
+    expect(summaries).not.toContain("許諾なし");
+    expect(summaries).not.toContain("非公開");
+
+    const row = rows.find((r) => r.summary === "許諾あり");
+    expect(row?.bill_id).toBe(bill.id);
+    expect(row?.bill_name).toBe(bill.name);
+    expect(row?.opinions).toEqual([{ title: "意見", content: "本文" }]);
+  });
+
+  it("公開レポート数が閾値未満の議案は除外する（k-匿名性ゲート）", async () => {
+    const bill = await createTestBill({ publish_status: "published" });
+    billIds.push(bill.id);
+    const config = await createTestInterviewConfig(bill.id);
+
+    const session = await createTestSession(config.id, testUser.id);
+    await createTestReport(session.id, {
+      is_public_by_user: true,
+      is_public_by_admin: true,
+      is_data_reuse_consented: true,
+      summary: "ゲート対象",
+    });
+
+    const withThreshold2 = await findOpenData({ minPublicReports: 2 });
+    expect(withThreshold2.map((r) => r.summary)).not.toContain("ゲート対象");
+
+    const withThreshold1 = await findOpenData({ minPublicReports: 1 });
+    expect(withThreshold1.map((r) => r.summary)).toContain("ゲート対象");
+  });
+
+  it("非公開議案（draft）のレポートは除外する", async () => {
+    const bill = await createTestBill({ publish_status: "draft" });
+    billIds.push(bill.id);
+    const config = await createTestInterviewConfig(bill.id);
+
+    const session = await createTestSession(config.id, testUser.id);
+    await createTestReport(session.id, {
+      is_public_by_user: true,
+      is_public_by_admin: true,
+      is_data_reuse_consented: true,
+      summary: "非公開議案",
+    });
+
+    const rows = await findOpenData({});
+    expect(rows.map((r) => r.summary)).not.toContain("非公開議案");
+  });
+
+  it("新しい順に返り、カーソル以降のページを取得できる", async () => {
+    const bill = await createTestBill({ publish_status: "published" });
+    billIds.push(bill.id);
+    const config = await createTestInterviewConfig(bill.id);
+
+    const summaries = ["古い", "中間", "新しい"];
+    for (const [index, summary] of summaries.entries()) {
+      const session = await createTestSession(config.id, testUser.id);
+      await createTestReport(session.id, {
+        is_public_by_user: true,
+        is_public_by_admin: true,
+        is_data_reuse_consented: true,
+        summary,
+        created_at: `2026-07-0${index + 1}T00:00:00.000Z`,
+      });
+    }
+
+    // ローカルDBには他の条件合致データが存在し得るため、
+    // このテストの議案の行だけに絞って順序とカーソル動作を検証する
+    const allRows = await findOpenData({ limit: 1000 });
+    const ownRows = allRows.filter((r) => r.bill_id === bill.id);
+    expect(ownRows.map((r) => r.summary)).toEqual(["新しい", "中間", "古い"]);
+
+    const middle = ownRows[1];
+    const afterCursor = await findOpenData({
+      limit: 1000,
+      cursorCreatedAt: middle?.created_at,
+      cursorId: middle?.report_id,
+    });
+    const ownAfterCursor = afterCursor.filter((r) => r.bill_id === bill.id);
+    expect(ownAfterCursor.map((r) => r.summary)).toEqual(["古い"]);
+  });
+});

--- a/tests/supabase/db-function/find-sessions-ordered-by-message-count-filters.integration.test.ts
+++ b/tests/supabase/db-function/find-sessions-ordered-by-message-count-filters.integration.test.ts
@@ -1,11 +1,11 @@
-import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   adminClient,
-  createTestUser,
+  cleanupTestBill,
   cleanupTestUser,
   createTestBill,
   createTestInterviewMessages,
-  cleanupTestBill,
+  createTestUser,
   type TestUser,
 } from "../utils";
 

--- a/tests/supabase/db-function/find-sessions-ordered-by-message-count.test.ts
+++ b/tests/supabase/db-function/find-sessions-ordered-by-message-count.test.ts
@@ -1,11 +1,11 @@
-import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   adminClient,
-  createTestUser,
+  cleanupTestBill,
   cleanupTestUser,
   createTestBill,
   createTestInterviewMessages,
-  cleanupTestBill,
+  createTestUser,
   type TestUser,
 } from "../utils";
 

--- a/tests/supabase/db-function/find-sessions-ordered-by-total-content-richness.integration.test.ts
+++ b/tests/supabase/db-function/find-sessions-ordered-by-total-content-richness.integration.test.ts
@@ -1,10 +1,10 @@
-import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   adminClient,
-  createTestUser,
+  cleanupTestBill,
   cleanupTestUser,
   createTestBill,
-  cleanupTestBill,
+  createTestUser,
   type TestUser,
 } from "../utils";
 

--- a/tests/supabase/db-function/get-admin-users.test.ts
+++ b/tests/supabase/db-function/get-admin-users.test.ts
@@ -1,10 +1,10 @@
-import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   adminClient,
-  getAnonClient,
+  cleanupTestUser,
   createTestAdminUser,
   createTestUser,
-  cleanupTestUser,
+  getAnonClient,
   type TestUser,
 } from "../utils";
 

--- a/tests/supabase/db-function/get-interview-message-counts.test.ts
+++ b/tests/supabase/db-function/get-interview-message-counts.test.ts
@@ -1,11 +1,11 @@
-import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   adminClient,
-  createTestUser,
+  cleanupTestBill,
   cleanupTestUser,
   createTestInterviewData,
   createTestInterviewMessages,
-  cleanupTestBill,
+  createTestUser,
   type TestUser,
 } from "../utils";
 

--- a/tests/supabase/db-function/get-interview-statistics.test.ts
+++ b/tests/supabase/db-function/get-interview-statistics.test.ts
@@ -1,11 +1,11 @@
-import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   adminClient,
-  createTestUser,
+  cleanupTestBill,
   cleanupTestUser,
   createTestBill,
   createTestInterviewMessages,
-  cleanupTestBill,
+  createTestUser,
   type TestUser,
 } from "../utils";
 

--- a/tests/supabase/db-function/handle-google-workspace-admin-role.test.ts
+++ b/tests/supabase/db-function/handle-google-workspace-admin-role.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, afterEach } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { adminClient, cleanupTestUser } from "../utils";
 
 describe("apply_admin_role_if_eligible 関数", () => {

--- a/tests/supabase/db-function/increment-api-rate-limit.test.ts
+++ b/tests/supabase/db-function/increment-api-rate-limit.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { adminClient } from "../utils";
+
+const TEST_KEY_PREFIX = `test-rate-limit-${Date.now()}`;
+
+async function increment(key: string, windowStart: string, limit: number) {
+  const { data, error } = await adminClient.rpc("increment_api_rate_limit", {
+    p_key: key,
+    p_window_start: windowStart,
+    p_limit: limit,
+  });
+  if (error) throw new Error(`increment_api_rate_limit 失敗: ${error.message}`);
+  return data;
+}
+
+describe("increment_api_rate_limit", () => {
+  afterEach(async () => {
+    await adminClient
+      .from("api_rate_limits")
+      .delete()
+      .like("key", `${TEST_KEY_PREFIX}%`);
+  });
+
+  it("制限内は true、超過すると false を返す", async () => {
+    const key = `${TEST_KEY_PREFIX}-basic`;
+    const windowStart = "2026-07-14T12:00:00.000Z";
+
+    expect(await increment(key, windowStart, 3)).toBe(true);
+    expect(await increment(key, windowStart, 3)).toBe(true);
+    expect(await increment(key, windowStart, 3)).toBe(true);
+    expect(await increment(key, windowStart, 3)).toBe(false);
+  });
+
+  it("ウィンドウが変わるとカウントがリセットされ、過去ウィンドウの行は掃除される", async () => {
+    const key = `${TEST_KEY_PREFIX}-window`;
+    const window1 = "2026-07-14T12:00:00.000Z";
+    const window2 = "2026-07-14T12:01:00.000Z";
+
+    expect(await increment(key, window1, 1)).toBe(true);
+    expect(await increment(key, window1, 1)).toBe(false);
+
+    // 新しいウィンドウではリセットされて許可される
+    expect(await increment(key, window2, 1)).toBe(true);
+
+    // 過去ウィンドウの行は削除されている
+    const { data } = await adminClient
+      .from("api_rate_limits")
+      .select("window_start")
+      .eq("key", key);
+    expect(data).toHaveLength(1);
+    expect(new Date(data?.[0]?.window_start ?? "").toISOString()).toBe(window2);
+  });
+
+  it("1時間より古い他キーの行も、新規ウィンドウ作成時に掃除される", async () => {
+    const staleKey = `${TEST_KEY_PREFIX}-stale`;
+    const activeKey = `${TEST_KEY_PREFIX}-active`;
+
+    await increment(staleKey, "2026-07-14T10:00:00.000Z", 5);
+    // 12:00 の新規ウィンドウ作成時に、11:00 より古い全キーの行が掃除される
+    await increment(activeKey, "2026-07-14T12:00:00.000Z", 5);
+
+    const { data } = await adminClient
+      .from("api_rate_limits")
+      .select("key")
+      .eq("key", staleKey);
+    expect(data).toHaveLength(0);
+  });
+
+  it("キーが異なればカウントは独立している", async () => {
+    const windowStart = "2026-07-14T12:00:00.000Z";
+
+    expect(await increment(`${TEST_KEY_PREFIX}-a`, windowStart, 1)).toBe(true);
+    expect(await increment(`${TEST_KEY_PREFIX}-a`, windowStart, 1)).toBe(false);
+    expect(await increment(`${TEST_KEY_PREFIX}-b`, windowStart, 1)).toBe(true);
+  });
+});

--- a/tests/supabase/db-function/is-admin.test.ts
+++ b/tests/supabase/db-function/is-admin.test.ts
@@ -1,8 +1,8 @@
-import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  cleanupTestUser,
   createTestAdminUser,
   createTestUser,
-  cleanupTestUser,
   getAnonClient,
   getAuthenticatedClient,
   type TestUser,

--- a/tests/supabase/db-function/set-active-diet-session.test.ts
+++ b/tests/supabase/db-function/set-active-diet-session.test.ts
@@ -1,8 +1,8 @@
-import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   adminClient,
-  createTestDietSession,
   cleanupTestDietSession,
+  createTestDietSession,
 } from "../utils";
 
 describe("set_active_diet_session() 関数", () => {

--- a/tests/supabase/db-function/sum-chat-usage-cost.test.ts
+++ b/tests/supabase/db-function/sum-chat-usage-cost.test.ts
@@ -1,8 +1,8 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
   adminClient,
-  createTestUser,
   cleanupTestUser,
+  createTestUser,
   type TestUser,
 } from "../utils";
 

--- a/tests/supabase/db-function/unpublish-reports-by-config-id.test.ts
+++ b/tests/supabase/db-function/unpublish-reports-by-config-id.test.ts
@@ -1,10 +1,10 @@
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
   adminClient,
-  createTestBill,
-  createTestUser,
   cleanupTestBill,
   cleanupTestUser,
+  createTestBill,
+  createTestUser,
 } from "../utils";
 
 /**

--- a/tests/supabase/db-function/update-updated-at-column.test.ts
+++ b/tests/supabase/db-function/update-updated-at-column.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it, afterEach } from "vitest";
-import { adminClient, createTestBill, cleanupTestBill } from "../utils";
+import { afterEach, describe, expect, it } from "vitest";
+import { adminClient, cleanupTestBill, createTestBill } from "../utils";
 
 describe("update_updated_at_column トリガー", () => {
   let billId: string | undefined;

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -7,6 +7,14 @@ const nextConfig: NextConfig = {
     serverSourceMaps: true,
   },
   typedRoutes: true,
+  redirects: async () => [
+    {
+      // データ利用規約を /developers 配下へ移動した際の旧URL互換
+      source: "/interview-data-terms",
+      destination: "/developers/interview-data-terms",
+      permanent: true,
+    },
+  ],
   turbopack: {
     root: "../",
   },

--- a/web/package.json
+++ b/web/package.json
@@ -34,6 +34,7 @@
     "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@radix-ui/react-use-controllable-state": "^1.2.2",
+    "@scalar/api-reference-react": "^0.9.54",
     "@supabase/ssr": "^0.5.2",
     "@vercel/speed-insights": "^1.2.0",
     "ai": "^6.0.3",

--- a/web/public/openapi/open-data-api.json
+++ b/web/public/openapi/open-data-api.json
@@ -1,0 +1,243 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "みらい議会オープンデータAPI",
+    "version": "1.0.0",
+    "description": "みらい議会のAIインタビューを通じて取得した回答データのうち、回答者本人が公開に同意し、二次利用を許諾したものをオープンデータとして取得できるAPIです。\n\n- データはクリエイティブ・コモンズ 表示 4.0 国際ライセンス（CC BY 4.0）の下で提供されます\n- 利用には[みらい議会AIインタビューデータ利用規約](/developers/interview-data-terms)への同意が必要です。同意の表明として、すべてのリクエストに `agreeToTerms=true` を付与してください\n- APIキーの発行や事前登録は不要です。代わりにIP単位およびAPI全体のレートリミットがあります\n- 成果物には利用規約第4条に基づく出典表示（データ出典「みらい議会AIインタビュー（チームみらい）」・提供元URL・規約URL・CC BY 4.0ライセンス）を行ってください\n\n### 提供されるデータの範囲\n\n- 回答者本人が公開に同意し、二次利用（オープンデータとしての第三者提供）を許諾したインタビューのみ\n- 公開中の議案に紐づくもののみ\n- 議案あたりの公開レポート数が一定数以上ある議案のみ（少数回答の議案は回答者保護のため除外されます）\n\n回答者が公開設定を変更した場合、そのデータは以降のレスポンスに含まれなくなります（レスポンスはキャッシュされません）。",
+    "contact": {
+      "email": "support@team-mir.ai"
+    },
+    "license": {
+      "name": "CC BY 4.0（提供データのライセンス）",
+      "url": "https://creativecommons.org/licenses/by/4.0/deed.ja"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://gikai.team-mir.ai",
+      "description": "本番環境"
+    }
+  ],
+  "paths": {
+    "/api/open-data/interviews": {
+      "get": {
+        "summary": "インタビューデータの取得",
+        "description": "二次利用許諾済みの公開インタビューデータを新しい順に返します。`nextCursor` を次のリクエストの `cursor` に指定することで全件を取得できます。",
+        "operationId": "listOpenDataInterviews",
+        "parameters": [
+          {
+            "name": "agreeToTerms",
+            "in": "query",
+            "required": true,
+            "description": "みらい議会AIインタビューデータ利用規約への同意の表明。`true` を指定します。",
+            "schema": {
+              "type": "string",
+              "enum": ["true"]
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "1ページあたりの取得件数（1〜100）。",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 20
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "description": "ページネーション用カーソル。前のレスポンスの `nextCursor` をそのまま指定します。",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "取得成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpenDataInterviewsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "パラメータ不正（limit の範囲外・cursor の形式不正）",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+              }
+            }
+          },
+          "403": {
+            "description": "agreeToTerms=true が未指定",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    { "$ref": "#/components/schemas/ErrorResponse" },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "termsUrl": {
+                          "type": "string",
+                          "description": "データ利用規約のURL"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "レートリミット超過。`Retry-After` ヘッダで再試行までの秒数を案内します。",
+            "headers": {
+              "Retry-After": {
+                "description": "再試行までの秒数",
+                "schema": { "type": "integer" }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+              }
+            }
+          },
+          "500": {
+            "description": "サーバーエラー",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "OpenDataInterviewsResponse": {
+        "type": "object",
+        "required": ["items", "nextCursor", "license", "termsUrl"],
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/OpenDataInterviewItem" }
+          },
+          "nextCursor": {
+            "type": ["string", "null"],
+            "description": "次ページのカーソル。最終ページでは null。"
+          },
+          "license": {
+            "type": "string",
+            "const": "CC BY 4.0",
+            "description": "提供データのライセンス"
+          },
+          "termsUrl": {
+            "type": "string",
+            "description": "データ利用規約のURL"
+          }
+        }
+      },
+      "OpenDataInterviewItem": {
+        "type": "object",
+        "required": [
+          "reportId",
+          "billId",
+          "billName",
+          "opinions",
+          "messages",
+          "createdAt"
+        ],
+        "properties": {
+          "reportId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "インタビューレポートのID"
+          },
+          "billId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "議案のID"
+          },
+          "billName": {
+            "type": "string",
+            "description": "議案名"
+          },
+          "stance": {
+            "type": ["string", "null"],
+            "description": "議案への立場（for / against / neutral など）"
+          },
+          "role": {
+            "type": ["string", "null"],
+            "description": "回答者の立場の分類（daily_life_affected / work_related / subject_expert / general_citizen など）"
+          },
+          "roleTitle": {
+            "type": ["string", "null"],
+            "description": "回答者の立場の見出し"
+          },
+          "roleDescription": {
+            "type": ["string", "null"],
+            "description": "回答者の立場の説明"
+          },
+          "summary": {
+            "type": ["string", "null"],
+            "description": "意見の要約"
+          },
+          "opinions": {
+            "type": "array",
+            "description": "抽出された意見の一覧",
+            "items": {
+              "type": "object",
+              "required": ["title", "content"],
+              "properties": {
+                "title": { "type": "string", "description": "意見の見出し" },
+                "content": { "type": "string", "description": "意見の本文" }
+              }
+            }
+          },
+          "messages": {
+            "type": "array",
+            "description": "インタビューの対話ログ（時系列順）",
+            "items": {
+              "type": "object",
+              "required": ["role", "content"],
+              "properties": {
+                "role": {
+                  "type": "string",
+                  "enum": ["assistant", "user"],
+                  "description": "発話者（assistant: AI / user: 回答者）"
+                },
+                "content": { "type": "string", "description": "発話内容" }
+              }
+            }
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "回答日時（ISO 8601）"
+          }
+        }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "required": ["error"],
+        "properties": {
+          "error": {
+            "type": "string",
+            "description": "エラーメッセージ"
+          }
+        }
+      }
+    }
+  }
+}

--- a/web/src/app/(developers)/developers/open-data-api/page.tsx
+++ b/web/src/app/(developers)/developers/open-data-api/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+import { OpenDataApiReference } from "@/features/open-data/client/components/open-data-api-reference";
+
+export const metadata: Metadata = {
+  title: "オープンデータAPI | みらい議会",
+  description:
+    "みらい議会のAIインタビューデータをオープンデータとして取得できるAPIのリファレンスです。",
+};
+
+export default function OpenDataApiPage() {
+  return <OpenDataApiReference />;
+}

--- a/web/src/app/(developers)/layout.tsx
+++ b/web/src/app/(developers)/layout.tsx
@@ -1,0 +1,25 @@
+import { GoogleAnalytics } from "@next/third-parties/google";
+import type { ReactNode } from "react";
+import { Header } from "@/components/header";
+import { AuthGate } from "@/components/layouts/auth-gate";
+import { env } from "@/lib/env";
+
+/**
+ * 開発者向けのフル幅レイアウト。
+ * サイト標準の MainLayout はモバイルファーストの1カラム（max-w-700px）だが、
+ * APIリファレンス等のドキュメントは横幅を要するため制約なしで表示する。
+ */
+export default function DevelopersGroupLayout({
+  children,
+}: Readonly<{
+  children: ReactNode;
+}>) {
+  return (
+    <>
+      <GoogleAnalytics gaId={env.analytics.gaTrackingId ?? ""} />
+      <AuthGate />
+      <Header />
+      <main className="min-h-dvh bg-mirai-surface-light pt-24">{children}</main>
+    </>
+  );
+}

--- a/web/src/app/(main)/developers/interview-data-terms/page.tsx
+++ b/web/src/app/(main)/developers/interview-data-terms/page.tsx
@@ -88,7 +88,7 @@ export default function InterviewDataTermsPage() {
             items={[
               "データ出典：「みらい議会AIインタビュー（チームみらい）」",
               "データ提供元URL：https://gikai.team-mir.ai/",
-              "本規約のURL：https://gikai.team-mir.ai/interview-data-terms",
+              "本規約のURL：https://gikai.team-mir.ai/developers/interview-data-terms",
               {
                 id: "license",
                 content: (

--- a/web/src/app/(main)/developers/page.tsx
+++ b/web/src/app/(main)/developers/page.tsx
@@ -1,0 +1,119 @@
+import {
+  ArrowRight,
+  ArrowUpRight,
+  BookOpen,
+  Database,
+  Github,
+  ScrollText,
+} from "lucide-react";
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Container } from "@/components/layouts/container";
+import {
+  LegalPageLayout,
+  LegalParagraph,
+} from "@/components/layouts/legal-page-layout";
+import { EXTERNAL_LINKS } from "@/config/external-links";
+import { routes } from "@/lib/routes";
+
+export const metadata: Metadata = {
+  title: "開発者向け | みらい議会",
+  description:
+    "みらい議会のオープンデータAPIなど、開発者・研究者向けの情報をまとめています。",
+};
+
+const links = [
+  {
+    href: routes.developersOpenDataApi(),
+    icon: Database,
+    title: "オープンデータAPI",
+    description:
+      "AIインタビューの回答データをオープンデータとして取得できるAPIの利用方法",
+    external: false,
+  },
+  {
+    href: routes.interviewDataTerms(),
+    icon: ScrollText,
+    title: "みらい議会AIインタビューデータ利用規約",
+    description: "オープンデータとして提供するデータの利用条件（CC BY 4.0）",
+    external: false,
+  },
+  {
+    href: EXTERNAL_LINKS.GITHUB_REPO,
+    icon: Github,
+    title: "GitHubリポジトリ",
+    description:
+      "みらい議会のソースコード。IssueやPull Requestでの貢献を歓迎しています",
+    external: true,
+  },
+  {
+    href: EXTERNAL_LINKS.FORK_GUIDELINES_NOTE,
+    icon: BookOpen,
+    title: "自主制作ガイドライン",
+    description: "みらい議会をフォーク・改変して自主制作する際のガイドライン",
+    external: true,
+  },
+];
+
+const cardClassName =
+  "group flex items-start gap-4 rounded-xl border border-slate-200 p-5 transition-colors hover:border-primary-accent";
+
+function LinkCardBody({
+  icon: Icon,
+  title,
+  description,
+  external,
+}: {
+  icon: typeof Database;
+  title: string;
+  description: string;
+  external: boolean;
+}) {
+  const Arrow = external ? ArrowUpRight : ArrowRight;
+  return (
+    <>
+      <Icon className="mt-1 size-6 shrink-0 text-primary-accent" />
+      <div className="flex-1 space-y-1">
+        <p className="font-semibold text-slate-900">{title}</p>
+        <p className="text-sm leading-relaxed text-slate-600">{description}</p>
+      </div>
+      <Arrow className="mt-1 size-5 shrink-0 text-slate-400 transition-colors group-hover:text-primary-accent" />
+    </>
+  );
+}
+
+export default function DevelopersPage() {
+  return (
+    <LegalPageLayout
+      title="開発者向け"
+      description="みらい議会のオープンデータAPIなど、開発者・研究者向けの情報をまとめています。"
+      className="pt-24 md:pt-12"
+    >
+      <Container className="space-y-6">
+        <LegalParagraph>
+          みらい議会は、AIインタビューで得られた法案への意見データを公共財と位置づけ、シビックエンジニアや研究機関など第三者が分析できる形で提供することを目指しています。
+        </LegalParagraph>
+
+        <div className="flex flex-col gap-4">
+          {links.map(({ href, external, ...item }) =>
+            external ? (
+              <a
+                key={href}
+                href={href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={cardClassName}
+              >
+                <LinkCardBody external {...item} />
+              </a>
+            ) : (
+              <Link key={href} href={href} className={cardClassName}>
+                <LinkCardBody external={false} {...item} />
+              </Link>
+            )
+          )}
+        </div>
+      </Container>
+    </LegalPageLayout>
+  );
+}

--- a/web/src/app/api/open-data/interviews/route.integration.test.ts
+++ b/web/src/app/api/open-data/interviews/route.integration.test.ts
@@ -1,0 +1,109 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import { getRetryAfterSeconds } from "@/features/open-data/shared/utils/rate-limit-window";
+import { GET } from "./route";
+
+// レートリミット設定はリクエスト毎に env から読まれる
+beforeAll(() => {
+  process.env.OPEN_DATA_RATE_LIMIT_PER_IP = "3";
+});
+
+function buildRequest(params: { query?: string; ip?: string }): Request {
+  const url = `http://localhost:3000/api/open-data/interviews${params.query ?? ""}`;
+  return new Request(url, {
+    headers: params.ip ? { "x-forwarded-for": params.ip } : {},
+  });
+}
+
+/** テストごとに一意なIPを払い出してレートリミットの干渉を防ぐ */
+let ipCounter = 0;
+function uniqueIp(): string {
+  ipCounter += 1;
+  return `203.0.113.${ipCounter}`;
+}
+
+describe("GET /api/open-data/interviews", () => {
+  it("agreeToTerms がない場合は403と規約URLを返す", async () => {
+    const res = await GET(buildRequest({ ip: uniqueIp() }));
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.termsUrl).toContain("/developers/interview-data-terms");
+  });
+
+  it("limit が不正な場合は400を返す", async () => {
+    const res = await GET(
+      buildRequest({ query: "?agreeToTerms=true&limit=0", ip: uniqueIp() })
+    );
+    expect(res.status).toBe(400);
+
+    const res2 = await GET(
+      buildRequest({ query: "?agreeToTerms=true&limit=abc", ip: uniqueIp() })
+    );
+    expect(res2.status).toBe(400);
+  });
+
+  it("cursor が不正な場合は400を返す", async () => {
+    const res = await GET(
+      buildRequest({
+        query: "?agreeToTerms=true&cursor=invalid!!",
+        ip: uniqueIp(),
+      })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("同意済みリクエストにはitems・license・termsUrlをno-storeで返す", async () => {
+    const res = await GET(
+      buildRequest({ query: "?agreeToTerms=true", ip: uniqueIp() })
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+
+    const body = await res.json();
+    expect(Array.isArray(body.items)).toBe(true);
+    expect(body.license).toBe("CC BY 4.0");
+    expect(body.termsUrl).toContain("/developers/interview-data-terms");
+    expect("nextCursor" in body).toBe(true);
+  });
+
+  it("IP単位のレートリミットを超えると429とRetry-Afterを返す", async () => {
+    const ip = uniqueIp();
+    const query = "?agreeToTerms=true&limit=1";
+
+    // テスト中にウィンドウが切り替わるとカウントがリセットされて
+    // フレークするため、残り時間が少ない場合は次のウィンドウまで待つ
+    const remaining = getRetryAfterSeconds(new Date(), 60);
+    if (remaining < 5) {
+      await new Promise((resolve) =>
+        setTimeout(resolve, remaining * 1000 + 100)
+      );
+    }
+
+    for (let i = 0; i < 3; i++) {
+      const res = await GET(buildRequest({ query, ip }));
+      expect(res.status).toBe(200);
+    }
+
+    const globalCountBefore = await fetchGlobalCount();
+    const blocked = await GET(buildRequest({ query, ip }));
+    expect(blocked.status).toBe(429);
+    expect(Number(blocked.headers.get("Retry-After"))).toBeGreaterThan(0);
+
+    // IP超過で拒否されたリクエストはグローバル枠を消費しない
+    expect(await fetchGlobalCount()).toBe(globalCountBefore);
+  });
+});
+
+async function fetchGlobalCount(): Promise<number> {
+  const { adminClient } = await import("@test-utils/utils");
+  const { data, error } = await adminClient
+    .from("api_rate_limits")
+    .select("request_count")
+    .eq("key", "open-data:global")
+    .order("window_start", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  if (error) throw new Error(`api_rate_limits 取得失敗: ${error.message}`);
+  return data?.request_count ?? 0;
+}

--- a/web/src/app/api/open-data/interviews/route.ts
+++ b/web/src/app/api/open-data/interviews/route.ts
@@ -1,0 +1,118 @@
+import { consumeRateLimit } from "@/features/open-data/server/repositories/open-data-repository";
+import { getOpenDataInterviews } from "@/features/open-data/server/services/get-open-data-interviews";
+import { getClientIp } from "@/features/open-data/shared/utils/client-ip";
+import {
+  parseInterviewsQuery,
+  toPositiveInt,
+} from "@/features/open-data/shared/utils/parse-interviews-query";
+import {
+  getRetryAfterSeconds,
+  getWindowStart,
+} from "@/features/open-data/shared/utils/rate-limit-window";
+import { NextResponse } from "next/server";
+import { routes } from "@/lib/routes";
+
+const LICENSE = "CC BY 4.0";
+const RATE_LIMIT_WINDOW_SECONDS = 60;
+
+const json = (body: unknown, status = 200, headers: HeadersInit = {}) =>
+  NextResponse.json(body, {
+    status,
+    headers: {
+      // 同意撤回・非公開化が即座に反映されるようキャッシュしない
+      "Cache-Control": "no-store",
+      ...headers,
+    },
+  });
+
+/**
+ * AIインタビューデータのオープンデータ取得API。
+ *
+ * - 「みらい議会AIインタビューデータ利用規約」への同意表明
+ *   （agreeToTerms=true）を必須とする
+ * - 回答者が二次利用を許諾し（is_data_reuse_consented）、公開条件
+ *   （管理者公開 × ユーザー公開 × 公開議案 × k-匿名性ゲート）を満たす
+ *   レポートのみを返す
+ * - APIキーは発行せず、API全体でレートリミットを設ける
+ */
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const termsUrl = new URL(routes.interviewDataTerms(), url.origin).toString();
+
+  // 規約同意の表明（クリックスルー相当）を必須にする
+  if (url.searchParams.get("agreeToTerms") !== "true") {
+    return json(
+      {
+        error:
+          "みらい議会AIインタビューデータ利用規約に同意の上、agreeToTerms=true を指定してください",
+        termsUrl,
+      },
+      403
+    );
+  }
+
+  const query = parseInterviewsQuery(url.searchParams);
+  if (!query.ok) {
+    return json({ error: query.error }, 400);
+  }
+  const { limit, cursor } = query;
+
+  try {
+    // レートリミット（IP単位 + API全体、環境変数で上書き可能）。
+    // モジュールロード時に固定せずリクエスト毎に読むことで、env変更の即時反映と
+    // テストの簡素化（動的import不要）を両立する
+    const perIpLimit = toPositiveInt(
+      process.env.OPEN_DATA_RATE_LIMIT_PER_IP,
+      30
+    );
+    const globalLimit = toPositiveInt(
+      process.env.OPEN_DATA_RATE_LIMIT_GLOBAL,
+      300
+    );
+    // IP制限を先に判定し、通過したリクエストだけがグローバル枠を消費する
+    // （超過IPの連投が全体枠を食い潰し、他クライアントを巻き込むのを防ぐ）
+    const now = new Date();
+    const windowStart = getWindowStart(
+      now,
+      RATE_LIMIT_WINDOW_SECONDS
+    ).toISOString();
+    const clientIp = getClientIp(request.headers) ?? "unknown";
+    const tooManyRequests = () =>
+      json(
+        {
+          error: "リクエストが多すぎます。しばらく待ってから再試行してください",
+        },
+        429,
+        {
+          "Retry-After": String(
+            getRetryAfterSeconds(now, RATE_LIMIT_WINDOW_SECONDS)
+          ),
+        }
+      );
+
+    const ipAllowed = await consumeRateLimit({
+      key: `open-data:ip:${clientIp}`,
+      windowStart,
+      limit: perIpLimit,
+    });
+    if (!ipAllowed) {
+      return tooManyRequests();
+    }
+
+    const globalAllowed = await consumeRateLimit({
+      key: "open-data:global",
+      windowStart,
+      limit: globalLimit,
+    });
+    if (!globalAllowed) {
+      return tooManyRequests();
+    }
+
+    const result = await getOpenDataInterviews({ limit, cursor });
+    return json({ ...result, license: LICENSE, termsUrl });
+  } catch (error) {
+    // 内部エラーの詳細（DBエラーメッセージ等）は公開APIのレスポンスに含めない
+    console.error("[OpenData] interviews read failed:", error);
+    return json({ error: "サーバー内部でエラーが発生しました" }, 500);
+  }
+}

--- a/web/src/components/layouts/footer/footer.config.test.ts
+++ b/web/src/components/layouts/footer/footer.config.test.ts
@@ -3,12 +3,12 @@ import { routes } from "@/lib/routes";
 import { policyLinks, primaryLinks } from "./footer.config";
 
 describe("footer.config", () => {
-  it("policyLinks に規約3ページへの内部リンクが含まれる", () => {
+  it("policyLinks に規約ページと開発者向けページへの内部リンクが含まれる", () => {
     const hrefs = policyLinks.map((link) => link.href);
 
     expect(hrefs).toContain(routes.terms());
     expect(hrefs).toContain(routes.privacy());
-    expect(hrefs).toContain(routes.interviewDataTerms());
+    expect(hrefs).toContain(routes.developers());
   });
 
   it("内部リンクには external フラグが付かない", () => {
@@ -16,7 +16,7 @@ describe("footer.config", () => {
       routes.home(),
       routes.terms(),
       routes.privacy(),
-      routes.interviewDataTerms(),
+      routes.developers(),
     ]);
 
     for (const link of [...primaryLinks, ...policyLinks]) {

--- a/web/src/components/layouts/footer/footer.config.ts
+++ b/web/src/components/layouts/footer/footer.config.ts
@@ -50,12 +50,7 @@ export const policyLinks: FooterPolicyLink[] = [
     href: routes.privacy(),
   },
   {
-    label: "AIインタビューデータ利用規約",
-    href: routes.interviewDataTerms(),
-  },
-  {
-    label: "自主制作ガイドライン",
-    href: EXTERNAL_LINKS.FORK_GUIDELINES_NOTE,
-    external: true,
+    label: "開発者向け",
+    href: routes.developers(),
   },
 ];

--- a/web/src/components/layouts/footer/footer.tsx
+++ b/web/src/components/layouts/footer/footer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import Image from "next/image";
 import type { Route } from "next";
+import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { isInterviewPage } from "@/lib/page-layout-utils";

--- a/web/src/config/external-links.ts
+++ b/web/src/config/external-links.ts
@@ -10,4 +10,5 @@ export const EXTERNAL_LINKS = {
   PRIVACY: "https://team-mir.ai/privacy",
   FAQ: "https://team-mirai.notion.site/FAQ-28cf6f56bae180bd84e7f7ae80f806a1",
   FORK_GUIDELINES_NOTE: "https://note.com/team_mirai_jp/n/nc59ec347e8c7",
+  GITHUB_REPO: "https://github.com/team-mirai/mirai-gikai",
 } as const;

--- a/web/src/features/open-data/client/components/open-data-api-reference.tsx
+++ b/web/src/features/open-data/client/components/open-data-api-reference.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { ApiReferenceReact } from "@scalar/api-reference-react";
+import "@scalar/api-reference-react/style.css";
+
+/**
+ * オープンデータAPIのOpenAPI仕様書ビューア。
+ * 仕様書本体は /openapi/open-data-api.json（public配下）で配信する。
+ */
+export function OpenDataApiReference() {
+  return (
+    <ApiReferenceReact
+      configuration={{
+        url: "/openapi/open-data-api.json",
+        darkMode: false,
+        hideDarkModeToggle: true,
+        hideClientButton: true,
+        showDeveloperTools: "never",
+        // トップページの最外枠（body背景 = mirai-surface-light）と同じ色に合わせる
+        customCss: `
+          .scalar-api-reference {
+            --scalar-background-1: var(--color-mirai-surface-light);
+            --scalar-background-2: var(--color-mirai-surface-gray);
+            --scalar-background-3: var(--color-mirai-surface-tag);
+            --scalar-sidebar-background-1: var(--color-mirai-surface-light);
+          }
+        `,
+      }}
+    />
+  );
+}

--- a/web/src/features/open-data/server/repositories/open-data-repository.ts
+++ b/web/src/features/open-data/server/repositories/open-data-repository.ts
@@ -1,0 +1,97 @@
+import "server-only";
+
+import { createAdminClient } from "@mirai-gikai/supabase";
+import type { OpenDataCursor } from "../../shared/utils/cursor";
+
+export type OpenDataReportRow = {
+  report_id: string;
+  bill_id: string;
+  bill_name: string;
+  stance: string | null;
+  role: string | null;
+  role_title: string | null;
+  role_description: string | null;
+  summary: string | null;
+  opinions: unknown;
+  interview_session_id: string;
+  created_at: string;
+};
+
+/**
+ * 二次利用許諾済みの公開レポートを新しい順に取得する。
+ * フィルタ条件（公開フラグ × 二次利用許諾 × 公開議案 × k-匿名性ゲート）は
+ * DB function 側に集約している。
+ */
+export async function findOpenDataReports(params: {
+  minPublicReports: number;
+  limit: number;
+  cursor: OpenDataCursor | null;
+}): Promise<OpenDataReportRow[]> {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase.rpc(
+    "find_open_data_interview_reports",
+    {
+      p_min_public_reports: params.minPublicReports,
+      p_limit: params.limit,
+      ...(params.cursor
+        ? {
+            p_cursor_created_at: params.cursor.createdAt,
+            p_cursor_id: params.cursor.id,
+          }
+        : {}),
+    }
+  );
+
+  if (error) {
+    throw new Error(`Failed to fetch open data reports: ${error.message}`);
+  }
+  return data ?? [];
+}
+
+export type OpenDataMessageRow = {
+  interview_session_id: string;
+  role: "assistant" | "user";
+  content: string;
+};
+
+/**
+ * セッションIDの集合に対する会話ログを作成日時昇順で取得する。
+ */
+export async function findMessagesBySessionIds(
+  sessionIds: string[]
+): Promise<OpenDataMessageRow[]> {
+  if (sessionIds.length === 0) return [];
+
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("interview_messages")
+    .select("interview_session_id, role, content")
+    .in("interview_session_id", sessionIds)
+    .order("created_at", { ascending: true });
+
+  if (error) {
+    throw new Error(`Failed to fetch open data messages: ${error.message}`);
+  }
+  return data ?? [];
+}
+
+/**
+ * レートリミットカウンタを加算し、制限内かを返す。
+ */
+export async function consumeRateLimit(params: {
+  key: string;
+  windowStart: string;
+  limit: number;
+}): Promise<boolean> {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase.rpc("increment_api_rate_limit", {
+    p_key: params.key,
+    p_window_start: params.windowStart,
+    p_limit: params.limit,
+  });
+
+  if (error) {
+    throw new Error(`Failed to consume rate limit: ${error.message}`);
+  }
+  return data === true;
+}

--- a/web/src/features/open-data/server/services/get-open-data-interviews.ts
+++ b/web/src/features/open-data/server/services/get-open-data-interviews.ts
@@ -1,0 +1,64 @@
+import "server-only";
+
+import { MIN_PUBLIC_REPORTS_FOR_DISPLAY } from "@mirai-gikai/shared/report-publication/auto-publish";
+import type {
+  OpenDataInterviewItem,
+  OpenDataInterviewsResult,
+  OpenDataMessage,
+} from "../../shared/types/open-data";
+import { encodeCursor, type OpenDataCursor } from "../../shared/utils/cursor";
+import { toOpenDataOpinions } from "../../shared/utils/opinions";
+import {
+  findMessagesBySessionIds,
+  findOpenDataReports,
+} from "../repositories/open-data-repository";
+
+/**
+ * 公開データAPI用のインタビューデータを取得する。
+ * limit+1 件取得して次ページの有無を判定し、nextCursor を組み立てる。
+ */
+export async function getOpenDataInterviews(params: {
+  limit: number;
+  cursor: OpenDataCursor | null;
+}): Promise<OpenDataInterviewsResult> {
+  const rows = await findOpenDataReports({
+    minPublicReports: MIN_PUBLIC_REPORTS_FOR_DISPLAY,
+    limit: params.limit + 1,
+    cursor: params.cursor,
+  });
+
+  const hasMore = rows.length > params.limit;
+  const pageRows = hasMore ? rows.slice(0, params.limit) : rows;
+
+  const messages = await findMessagesBySessionIds(
+    pageRows.map((row) => row.interview_session_id)
+  );
+  const messagesBySession = new Map<string, OpenDataMessage[]>();
+  for (const message of messages) {
+    const list = messagesBySession.get(message.interview_session_id) ?? [];
+    list.push({ role: message.role, content: message.content });
+    messagesBySession.set(message.interview_session_id, list);
+  }
+
+  const items: OpenDataInterviewItem[] = pageRows.map((row) => ({
+    reportId: row.report_id,
+    billId: row.bill_id,
+    billName: row.bill_name,
+    stance: row.stance,
+    role: row.role,
+    roleTitle: row.role_title,
+    roleDescription: row.role_description,
+    summary: row.summary,
+    opinions: toOpenDataOpinions(row.opinions),
+    messages: messagesBySession.get(row.interview_session_id) ?? [],
+    createdAt: row.created_at,
+  }));
+
+  const lastRow = pageRows.at(-1);
+  const nextCursor =
+    hasMore && lastRow
+      ? encodeCursor({ createdAt: lastRow.created_at, id: lastRow.report_id })
+      : null;
+
+  return { items, nextCursor };
+}

--- a/web/src/features/open-data/server/services/get-open-data-interviews.ts
+++ b/web/src/features/open-data/server/services/get-open-data-interviews.ts
@@ -8,6 +8,7 @@ import type {
 } from "../../shared/types/open-data";
 import { encodeCursor, type OpenDataCursor } from "../../shared/utils/cursor";
 import { toOpenDataOpinions } from "../../shared/utils/opinions";
+import { toOpenDataMessage } from "../../shared/utils/to-open-data-message";
 import {
   findMessagesBySessionIds,
   findOpenDataReports,
@@ -36,7 +37,7 @@ export async function getOpenDataInterviews(params: {
   const messagesBySession = new Map<string, OpenDataMessage[]>();
   for (const message of messages) {
     const list = messagesBySession.get(message.interview_session_id) ?? [];
-    list.push({ role: message.role, content: message.content });
+    list.push(toOpenDataMessage(message));
     messagesBySession.set(message.interview_session_id, list);
   }
 

--- a/web/src/features/open-data/shared/types/open-data.ts
+++ b/web/src/features/open-data/shared/types/open-data.ts
@@ -1,0 +1,25 @@
+import type { OpenDataOpinion } from "../utils/opinions";
+
+export type OpenDataMessage = {
+  role: "assistant" | "user";
+  content: string;
+};
+
+export type OpenDataInterviewItem = {
+  reportId: string;
+  billId: string;
+  billName: string;
+  stance: string | null;
+  role: string | null;
+  roleTitle: string | null;
+  roleDescription: string | null;
+  summary: string | null;
+  opinions: OpenDataOpinion[];
+  messages: OpenDataMessage[];
+  createdAt: string;
+};
+
+export type OpenDataInterviewsResult = {
+  items: OpenDataInterviewItem[];
+  nextCursor: string | null;
+};

--- a/web/src/features/open-data/shared/utils/client-ip.test.ts
+++ b/web/src/features/open-data/shared/utils/client-ip.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { getClientIp } from "./client-ip";
+
+describe("getClientIp", () => {
+  it("x-forwarded-for の先頭IPを返す", () => {
+    const headers = new Headers({
+      "x-forwarded-for": "203.0.113.1, 198.51.100.2",
+    });
+    expect(getClientIp(headers)).toBe("203.0.113.1");
+  });
+
+  it("x-forwarded-for がなければ x-real-ip を返す", () => {
+    const headers = new Headers({ "x-real-ip": "203.0.113.9" });
+    expect(getClientIp(headers)).toBe("203.0.113.9");
+  });
+
+  it("どちらもなければ null", () => {
+    expect(getClientIp(new Headers())).toBeNull();
+  });
+
+  it("空の x-forwarded-for は無視して null", () => {
+    const headers = new Headers({ "x-forwarded-for": " " });
+    expect(getClientIp(headers)).toBeNull();
+  });
+});

--- a/web/src/features/open-data/shared/utils/client-ip.ts
+++ b/web/src/features/open-data/shared/utils/client-ip.ts
@@ -1,0 +1,18 @@
+/**
+ * リバースプロキシ（Vercel等）越しのクライアントIPを取得する。
+ *
+ * 前提: Vercel は x-forwarded-for をプロキシで正規化するため先頭の値を
+ * 信頼できる。プロキシがヘッダを正規化しない環境ではクライアントが
+ * 偽装可能なため、IP単位の制限はベストエフォート（最終防波堤は
+ * API全体のレートリミット）。取得できなければ null。
+ */
+export function getClientIp(headers: Headers): string | null {
+  const forwardedFor = headers.get("x-forwarded-for");
+  if (forwardedFor) {
+    const first = forwardedFor.split(",")[0]?.trim();
+    if (first) return first;
+  }
+
+  const realIp = headers.get("x-real-ip")?.trim();
+  return realIp || null;
+}

--- a/web/src/features/open-data/shared/utils/cursor.test.ts
+++ b/web/src/features/open-data/shared/utils/cursor.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { decodeCursor, encodeCursor } from "./cursor";
+
+const cursor = {
+  createdAt: "2026-07-14T12:00:00.000Z",
+  id: "123e4567-e89b-42d3-a456-426614174000",
+};
+
+describe("encodeCursor / decodeCursor", () => {
+  it("エンコードしたカーソルをデコードすると元に戻る", () => {
+    expect(decodeCursor(encodeCursor(cursor))).toEqual(cursor);
+  });
+
+  it("base64urlでない文字列は null", () => {
+    expect(decodeCursor("!!!not-base64!!!")).toBeNull();
+  });
+
+  it("区切りのない文字列は null", () => {
+    const encoded = Buffer.from("no-separator", "utf8").toString("base64url");
+    expect(decodeCursor(encoded)).toBeNull();
+  });
+
+  it("日時が不正な場合は null", () => {
+    const encoded = Buffer.from(`not-a-date|${cursor.id}`, "utf8").toString(
+      "base64url"
+    );
+    expect(decodeCursor(encoded)).toBeNull();
+  });
+
+  it("ISO形式だが実在しない日付（2/30等）は null", () => {
+    // Date.parse は 3/2 に正規化して受理するが、Postgres 側でエラーになるため弾く
+    const encoded = Buffer.from(
+      `2026-02-30T00:00:00.000Z|${cursor.id}`,
+      "utf8"
+    ).toString("base64url");
+    expect(decodeCursor(encoded)).toBeNull();
+  });
+
+  it("ISO形式でない日付表現（英語表記等）は null", () => {
+    const encoded = Buffer.from(
+      `March 5 2026 00:00:00 GMT|${cursor.id}`,
+      "utf8"
+    ).toString("base64url");
+    expect(decodeCursor(encoded)).toBeNull();
+  });
+
+  it("DBが返す +00:00 オフセット・マイクロ秒形式も受理する", () => {
+    const dbFormat = "2026-07-14T12:00:00.123456+00:00";
+    const encoded = Buffer.from(`${dbFormat}|${cursor.id}`, "utf8").toString(
+      "base64url"
+    );
+    expect(decodeCursor(encoded)).toEqual({
+      createdAt: dbFormat,
+      id: cursor.id,
+    });
+  });
+
+  it("IDがUUIDでない場合は null", () => {
+    const encoded = Buffer.from(
+      `${cursor.createdAt}|not-a-uuid`,
+      "utf8"
+    ).toString("base64url");
+    expect(decodeCursor(encoded)).toBeNull();
+  });
+});

--- a/web/src/features/open-data/shared/utils/cursor.ts
+++ b/web/src/features/open-data/shared/utils/cursor.ts
@@ -1,0 +1,62 @@
+export type OpenDataCursor = {
+  /** ISO 8601 の created_at */
+  createdAt: string;
+  /** レポートID（UUID） */
+  id: string;
+};
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// Postgres の timestamptz が受理できる ISO 8601 形式（DBから返る +00:00 形式も含む）
+const ISO_TIMESTAMP_PATTERN =
+  /^(\d{4})-(\d{2})-(\d{2})T\d{2}:\d{2}:\d{2}(?:\.\d{1,6})?(?:Z|[+-]\d{2}:\d{2})$/;
+
+/**
+ * Date.parse は "2026-02-30" のような実在しない日付を正規化して受理するが、
+ * Postgres 側はエラーになるため、月日が実在することまで検証する。
+ */
+function isValidIsoTimestamp(value: string): boolean {
+  const match = ISO_TIMESTAMP_PATTERN.exec(value);
+  if (!match) return false;
+  if (Number.isNaN(Date.parse(value))) return false;
+
+  const [, year, month, day] = match;
+  const date = new Date(Date.UTC(Number(year), Number(month) - 1, Number(day)));
+  return (
+    date.getUTCFullYear() === Number(year) &&
+    date.getUTCMonth() === Number(month) - 1 &&
+    date.getUTCDate() === Number(day)
+  );
+}
+
+/**
+ * キーセットページネーション用カーソルを不透明な文字列にエンコードする。
+ */
+export function encodeCursor(cursor: OpenDataCursor): string {
+  return Buffer.from(`${cursor.createdAt}|${cursor.id}`, "utf8").toString(
+    "base64url"
+  );
+}
+
+/**
+ * カーソル文字列をデコードする。形式が不正な場合は null。
+ */
+export function decodeCursor(value: string): OpenDataCursor | null {
+  let decoded: string;
+  try {
+    decoded = Buffer.from(value, "base64url").toString("utf8");
+  } catch {
+    return null;
+  }
+
+  const separatorIndex = decoded.indexOf("|");
+  if (separatorIndex < 0) return null;
+
+  const createdAt = decoded.slice(0, separatorIndex);
+  const id = decoded.slice(separatorIndex + 1);
+  if (!isValidIsoTimestamp(createdAt)) return null;
+  if (!UUID_PATTERN.test(id)) return null;
+
+  return { createdAt, id };
+}

--- a/web/src/features/open-data/shared/utils/opinions.test.ts
+++ b/web/src/features/open-data/shared/utils/opinions.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { toOpenDataOpinions } from "./opinions";
+
+describe("toOpenDataOpinions", () => {
+  it("title/content のみを抽出し内部メタデータを含めない", () => {
+    const opinions = toOpenDataOpinions([
+      {
+        title: "賛成の理由",
+        content: "社会全体の利益になる",
+        source_message_id: "message-1",
+        source_message_content: "元発言",
+        richness: 70,
+      },
+    ]);
+
+    expect(opinions).toEqual([
+      { title: "賛成の理由", content: "社会全体の利益になる" },
+    ]);
+  });
+
+  it("配列でない値は空配列", () => {
+    expect(toOpenDataOpinions(null)).toEqual([]);
+    expect(toOpenDataOpinions({ title: "x", content: "y" })).toEqual([]);
+  });
+
+  it("title/content が欠けた要素は除外する", () => {
+    const opinions = toOpenDataOpinions([
+      { title: "有効", content: "本文" },
+      { title: "contentなし" },
+      { content: "titleなし" },
+      null,
+    ]);
+
+    expect(opinions).toEqual([{ title: "有効", content: "本文" }]);
+  });
+});

--- a/web/src/features/open-data/shared/utils/opinions.ts
+++ b/web/src/features/open-data/shared/utils/opinions.ts
@@ -1,0 +1,22 @@
+export type OpenDataOpinion = {
+  title: string;
+  content: string;
+};
+
+/**
+ * interview_report.opinions（JSONB）を公開API用の形に変換する。
+ * title/content のみを返し、内部用のメタデータ（根拠メッセージID等）は含めない。
+ * 配列でない・要素が不正な場合は握りつぶさず空要素を除外する。
+ */
+export function toOpenDataOpinions(value: unknown): OpenDataOpinion[] {
+  if (!Array.isArray(value)) return [];
+
+  const opinions: OpenDataOpinion[] = [];
+  for (const item of value) {
+    if (typeof item !== "object" || item === null) continue;
+    const { title, content } = item as { title?: unknown; content?: unknown };
+    if (typeof title !== "string" || typeof content !== "string") continue;
+    opinions.push({ title, content });
+  }
+  return opinions;
+}

--- a/web/src/features/open-data/shared/utils/parse-interviews-query.test.ts
+++ b/web/src/features/open-data/shared/utils/parse-interviews-query.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { encodeCursor } from "./cursor";
+import {
+  DEFAULT_LIMIT,
+  parseInterviewsQuery,
+  toPositiveInt,
+} from "./parse-interviews-query";
+
+describe("parseInterviewsQuery", () => {
+  it("未指定時はデフォルトlimit・cursorなしで解析する", () => {
+    const result = parseInterviewsQuery(new URLSearchParams());
+    expect(result).toEqual({ ok: true, limit: DEFAULT_LIMIT, cursor: null });
+  });
+
+  it("limit と cursor を解析する", () => {
+    const cursor = {
+      createdAt: "2026-07-14T12:00:00.000Z",
+      id: "123e4567-e89b-42d3-a456-426614174000",
+    };
+    const params = new URLSearchParams({
+      limit: "50",
+      cursor: encodeCursor(cursor),
+    });
+
+    expect(parseInterviewsQuery(params)).toEqual({
+      ok: true,
+      limit: 50,
+      cursor,
+    });
+  });
+
+  it.each([
+    "0",
+    "101",
+    "abc",
+    "1.5",
+  ])("不正な limit (%s) はエラーを返す", (limit) => {
+    const result = parseInterviewsQuery(new URLSearchParams({ limit }));
+    expect(result.ok).toBe(false);
+  });
+
+  it("不正な cursor はエラーを返す", () => {
+    const result = parseInterviewsQuery(
+      new URLSearchParams({ cursor: "invalid!!" })
+    );
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe("toPositiveInt", () => {
+  it("正の整数文字列を解析する", () => {
+    expect(toPositiveInt("30", 10)).toBe(30);
+  });
+
+  it.each([
+    undefined,
+    "0",
+    "-1",
+    "abc",
+    "1.5",
+  ])("不正な値 (%s) は fallback を返す", (value) => {
+    expect(toPositiveInt(value, 10)).toBe(10);
+  });
+});

--- a/web/src/features/open-data/shared/utils/parse-interviews-query.ts
+++ b/web/src/features/open-data/shared/utils/parse-interviews-query.ts
@@ -1,0 +1,45 @@
+import { decodeCursor, type OpenDataCursor } from "./cursor";
+
+export const DEFAULT_LIMIT = 20;
+export const MAX_LIMIT = 100;
+
+export type ParsedInterviewsQuery =
+  | { ok: true; limit: number; cursor: OpenDataCursor | null }
+  | { ok: false; error: string };
+
+/**
+ * 公開データAPIのクエリパラメータ（limit / cursor）を検証・解析する。
+ */
+export function parseInterviewsQuery(
+  searchParams: URLSearchParams
+): ParsedInterviewsQuery {
+  const limitParam = searchParams.get("limit");
+  const limit = limitParam === null ? DEFAULT_LIMIT : Number(limitParam);
+  if (!Number.isInteger(limit) || limit < 1 || limit > MAX_LIMIT) {
+    return {
+      ok: false,
+      error: `limit は 1〜${MAX_LIMIT} の整数で指定してください`,
+    };
+  }
+
+  const cursorParam = searchParams.get("cursor");
+  const cursor = cursorParam === null ? null : decodeCursor(cursorParam);
+  if (cursorParam !== null && cursor === null) {
+    return { ok: false, error: "cursor の形式が不正です" };
+  }
+
+  return { ok: true, limit, cursor };
+}
+
+/**
+ * 環境変数等の文字列を正の整数として解析する。不正・未設定は fallback。
+ * `Number(x) || fallback` と違い、0 や NaN を暗黙に既定値へ丸めた事実が
+ * 分かるよう明示的に判定する（0 は「制限なし」ではなく不正値として扱う）。
+ */
+export function toPositiveInt(
+  value: string | undefined,
+  fallback: number
+): number {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}

--- a/web/src/features/open-data/shared/utils/rate-limit-window.test.ts
+++ b/web/src/features/open-data/shared/utils/rate-limit-window.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { getRetryAfterSeconds, getWindowStart } from "./rate-limit-window";
+
+describe("getWindowStart", () => {
+  it("60秒ウィンドウでは分頭に丸める", () => {
+    const now = new Date("2026-07-14T12:34:56.789Z");
+    expect(getWindowStart(now, 60).toISOString()).toBe(
+      "2026-07-14T12:34:00.000Z"
+    );
+  });
+
+  it("ウィンドウ境界ちょうどの時刻はそのまま返す", () => {
+    const now = new Date("2026-07-14T12:34:00.000Z");
+    expect(getWindowStart(now, 60).toISOString()).toBe(
+      "2026-07-14T12:34:00.000Z"
+    );
+  });
+
+  it("同一ウィンドウ内の時刻は同じ開始時刻になる", () => {
+    const a = getWindowStart(new Date("2026-07-14T12:34:01.000Z"), 60);
+    const b = getWindowStart(new Date("2026-07-14T12:34:59.999Z"), 60);
+    expect(a.getTime()).toBe(b.getTime());
+  });
+});
+
+describe("getRetryAfterSeconds", () => {
+  it("ウィンドウ終了までの残り秒数を切り上げで返す", () => {
+    const now = new Date("2026-07-14T12:34:56.500Z");
+    expect(getRetryAfterSeconds(now, 60)).toBe(4);
+  });
+
+  it("最小でも1秒を返す", () => {
+    const now = new Date("2026-07-14T12:34:59.999Z");
+    expect(getRetryAfterSeconds(now, 60)).toBe(1);
+  });
+});

--- a/web/src/features/open-data/shared/utils/rate-limit-window.ts
+++ b/web/src/features/open-data/shared/utils/rate-limit-window.ts
@@ -1,0 +1,17 @@
+/**
+ * 固定ウィンドウ方式のレートリミットで使うウィンドウ開始時刻を計算する。
+ * 同一ウィンドウ内のリクエストは同じ開始時刻に丸められ、DB側カウンタのキーになる。
+ */
+export function getWindowStart(now: Date, windowSeconds: number): Date {
+  const windowMs = windowSeconds * 1000;
+  return new Date(Math.floor(now.getTime() / windowMs) * windowMs);
+}
+
+/**
+ * 現在のウィンドウが終わるまでの残り秒数（429レスポンスの Retry-After 用）。
+ */
+export function getRetryAfterSeconds(now: Date, windowSeconds: number): number {
+  const windowEnd =
+    getWindowStart(now, windowSeconds).getTime() + windowSeconds * 1000;
+  return Math.max(1, Math.ceil((windowEnd - now.getTime()) / 1000));
+}

--- a/web/src/features/open-data/shared/utils/to-open-data-message.test.ts
+++ b/web/src/features/open-data/shared/utils/to-open-data-message.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { toOpenDataMessage } from "./to-open-data-message";
+
+describe("toOpenDataMessage", () => {
+  it("assistantの構造化JSONからは表示テキストのみを返す", () => {
+    const content = JSON.stringify({
+      text: "ご意見ありがとうございます。",
+      next_stage: "closing",
+      report: {
+        summary: "内部メタデータ",
+        opinions: [
+          {
+            title: "t",
+            content: "c",
+            source_message_id: "m-1",
+            contextual_quote: "引用",
+          },
+        ],
+        content_richness: { total: 80 },
+      },
+    });
+
+    expect(toOpenDataMessage({ role: "assistant", content })).toEqual({
+      role: "assistant",
+      content: "ご意見ありがとうございます。",
+    });
+  });
+
+  it("assistantのプレーンテキストはそのまま返す", () => {
+    expect(
+      toOpenDataMessage({ role: "assistant", content: "こんにちは" })
+    ).toEqual({ role: "assistant", content: "こんにちは" });
+  });
+
+  it("userのcontentはJSON風の文字列でも変換しない", () => {
+    const content = '{"text":"ユーザーが入力したJSON風の文章"}';
+    expect(toOpenDataMessage({ role: "user", content })).toEqual({
+      role: "user",
+      content,
+    });
+  });
+});

--- a/web/src/features/open-data/shared/utils/to-open-data-message.ts
+++ b/web/src/features/open-data/shared/utils/to-open-data-message.ts
@@ -1,0 +1,24 @@
+import { getMessageDisplayText } from "@/features/interview-report/shared/utils/get-message-display-text";
+import type { OpenDataMessage } from "../types/open-data";
+
+/**
+ * DBに保存されたメッセージ行を公開APIのメッセージ形式に変換する。
+ *
+ * assistant の content は構造化JSONの生文字列で保存されており、最終ターンには
+ * 内部メタデータ（report・content_richness 等）が埋め込まれる。webの公開ページと
+ * 同じ表示テキスト抽出（getMessageDisplayText）を適用することで、
+ * 「APIで取得できる内容 = みらい議会上で公開されている内容」を関数レベルで保証する。
+ * user の content はwebと同様にそのまま返す。
+ */
+export function toOpenDataMessage(row: {
+  role: OpenDataMessage["role"];
+  content: string;
+}): OpenDataMessage {
+  return {
+    role: row.role,
+    content:
+      row.role === "assistant"
+        ? getMessageDisplayText(row.content)
+        : row.content,
+  };
+}

--- a/web/src/lib/routes.test.ts
+++ b/web/src/lib/routes.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { isDevRoute } from "../middleware";
 import { routes } from "./routes";
 
 /**
@@ -74,7 +75,9 @@ describe("routes", () => {
     .filter(
       (r) =>
         !r.startsWith("/api") &&
-        !r.startsWith("/dev") &&
+        // 開発用プレビュー（/dev 完全一致・/dev/ 配下）のみ除外する。
+        // /developers 等の通常ページは対象に含める（判定はmiddlewareと共有）
+        !isDevRoute(r) &&
         !r.startsWith("/preview")
     )
     .map(normalizeAppRoute)

--- a/web/src/lib/routes.ts
+++ b/web/src/lib/routes.ts
@@ -11,7 +11,9 @@ export const routes = {
   home: () => "/" as const,
   terms: () => "/terms" as const,
   privacy: () => "/privacy" as const,
-  interviewDataTerms: () => "/interview-data-terms" as const,
+  developers: () => "/developers" as const,
+  developersOpenDataApi: () => "/developers/open-data-api" as const,
+  interviewDataTerms: () => "/developers/interview-data-terms" as const,
 
   // ── 議案 ──────────────────────────────────────────
   billDetail: (billId: string) => `/bills/${billId}` as const,

--- a/web/src/middleware.test.ts
+++ b/web/src/middleware.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { isHtmlAcceptHeader, isValidDifficultyLevel } from "./middleware";
+import {
+  isDevRoute,
+  isHtmlAcceptHeader,
+  isValidDifficultyLevel,
+} from "./middleware";
 
 describe("isValidDifficultyLevel", () => {
   it("should return true for 'normal'", () => {
@@ -46,5 +50,22 @@ describe("isHtmlAcceptHeader", () => {
 
   it("should return false for empty string", () => {
     expect(isHtmlAcceptHeader("")).toBe(false);
+  });
+});
+
+describe("isDevRoute", () => {
+  it("/dev と /dev/ 配下は開発用ルートと判定する", () => {
+    expect(isDevRoute("/dev")).toBe(true);
+    expect(isDevRoute("/dev/preview")).toBe(true);
+  });
+
+  it("/developers など /dev で始まる通常ページは対象外", () => {
+    expect(isDevRoute("/developers")).toBe(false);
+    expect(isDevRoute("/developers/open-data-api")).toBe(false);
+  });
+
+  it("その他のパスは対象外", () => {
+    expect(isDevRoute("/")).toBe(false);
+    expect(isDevRoute("/terms")).toBe(false);
   });
 });

--- a/web/src/middleware.ts
+++ b/web/src/middleware.ts
@@ -13,9 +13,18 @@ import {
 } from "./lib/basic-auth";
 import { updateSupabaseSession } from "./lib/supabase/middleware";
 
+/**
+ * 開発用プレビュー（/dev 配下）のルートか判定する。
+ * 単純な startsWith("/dev") だと /developers 等の通常ページまで
+ * 巻き込むため、完全一致か "/dev/" 配下のみを対象にする。
+ */
+export function isDevRoute(pathname: string): boolean {
+  return pathname === "/dev" || pathname.startsWith("/dev/");
+}
+
 export async function middleware(request: NextRequest) {
   // /dev routes: 本番では404、開発ではauthスキップ
-  if (request.nextUrl.pathname.startsWith("/dev")) {
+  if (isDevRoute(request.nextUrl.pathname)) {
     if (process.env.NODE_ENV !== "development") {
       return NextResponse.rewrite(new URL("/not-found", request.url));
     }


### PR DESCRIPTION
## 概要

AIインタビューデータのオープンデータAPI (`GET /api/open-data/interviews`) と、開発者向けドキュメントページ（`/developers` 配下: APIリファレンス・データ利用規約・自主制作ガイドライン導線）を追加します。

> **Note: base は `update-terms-privacy`（#923）です。** インタビューデータ利用規約ページ等が #923 に依存するためのスタックPRで、#923 マージ後に base を develop に切り替えてください。インタビュー開始前モーダルからのオープンデータ告知削除（3c0981ec）も本ブランチに含まれています。

## 主な内容

- **公開API** `GET /api/open-data/interviews`: `agreeToTerms=true`（クリックスルー同意）必須。返すのは「二次利用許諾済み（is_data_reuse_consented）× 管理者公開 × ユーザー公開 × 公開議案 × k-匿名性ゲート（webと同一の閾値を共有定数で注入）」を満たすレポートのみ。keyset paginationで全件クロール可能、CC BY 4.0
- **レートリミット**: APIキーなし。IP単位 + API全体の固定ウィンドウをDB function（`increment_api_rate_limit`、原子的upsert）で実装。fail-closed、超過IPはグローバル枠を消費しない
- **DB function** `find_open_data_interview_reports`: フィルタ・k-匿名性・keyset paginationをDB側に集約
- **開発者向けページ**: `/developers`（ランディング）、`/developers/open-data-api`（Scalar + OpenAPI定義）、`/developers/interview-data-terms`（規約、旧URLから301）
- middleware の `/dev` プレフィックス判定を `isDevRoute()` に切り出して `/developers` の巻き込みを修正（テスト付き）

## セルフレビューで適用した修正

/simplify・/review（Codex + 品質/テストガイドラインチェッカー）の指摘から以下を適用済み:

- 公開APIの500レスポンスから内部エラー詳細を除去（固定文言化）
- レートリミット行の無限成長対策（1時間より古い全キー横断の掃除 + `window_start` インデックス）とDELETE頻度の最適化（新規ウィンドウ作成時のみ）
- 不正カーソル（実在しない日付等）が500になるケースを400に（ISO形式+実在日付の検証、テスト追加）
- k-匿名性ゲート集計用のpartial index追加
- レートリミット設定をリクエスト毎にenvから読む化（テストの動的import解消）、`NextResponse.json` 化、`isDevRoute()` のテストでの再利用

## セキュリティ監査（web公開範囲との突合）

「APIでDLできるデータ = みらい議会上で公開されているデータ」の不変条件を、web公開ページのクエリ・表示フィールドとAPIのDB function・レスポンスを突合して監査済み:

- **レコード単位**: APIの返却集合はweb公開集合の部分集合（公開フラグ×k-匿名性ゲートは同一基準を共有し、APIはさらに二次利用同意＋議案publishedを追加要求）
- **同意フラグの書き込み経路**: `is_data_reuse_consented` はデフォルトfalse・バックフィルなしで、告知UIを表示したフローからの明示送信のみ。admin・migration・seedからは設定不可。失効は即時反映（no-store）
- **フィールド単位で1件検出→修正済み**: assistantメッセージの生JSON（最終ターンに内部メタデータ入りreportが埋め込まれる）がそのまま返っていたため、webの公開ページと同じ表示テキスト抽出（`getMessageDisplayText`）を適用（0876047c）

## 個人情報の扱いについて（レビューで検討済み）

データ利用規約の「氏名、住所、連絡先その他特定の個人を識別できる情報を除去したものに限られます」との関係は以下の通り整理済み:

- **モデレーションが公開ゲートに組み込まれている**: モデレーション判定基準の第1項目が「個人情報の開示」（氏名・住所・電話番号・所属組織等）であり、`isReportAutoPublishEligible` が moderationScore を閾値未満に制限するため、個人情報を含むと判定されたレポートは公開されず、本APIの `is_public_by_admin × is_public_by_user` フィルタも通過しない

## 検証記録

- `pnpm lint` ✅ / `pnpm typecheck` ✅ / `pnpm build` ✅
- DB統合テスト: 184件全パス（`find-open-data-interview-reports` / `increment-api-rate-limit` の新規テスト含む）
- web統合テスト: 147件全パス（APIルートの実挙動: 403/400/429/Retry-After/グローバル枠非消費）
- 純粋関数（cursor / client-ip / opinions / parse-query / rate-limit-window）はすべて同階層テスト付き
- テストガイドラインチェック: 違反なし（mock不使用・real Supabase・server-only付与）

## 検討事項（今回は未対応、必要ならフォローアップ）

- レートリミットの2回のDBラウンドトリップを1つのfunctionに統合
- OpenAPI定義と実装定数（MAX_LIMIT等）の同期テスト
- `/api/open-data` を middleware の matcher から除外（匿名APIでのセッション更新スキップ）
- レートリミット環境変数の `lib/env.ts` への集約

🤖 Generated with [Claude Code](https://claude.com/claude-code)

