### PR TITLE
難易度・ふりがな表示の利用状況をGAでトラッキング

### DIFF
--- a/web/src/components/header/header-client.test.tsx
+++ b/web/src/components/header/header-client.test.tsx
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { HeaderClient } from "./header-client";
+
+const sendGAEventMock = vi.hoisted(() => vi.fn());
+const usePathnameMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@next/third-parties/google", () => ({
+  sendGAEvent: sendGAEventMock,
+}));
+vi.mock("next/navigation", () => ({ usePathname: usePathnameMock }));
+vi.mock("next/image", () => ({
+  default: ({ alt }: { alt: string }) => <span role="img" aria-label={alt} />,
+}));
+vi.mock(
+  "@/features/bill-difficulty/client/components/difficulty-selector",
+  () => ({
+    DifficultySelector: () => null,
+  })
+);
+vi.mock(
+  "@/features/interview-session/client/components/interview-header-actions",
+  () => ({
+    InterviewHeaderActions: () => null,
+  })
+);
+vi.mock("./hamburger-menu", () => ({ HamburgerMenu: () => null }));
+
+beforeEach(() => {
+  sendGAEventMock.mockClear();
+  usePathnameMock.mockReturnValue("/");
+});
+
+describe("HeaderClient", () => {
+  it("マウント時に難易度設定の現在値をGAへ送る", () => {
+    render(<HeaderClient difficultyLevel="hard" />);
+
+    expect(sendGAEventMock).toHaveBeenCalledWith("event", "difficulty_state", {
+      level: "hard",
+    });
+  });
+
+  it("pathnameが変わると再度GAへ送る", () => {
+    const { rerender } = render(<HeaderClient difficultyLevel="normal" />);
+    expect(sendGAEventMock).toHaveBeenCalledTimes(1);
+
+    usePathnameMock.mockReturnValue("/bills/1");
+    rerender(<HeaderClient difficultyLevel="normal" />);
+
+    expect(sendGAEventMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/web/src/components/header/header-client.tsx
+++ b/web/src/components/header/header-client.tsx
@@ -6,6 +6,8 @@ import { usePathname } from "next/navigation";
 import { DifficultySelector } from "@/features/bill-difficulty/client/components/difficulty-selector";
 import type { DifficultyLevelEnum } from "@/features/bill-difficulty/shared/types";
 import { InterviewHeaderActions } from "@/features/interview-session/client/components/interview-header-actions";
+import { sendDifficultyStateEvent } from "@/lib/analytics/preference-state-events";
+import { useOnPageView } from "@/lib/analytics/use-on-page-view";
 import { isInterviewPage, isMainPage } from "@/lib/page-layout-utils";
 import { routes } from "@/lib/routes";
 import { HamburgerMenu } from "./hamburger-menu";
@@ -18,6 +20,12 @@ export function HeaderClient({ difficultyLevel }: HeaderClientProps) {
   const pathname = usePathname();
   const showDifficultySelector = isMainPage(pathname);
   const showInterviewActions = isInterviewPage(pathname);
+
+  // Headerは1ページに1つだけ常時マウントされるため、
+  // ここで難易度設定をページ表示のたびにGAへ送る
+  // (DifficultySelectorはmarkdown埋め込み等で複数箇所に
+  //  同時マウントされ得るため、送信元には適さない)
+  useOnPageView(() => sendDifficultyStateEvent(difficultyLevel));
 
   return (
     <header className="px-3 fixed top-4 left-0 right-0 z-40 max-w-[1440px] mx-auto">

--- a/web/src/features/bill-difficulty/client/components/difficulty-selector.tsx
+++ b/web/src/features/bill-difficulty/client/components/difficulty-selector.tsx
@@ -3,8 +3,6 @@
 import type { CSSProperties } from "react";
 import { useId, useState } from "react";
 import { Switch } from "@/components/ui/switch";
-import { sendDifficultyStateEvent } from "@/lib/analytics/preference-state-events";
-import { useOnPageView } from "@/lib/analytics/use-on-page-view";
 import { setDifficultyLevel } from "../../server/actions/set-difficulty-level";
 import type { DifficultyLevelEnum } from "../../shared/types";
 import {
@@ -34,11 +32,6 @@ export function DifficultySelector({
 
   // ページロード時にスクロール位置を復元
   useRestoreScrollFromBottom(maintainScrollFromBottom ?? false);
-
-  // 保存済み(サーバー確定)の難易度設定を、ページ表示のたびにGAへ送る。
-  // 操作直後の楽観的なselectedLevelではなくcurrentLevelを使うのは、
-  // setDifficultyLevelが失敗してロールバックされた値を送らないため。
-  useOnPageView(() => sendDifficultyStateEvent(currentLevel));
 
   const handleToggle = async (checked: boolean) => {
     const newLevel = checked ? "hard" : "normal";

--- a/web/src/features/bill-difficulty/client/components/difficulty-selector.tsx
+++ b/web/src/features/bill-difficulty/client/components/difficulty-selector.tsx
@@ -3,12 +3,14 @@
 import type { CSSProperties } from "react";
 import { useId, useState } from "react";
 import { Switch } from "@/components/ui/switch";
+import { sendDifficultyStateEvent } from "@/lib/analytics/preference-state-events";
+import { useOnPageView } from "@/lib/analytics/use-on-page-view";
 import { setDifficultyLevel } from "../../server/actions/set-difficulty-level";
+import type { DifficultyLevelEnum } from "../../shared/types";
 import {
   saveScrollDistanceFromBottom,
   useRestoreScrollFromBottom,
 } from "../hooks/use-scroll-from-bottom";
-import type { DifficultyLevelEnum } from "../../shared/types";
 
 interface DifficultySelectorProps {
   currentLevel: DifficultyLevelEnum;
@@ -32,6 +34,11 @@ export function DifficultySelector({
 
   // ページロード時にスクロール位置を復元
   useRestoreScrollFromBottom(maintainScrollFromBottom ?? false);
+
+  // 保存済み(サーバー確定)の難易度設定を、ページ表示のたびにGAへ送る。
+  // 操作直後の楽観的なselectedLevelではなくcurrentLevelを使うのは、
+  // setDifficultyLevelが失敗してロールバックされた値を送らないため。
+  useOnPageView(() => sendDifficultyStateEvent(currentLevel));
 
   const handleToggle = async (checked: boolean) => {
     const newLevel = checked ? "hard" : "normal";

--- a/web/src/lib/analytics/preference-state-events.ts
+++ b/web/src/lib/analytics/preference-state-events.ts
@@ -1,0 +1,14 @@
+"use client";
+
+import { sendGAEvent } from "@next/third-parties/google";
+import type { DifficultyLevelEnum } from "@/features/bill-difficulty/shared/types";
+
+/** 難易度表示の現在の設定を、ページ表示のたびにGAへ送る */
+export function sendDifficultyStateEvent(level: DifficultyLevelEnum) {
+  sendGAEvent("event", "difficulty_state", { level });
+}
+
+/** ふりがな表示の現在の設定を、ページ表示のたびにGAへ送る */
+export function sendFuriganaStateEvent(enabled: boolean) {
+  sendGAEvent("event", "furigana_state", { enabled });
+}

--- a/web/src/lib/analytics/use-on-page-view.test.ts
+++ b/web/src/lib/analytics/use-on-page-view.test.ts
@@ -1,0 +1,39 @@
+// @vitest-environment jsdom
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useOnPageView } from "./use-on-page-view";
+
+const usePathnameMock = vi.hoisted(() => vi.fn());
+
+vi.mock("next/navigation", () => ({ usePathname: usePathnameMock }));
+
+beforeEach(() => {
+  usePathnameMock.mockReturnValue("/bills/1");
+});
+
+describe("useOnPageView", () => {
+  it("マウント時にeffectを実行する", () => {
+    const effect = vi.fn();
+    renderHook(() => useOnPageView(effect));
+    expect(effect).toHaveBeenCalledTimes(1);
+  });
+
+  it("pathnameが変わると再度effectを実行する", () => {
+    const effect = vi.fn();
+    const { rerender } = renderHook(() => useOnPageView(effect));
+    expect(effect).toHaveBeenCalledTimes(1);
+
+    usePathnameMock.mockReturnValue("/bills/2");
+    rerender();
+    expect(effect).toHaveBeenCalledTimes(2);
+  });
+
+  it("pathnameが変わらなければeffectを再実行しない", () => {
+    const effect = vi.fn();
+    const { rerender } = renderHook(() => useOnPageView(effect));
+    expect(effect).toHaveBeenCalledTimes(1);
+
+    rerender();
+    expect(effect).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/lib/analytics/use-on-page-view.ts
+++ b/web/src/lib/analytics/use-on-page-view.ts
@@ -1,0 +1,13 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { useEffect } from "react";
+
+/** ページ表示のたびに(pathnameが変わるたびに)effectを実行する */
+export function useOnPageView(effect: () => void) {
+  const pathname = usePathname();
+  // biome-ignore lint/correctness/useExhaustiveDependencies: pathnameが変わるたびに再実行するため意図的に依存配列に含めている
+  useEffect(() => {
+    effect();
+  }, [pathname]);
+}

--- a/web/src/lib/rubyful/initializer.test.tsx
+++ b/web/src/lib/rubyful/initializer.test.tsx
@@ -1,0 +1,37 @@
+// @vitest-environment jsdom
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { RubyfulInitializer } from "./initializer";
+
+const sendGAEventMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@next/third-parties/google", () => ({
+  sendGAEvent: sendGAEventMock,
+}));
+vi.mock("next/script", () => ({
+  default: () => null,
+}));
+
+beforeEach(() => {
+  localStorage.clear();
+  sendGAEventMock.mockClear();
+});
+
+describe("RubyfulInitializer", () => {
+  it("マウント時にふりがな表示の現在値をGAへ送る", () => {
+    localStorage.setItem("rubyful-enabled", "true");
+    render(<RubyfulInitializer />);
+
+    expect(sendGAEventMock).toHaveBeenCalledWith("event", "furigana_state", {
+      enabled: true,
+    });
+  });
+
+  it("localStorage未設定時はfalseで送る", () => {
+    render(<RubyfulInitializer />);
+
+    expect(sendGAEventMock).toHaveBeenCalledWith("event", "furigana_state", {
+      enabled: false,
+    });
+  });
+});

--- a/web/src/lib/rubyful/initializer.tsx
+++ b/web/src/lib/rubyful/initializer.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import Script from "next/script";
+import { sendFuriganaStateEvent } from "@/lib/analytics/preference-state-events";
+import { useOnPageView } from "@/lib/analytics/use-on-page-view";
 import { rubyfulClient } from "./index";
 import "./styles.css";
 
@@ -18,6 +20,14 @@ declare global {
 }
 
 export function RubyfulInitializer() {
+  // レイアウトに常時マウントされるこのコンポーネントで、
+  // 現在のふりがな表示設定をページ表示のたびにGAへ送る
+  // (RubyToggleはPopoverContent内にありポップオーバーを
+  //  開くまでマウントされないため、送信元には適さない)
+  useOnPageView(() => {
+    sendFuriganaStateEvent(rubyfulClient.getIsEnabledFromStorage());
+  });
+
   return (
     <Script
       src="https://rubyful-v2.s3.ap-northeast-1.amazonaws.com/v2/rubyful.js?t=20250507022654"

--- a/web/src/lib/rubyful/use-ruby-toggle.test.ts
+++ b/web/src/lib/rubyful/use-ruby-toggle.test.ts
@@ -3,12 +3,6 @@ import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useRubyToggle } from "./use-ruby-toggle";
 
-const sendGAEventMock = vi.hoisted(() => vi.fn());
-
-vi.mock("@next/third-parties/google", () => ({
-  sendGAEvent: sendGAEventMock,
-}));
-
 describe("useRubyToggle", () => {
   const originalLocation = window.location;
 
@@ -18,7 +12,6 @@ describe("useRubyToggle", () => {
       writable: true,
     });
     localStorage.clear();
-    sendGAEventMock.mockClear();
   });
 
   afterEach(() => {
@@ -82,14 +75,5 @@ describe("useRubyToggle", () => {
     expect(localStorage.getItem("rubyful-enabled")).toBe("true");
 
     document.body.innerHTML = "";
-  });
-
-  it("マウント時にふりがな表示の現在値をGAへ送る", () => {
-    localStorage.setItem("rubyful-enabled", "true");
-    renderHook(() => useRubyToggle());
-
-    expect(sendGAEventMock).toHaveBeenCalledWith("event", "furigana_state", {
-      enabled: true,
-    });
   });
 });

--- a/web/src/lib/rubyful/use-ruby-toggle.test.ts
+++ b/web/src/lib/rubyful/use-ruby-toggle.test.ts
@@ -3,6 +3,12 @@ import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useRubyToggle } from "./use-ruby-toggle";
 
+const sendGAEventMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@next/third-parties/google", () => ({
+  sendGAEvent: sendGAEventMock,
+}));
+
 describe("useRubyToggle", () => {
   const originalLocation = window.location;
 
@@ -12,6 +18,7 @@ describe("useRubyToggle", () => {
       writable: true,
     });
     localStorage.clear();
+    sendGAEventMock.mockClear();
   });
 
   afterEach(() => {
@@ -75,5 +82,14 @@ describe("useRubyToggle", () => {
     expect(localStorage.getItem("rubyful-enabled")).toBe("true");
 
     document.body.innerHTML = "";
+  });
+
+  it("マウント時にふりがな表示の現在値をGAへ送る", () => {
+    localStorage.setItem("rubyful-enabled", "true");
+    renderHook(() => useRubyToggle());
+
+    expect(sendGAEventMock).toHaveBeenCalledWith("event", "furigana_state", {
+      enabled: true,
+    });
   });
 });

--- a/web/src/lib/rubyful/use-ruby-toggle.ts
+++ b/web/src/lib/rubyful/use-ruby-toggle.ts
@@ -1,4 +1,6 @@
 import { useEffect, useState } from "react";
+import { sendFuriganaStateEvent } from "@/lib/analytics/preference-state-events";
+import { useOnPageView } from "@/lib/analytics/use-on-page-view";
 import { rubyfulClient } from "./index";
 
 /**
@@ -11,6 +13,13 @@ export function useRubyToggle() {
     // LocalStorageから初期状態を取得
     setRubyEnabled(rubyfulClient.getIsEnabledFromStorage());
   }, []);
+
+  // 現在の設定をLocalStorageから直接読み、ページ表示のたびにGAへ送る
+  // (rubyEnabled stateではなくstorageを直接読むのは、マウント直後の
+  //  state未反映タイミングで古い値を送ってしまうのを避けるため)
+  useOnPageView(() => {
+    sendFuriganaStateEvent(rubyfulClient.getIsEnabledFromStorage());
+  });
 
   const handleRubyToggle = (checked: boolean) => {
     setRubyEnabled(checked);

--- a/web/src/lib/rubyful/use-ruby-toggle.ts
+++ b/web/src/lib/rubyful/use-ruby-toggle.ts
@@ -1,10 +1,12 @@
 import { useEffect, useState } from "react";
-import { sendFuriganaStateEvent } from "@/lib/analytics/preference-state-events";
-import { useOnPageView } from "@/lib/analytics/use-on-page-view";
 import { rubyfulClient } from "./index";
 
 /**
  * ルビ表示の切り替えロジックを管理するカスタムフック
+ *
+ * このフックは PopoverContent 内の RubyToggle からのみ使われ、
+ * ポップオーバーを開くまでマウントされない。ページ表示のたびに送るべき
+ * GAトラッキングは、常時マウントされる RubyfulInitializer 側で行う。
  */
 export function useRubyToggle() {
   const [rubyEnabled, setRubyEnabled] = useState(false);
@@ -13,13 +15,6 @@ export function useRubyToggle() {
     // LocalStorageから初期状態を取得
     setRubyEnabled(rubyfulClient.getIsEnabledFromStorage());
   }, []);
-
-  // 現在の設定をLocalStorageから直接読み、ページ表示のたびにGAへ送る
-  // (rubyEnabled stateではなくstorageを直接読むのは、マウント直後の
-  //  state未反映タイミングで古い値を送ってしまうのを避けるため)
-  useOnPageView(() => {
-    sendFuriganaStateEvent(rubyfulClient.getIsEnabledFromStorage());
-  });
 
   const handleRubyToggle = (checked: boolean) => {
     setRubyEnabled(checked);


### PR DESCRIPTION
## 概要

難易度表示（ふつう/難しい）とふりがな表示の現在の設定を、ページ表示のたびにGAへ送信する（Linear: GIKAI-393）。

## 主な内容

- `web/src/lib/analytics/use-on-page-view.ts`: pathname変化のたびにeffectを再実行する共通フック（新規）
- `web/src/lib/analytics/preference-state-events.ts`: 難易度・ふりがな設定をGAへ送るラッパー（新規）
- 送信元は「1ページに1つだけ常時マウントされる」`HeaderClient`（難易度）と`RubyfulInitializer`（ふりがな）。`DifficultySelector`・`useRubyToggle`自体はmarkdown埋め込みやPopover内など複数箇所・非常時マウントの箇所で再利用されるため、送信元には含めていない

## 検証記録

- `pnpm lint` ✅ / `pnpm typecheck` ✅ / `pnpm test` ✅（752/752。既知の環境要因エラー19〜20件は本diffと無関係、別issue化済み: GIKAI-394）
- ローカルで実機動作確認済み（`window.dataLayer`にイベントが正しいタイミング・値で記録されることを確認）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - ページ表示時に、選択中の難易度設定とふりがな表示設定が自動的に記録されるようになりました。
  - ページ移動時も最新の設定状態が正しく記録されます。

- **品質向上**
  - ページ移動や設定状態の記録に関する動作確認を追加し、安定性を高めました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->