### PR TITLE
fix: Supabase previewブランチのstatus確認をbranches listから行う

### DIFF
--- a/.github/workflows/supabase_preview.yml
+++ b/.github/workflows/supabase_preview.yml
@@ -151,10 +151,14 @@ jobs:
           github.event.action != 'closed' && steps.changes.outputs.supabase == 'true' &&
           steps.ready.outputs.branching == 'true'
         run: |
-          # 20秒間隔 × 30回 = 最大10分待つ（新規作成時のプロビジョニングを想定）
+          # 20秒間隔 × 30回 = 最大10分待つ（新規作成時のプロビジョニングを想定）。
+          # 注意: `branches get` の JSON は接続情報のみで status を含まないため、
+          # status は `branches list` からブランチ名で引く（PR #934 の初回実運用で判明）
           for i in $(seq 1 30); do
-            status=$(supabase branches get "${{ steps.branch.outputs.name }}" \
-              --project-ref "$SUPABASE_MAIN_PROJECT_REF" -o json | jq -r '.status // empty')
+            status=$(supabase branches list \
+              --project-ref "$SUPABASE_MAIN_PROJECT_REF" -o json \
+              | jq -r --arg name "${{ steps.branch.outputs.name }}" \
+                'try ([.[] | select(.name == $name)][0].status) // empty')
             echo "Branch status: ${status:-unknown} (attempt $i)"
             case "$status" in
               ACTIVE_HEALTHY|MIGRATIONS_PASSED|FUNCTIONS_DEPLOYED) exit 0 ;;
@@ -165,6 +169,8 @@ jobs:
             esac
             sleep 20
           done
+          # 調査用にブランチ一覧の生出力を残してから失敗させる
+          supabase branches list --project-ref "$SUPABASE_MAIN_PROJECT_REF" -o json || true
           echo "Branch did not become healthy in time" >&2
           exit 1
 

--- a/docs/20260717_1200_Supabase_PreviewブランチCI設計.md
+++ b/docs/20260717_1200_Supabase_PreviewブランチCI設計.md
@@ -64,7 +64,8 @@ Supabase Branching（preview ブランチ）を PR のライフサイクルに�
 
 ## 制約・注意点
 
-- **初回実運用時に要確認**: `branches get -o env` の出力キーはワークフロー内で検証しており、想定と異なる場合は明示的に失敗する（Available keys がログに出る）。あわせて `branches get / delete` がブランチ名（ID ではなく）を受け付けること、ステータス文字列（`ACTIVE_HEALTHY` 等）が待機ループの想定と一致することも初回に確認する
+- **初回実運用時に要確認**: `branches get -o env` の出力キーはワークフロー内で検証しており、想定と異なる場合は明示的に失敗する（Available keys がログに出る）。`branches get / delete` がブランチ名（ID ではなく）を受け付けることは初回実運用（PR #934）で確認済み
+- **`branches get` の JSON に status は含まれない**: `branches get -o json` が返すのは接続情報のみ。ブランチの status（`ACTIVE_HEALTHY` 等）は `branches list -o json` からブランチ名で引く必要がある（初回実運用で待機ループが `unknown` のままタイムアウトした原因。修正済み）
 - **Google 認証は動かない**: ブランチ DB には `supabase config push`（Google OAuth のリダイレクト URL 等）を適用していないため、認証が必要な画面の検証は staging 共有の Preview と同様の制約が残る
 - **synchronize 時のレース**: push 直後は Vercel のビルドとマイグレーション適用が並行するため、ビルド完了直後の一瞬だけ新スキーマ未適用の可能性がある（リロードで解消）
 - **データは seed のみ**: ブランチ DB は本番/staging のデータを引き継がず、`supabase/seed.sql` で初期化される（`--with-data` オプションは将来検討）


### PR DESCRIPTION
## 概要

PR #934 での初回実運用で、`manage-preview-branch` の「Wait for branch to be ready」が `Branch status: unknown` のまま10分タイムアウトする問題の修正です（#929 のフォローアップ）。

### 原因
`supabase branches get -o json` が返すJSONは**接続情報のみで `status` フィールドを含まない**ため、`jq -r '.status // empty'` が常に空になり、ヘルスチェックが永遠に成立しなかった。

### 修正
- 待機ループのstatus取得を `supabase branches list -o json` からブランチ名で引く形に変更（statusを持つのはlist側のAPI）
- jq式は `try ... // empty` で、一覧が空・形式不一致でもエラーにせず `unknown` 扱いになるようにした
- タイムアウト時に `branches list` の生出力をログに残し、次回以降のデバッグを容易にした
- 設計doc（`docs/20260717_1200_Supabase_PreviewブランチCI設計.md`）の「初回実運用時に要確認」項を判明事項で更新

### 検証
- YAML構文チェック（PyYAML）
- jq式の単体確認: 空配列 → empty（`unknown` 表示）、該当ブランチあり → `ACTIVE_HEALTHY` を返すことを確認
- 実挙動はマージ後、PR #934 のsynchronize（またはRe-run）で確認する

なお `branches get` を存在チェック・削除・認証情報取得に使っている箇所は、PR #934 の実ログで正しく機能していることを確認済みのため変更していません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)