### PR TITLE
fix: previewブランチへのマイグレーション適用をpooler経由に変更

### DIFF
--- a/.github/workflows/supabase_preview.yml
+++ b/.github/workflows/supabase_preview.yml
@@ -182,7 +182,7 @@ jobs:
         run: |
           supabase branches get "${{ steps.branch.outputs.name }}" \
             --project-ref "$SUPABASE_MAIN_PROJECT_REF" -o env > branch.env
-          for key in SUPABASE_URL SUPABASE_ANON_KEY SUPABASE_SERVICE_ROLE_KEY POSTGRES_URL_NON_POOLING; do
+          for key in SUPABASE_URL SUPABASE_ANON_KEY SUPABASE_SERVICE_ROLE_KEY POSTGRES_URL; do
             if ! grep -q "^${key}=" branch.env; then
               echo "Missing ${key} in branch credentials. Available keys:" >&2
               cut -d= -f1 branch.env >&2
@@ -204,11 +204,13 @@ jobs:
           github.event.action != 'closed' && steps.changes.outputs.supabase == 'true' &&
           steps.ready.outputs.branching == 'true'
         run: |
+          # POSTGRES_URL_NON_POOLING（直接接続）は IPv6 必須で GitHub Actions の
+          # ランナーから到達できないため、IPv4 対応の pooler 経由（POSTGRES_URL）を使う
           if [ "${{ steps.create.outputs.created }}" = "true" ]; then
-            supabase db push --db-url "$BRANCH_POSTGRES_URL_NON_POOLING" \
+            supabase db push --db-url "$BRANCH_POSTGRES_URL" \
               --include-all --include-seed --yes
           else
-            supabase db push --db-url "$BRANCH_POSTGRES_URL_NON_POOLING" \
+            supabase db push --db-url "$BRANCH_POSTGRES_URL" \
               --include-all --yes
           fi
 

--- a/.github/workflows/supabase_preview.yml
+++ b/.github/workflows/supabase_preview.yml
@@ -151,10 +151,14 @@ jobs:
           github.event.action != 'closed' && steps.changes.outputs.supabase == 'true' &&
           steps.ready.outputs.branching == 'true'
         run: |
-          # 20秒間隔 × 30回 = 最大10分待つ（新規作成時のプロビジョニングを想定）
+          # 20秒間隔 × 30回 = 最大10分待つ（新規作成時のプロビジョニングを想定）。
+          # 注意: `branches get` の JSON は接続情報のみで status を含まないため、
+          # status は `branches list` からブランチ名で引く（PR #934 の初回実運用で判明）
           for i in $(seq 1 30); do
-            status=$(supabase branches get "${{ steps.branch.outputs.name }}" \
-              --project-ref "$SUPABASE_MAIN_PROJECT_REF" -o json | jq -r '.status // empty')
+            status=$(supabase branches list \
+              --project-ref "$SUPABASE_MAIN_PROJECT_REF" -o json \
+              | jq -r --arg name "${{ steps.branch.outputs.name }}" \
+                'try ([.[] | select(.name == $name)][0].status) // empty')
             echo "Branch status: ${status:-unknown} (attempt $i)"
             case "$status" in
               ACTIVE_HEALTHY|MIGRATIONS_PASSED|FUNCTIONS_DEPLOYED) exit 0 ;;
@@ -165,6 +169,8 @@ jobs:
             esac
             sleep 20
           done
+          # 調査用にブランチ一覧の生出力を残してから失敗させる
+          supabase branches list --project-ref "$SUPABASE_MAIN_PROJECT_REF" -o json || true
           echo "Branch did not become healthy in time" >&2
           exit 1
 

--- a/docs/20260717_1200_Supabase_PreviewブランチCI設計.md
+++ b/docs/20260717_1200_Supabase_PreviewブランチCI設計.md
@@ -66,6 +66,7 @@ Supabase Branching（preview ブランチ）を PR のライフサイクルに�
 
 - **初回実運用時に要確認**: `branches get -o env` の出力キーはワークフロー内で検証しており、想定と異なる場合は明示的に失敗する（Available keys がログに出る）。`branches get / delete` がブランチ名（ID ではなく）を受け付けることは初回実運用（PR #934）で確認済み
 - **`branches get` の JSON に status は含まれない**: `branches get -o json` が返すのは接続情報のみ。ブランチの status（`ACTIVE_HEALTHY` 等）は `branches list -o json` からブランチ名で引く必要がある（初回実運用で待機ループが `unknown` のままタイムアウトした原因。修正済み）
+- **マイグレーション適用は pooler 経由（`POSTGRES_URL`）**: 直接接続の `POSTGRES_URL_NON_POOLING` は IPv6 必須で GitHub Actions のランナーから到達できない（`network is unreachable` で失敗。初回実運用で判明し修正済み）
 - **Google 認証は動かない**: ブランチ DB には `supabase config push`（Google OAuth のリダイレクト URL 等）を適用していないため、認証が必要な画面の検証は staging 共有の Preview と同様の制約が残る
 - **synchronize 時のレース**: push 直後は Vercel のビルドとマイグレーション適用が並行するため、ビルド完了直後の一瞬だけ新スキーマ未適用の可能性がある（リロードで解消）
 - **データは seed のみ**: ブランチ DB は本番/staging のデータを引き継がず、`supabase/seed.sql` で初期化される（`--with-data` オプションは将来検討）

--- a/docs/20260717_1200_Supabase_PreviewブランチCI設計.md
+++ b/docs/20260717_1200_Supabase_PreviewブランチCI設計.md
@@ -64,7 +64,8 @@ Supabase Branching（preview ブランチ）を PR のライフサイクルに�
 
 ## 制約・注意点
 
-- **初回実運用時に要確認**: `branches get -o env` の出力キーはワークフロー内で検証しており、想定と異なる場合は明示的に失敗する（Available keys がログに出る）。あわせて `branches get / delete` がブランチ名（ID ではなく）を受け付けること、ステータス文字列（`ACTIVE_HEALTHY` 等）が待機ループの想定と一致することも初回に確認する
+- **初回実運用時に要確認**: `branches get -o env` の出力キーはワークフロー内で検証しており、想定と異なる場合は明示的に失敗する（Available keys がログに出る）。`branches get / delete` がブランチ名（ID ではなく）を受け付けることは初回実運用（PR #934）で確認済み
+- **`branches get` の JSON に status は含まれない**: `branches get -o json` が返すのは接続情報のみ。ブランチの status（`ACTIVE_HEALTHY` 等）は `branches list -o json` からブランチ名で引く必要がある（初回実運用で待機ループが `unknown` のままタイムアウトした原因。修正済み）
 - **Google 認証は動かない**: ブランチ DB には `supabase config push`（Google OAuth のリダイレクト URL 等）を適用していないため、認証が必要な画面の検証は staging 共有の Preview と同様の制約が残る
 - **synchronize 時のレース**: push 直後は Vercel のビルドとマイグレーション適用が並行するため、ビルド完了直後の一瞬だけ新スキーマ未適用の可能性がある（リロードで解消）
 - **データは seed のみ**: ブランチ DB は本番/staging のデータを引き継がず、`supabase/seed.sql` で初期化される（`--with-data` オプションは将来検討）


### PR DESCRIPTION
## 概要

#935 に続く Supabase preview ワークフローの初回実運用フォローアップ第2弾です。

PR #934 で status 待機（#935で修正）の次の段階まで進んだところ、`Apply migrations` が以下で失敗しました：

```
failed to connect to `host=db.<branch-ref>.supabase.co ...`: dial error (dial tcp [IPv6]:5432: connect: network is unreachable)
Your network does not support IPv6, which is required for direct connections to the database.
Retry with your project's IPv4 transaction pooler connection string via --db-url.
```

### 原因
`supabase db push --db-url` に **`POSTGRES_URL_NON_POOLING`（直接接続）** を渡していたが、直接接続はIPv6必須で、GitHub ActionsランナーはIPv6非対応。

### 修正
- `db push` の接続先を **`POSTGRES_URL`（IPv4対応のpooler経由）** に変更（CLIのエラーメッセージ自身が案内している対処）
- 認証情報検証の必須キーも `POSTGRES_URL_NON_POOLING` → `POSTGRES_URL` に変更（欠落時は従来どおりAvailable keysを出して明示的に失敗）
- 設計docの制約・注意点に追記

### 検証
- YAML構文チェック（PyYAML）
- 実挙動はマージ後、PR #934 のsynchronize/Re-runで確認する

🤖 Generated with [Claude Code](https://claude.com/claude-code)