### PR TITLE
7/30 15:55 本番反映

### DIFF
--- a/web/src/components/header/header-client.test.tsx
+++ b/web/src/components/header/header-client.test.tsx
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { HeaderClient } from "./header-client";
+
+const sendGAEventMock = vi.hoisted(() => vi.fn());
+const usePathnameMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@next/third-parties/google", () => ({
+  sendGAEvent: sendGAEventMock,
+}));
+vi.mock("next/navigation", () => ({ usePathname: usePathnameMock }));
+vi.mock("next/image", () => ({
+  default: ({ alt }: { alt: string }) => <span role="img" aria-label={alt} />,
+}));
+vi.mock(
+  "@/features/bill-difficulty/client/components/difficulty-selector",
+  () => ({
+    DifficultySelector: () => null,
+  })
+);
+vi.mock(
+  "@/features/interview-session/client/components/interview-header-actions",
+  () => ({
+    InterviewHeaderActions: () => null,
+  })
+);
+vi.mock("./hamburger-menu", () => ({ HamburgerMenu: () => null }));
+
+beforeEach(() => {
+  sendGAEventMock.mockClear();
+  usePathnameMock.mockReturnValue("/");
+});
+
+describe("HeaderClient", () => {
+  it("マウント時に難易度設定の現在値をGAへ送る", () => {
+    render(<HeaderClient difficultyLevel="hard" />);
+
+    expect(sendGAEventMock).toHaveBeenCalledWith("event", "difficulty_state", {
+      level: "hard",
+    });
+  });
+
+  it("pathnameが変わると再度GAへ送る", () => {
+    const { rerender } = render(<HeaderClient difficultyLevel="normal" />);
+    expect(sendGAEventMock).toHaveBeenCalledTimes(1);
+
+    usePathnameMock.mockReturnValue("/bills/1");
+    rerender(<HeaderClient difficultyLevel="normal" />);
+
+    expect(sendGAEventMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/web/src/components/header/header-client.tsx
+++ b/web/src/components/header/header-client.tsx
@@ -6,6 +6,8 @@ import { usePathname } from "next/navigation";
 import { DifficultySelector } from "@/features/bill-difficulty/client/components/difficulty-selector";
 import type { DifficultyLevelEnum } from "@/features/bill-difficulty/shared/types";
 import { InterviewHeaderActions } from "@/features/interview-session/client/components/interview-header-actions";
+import { sendDifficultyStateEvent } from "@/lib/analytics/preference-state-events";
+import { useOnPageView } from "@/lib/analytics/use-on-page-view";
 import { isInterviewPage, isMainPage } from "@/lib/page-layout-utils";
 import { routes } from "@/lib/routes";
 import { HamburgerMenu } from "./hamburger-menu";
@@ -18,6 +20,12 @@ export function HeaderClient({ difficultyLevel }: HeaderClientProps) {
   const pathname = usePathname();
   const showDifficultySelector = isMainPage(pathname);
   const showInterviewActions = isInterviewPage(pathname);
+
+  // Headerは1ページに1つだけ常時マウントされるため、
+  // ここで難易度設定をページ表示のたびにGAへ送る
+  // (DifficultySelectorはmarkdown埋め込み等で複数箇所に
+  //  同時マウントされ得るため、送信元には適さない)
+  useOnPageView(() => sendDifficultyStateEvent(difficultyLevel));
 
   return (
     <header className="px-3 fixed top-4 left-0 right-0 z-40 max-w-[1440px] mx-auto">

--- a/web/src/features/bill-difficulty/client/components/difficulty-selector.tsx
+++ b/web/src/features/bill-difficulty/client/components/difficulty-selector.tsx
@@ -4,11 +4,11 @@ import type { CSSProperties } from "react";
 import { useId, useState } from "react";
 import { Switch } from "@/components/ui/switch";
 import { setDifficultyLevel } from "../../server/actions/set-difficulty-level";
+import type { DifficultyLevelEnum } from "../../shared/types";
 import {
   saveScrollDistanceFromBottom,
   useRestoreScrollFromBottom,
 } from "../hooks/use-scroll-from-bottom";
-import type { DifficultyLevelEnum } from "../../shared/types";
 
 interface DifficultySelectorProps {
   currentLevel: DifficultyLevelEnum;

--- a/web/src/lib/analytics/preference-state-events.ts
+++ b/web/src/lib/analytics/preference-state-events.ts
@@ -1,0 +1,14 @@
+"use client";
+
+import { sendGAEvent } from "@next/third-parties/google";
+import type { DifficultyLevelEnum } from "@/features/bill-difficulty/shared/types";
+
+/** 難易度表示の現在の設定を、ページ表示のたびにGAへ送る */
+export function sendDifficultyStateEvent(level: DifficultyLevelEnum) {
+  sendGAEvent("event", "difficulty_state", { level });
+}
+
+/** ふりがな表示の現在の設定を、ページ表示のたびにGAへ送る */
+export function sendFuriganaStateEvent(enabled: boolean) {
+  sendGAEvent("event", "furigana_state", { enabled });
+}

--- a/web/src/lib/analytics/use-on-page-view.test.ts
+++ b/web/src/lib/analytics/use-on-page-view.test.ts
@@ -1,0 +1,39 @@
+// @vitest-environment jsdom
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useOnPageView } from "./use-on-page-view";
+
+const usePathnameMock = vi.hoisted(() => vi.fn());
+
+vi.mock("next/navigation", () => ({ usePathname: usePathnameMock }));
+
+beforeEach(() => {
+  usePathnameMock.mockReturnValue("/bills/1");
+});
+
+describe("useOnPageView", () => {
+  it("マウント時にeffectを実行する", () => {
+    const effect = vi.fn();
+    renderHook(() => useOnPageView(effect));
+    expect(effect).toHaveBeenCalledTimes(1);
+  });
+
+  it("pathnameが変わると再度effectを実行する", () => {
+    const effect = vi.fn();
+    const { rerender } = renderHook(() => useOnPageView(effect));
+    expect(effect).toHaveBeenCalledTimes(1);
+
+    usePathnameMock.mockReturnValue("/bills/2");
+    rerender();
+    expect(effect).toHaveBeenCalledTimes(2);
+  });
+
+  it("pathnameが変わらなければeffectを再実行しない", () => {
+    const effect = vi.fn();
+    const { rerender } = renderHook(() => useOnPageView(effect));
+    expect(effect).toHaveBeenCalledTimes(1);
+
+    rerender();
+    expect(effect).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/lib/analytics/use-on-page-view.ts
+++ b/web/src/lib/analytics/use-on-page-view.ts
@@ -1,0 +1,13 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { useEffect } from "react";
+
+/** ページ表示のたびに(pathnameが変わるたびに)effectを実行する */
+export function useOnPageView(effect: () => void) {
+  const pathname = usePathname();
+  // biome-ignore lint/correctness/useExhaustiveDependencies: pathnameが変わるたびに再実行するため意図的に依存配列に含めている
+  useEffect(() => {
+    effect();
+  }, [pathname]);
+}

--- a/web/src/lib/rubyful/initializer.test.tsx
+++ b/web/src/lib/rubyful/initializer.test.tsx
@@ -1,0 +1,37 @@
+// @vitest-environment jsdom
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { RubyfulInitializer } from "./initializer";
+
+const sendGAEventMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@next/third-parties/google", () => ({
+  sendGAEvent: sendGAEventMock,
+}));
+vi.mock("next/script", () => ({
+  default: () => null,
+}));
+
+beforeEach(() => {
+  localStorage.clear();
+  sendGAEventMock.mockClear();
+});
+
+describe("RubyfulInitializer", () => {
+  it("マウント時にふりがな表示の現在値をGAへ送る", () => {
+    localStorage.setItem("rubyful-enabled", "true");
+    render(<RubyfulInitializer />);
+
+    expect(sendGAEventMock).toHaveBeenCalledWith("event", "furigana_state", {
+      enabled: true,
+    });
+  });
+
+  it("localStorage未設定時はfalseで送る", () => {
+    render(<RubyfulInitializer />);
+
+    expect(sendGAEventMock).toHaveBeenCalledWith("event", "furigana_state", {
+      enabled: false,
+    });
+  });
+});

--- a/web/src/lib/rubyful/initializer.tsx
+++ b/web/src/lib/rubyful/initializer.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import Script from "next/script";
+import { sendFuriganaStateEvent } from "@/lib/analytics/preference-state-events";
+import { useOnPageView } from "@/lib/analytics/use-on-page-view";
 import { rubyfulClient } from "./index";
 import "./styles.css";
 
@@ -18,6 +20,14 @@ declare global {
 }
 
 export function RubyfulInitializer() {
+  // レイアウトに常時マウントされるこのコンポーネントで、
+  // 現在のふりがな表示設定をページ表示のたびにGAへ送る
+  // (RubyToggleはPopoverContent内にありポップオーバーを
+  //  開くまでマウントされないため、送信元には適さない)
+  useOnPageView(() => {
+    sendFuriganaStateEvent(rubyfulClient.getIsEnabledFromStorage());
+  });
+
   return (
     <Script
       src="https://rubyful-v2.s3.ap-northeast-1.amazonaws.com/v2/rubyful.js?t=20250507022654"

--- a/web/src/lib/rubyful/use-ruby-toggle.ts
+++ b/web/src/lib/rubyful/use-ruby-toggle.ts
@@ -3,6 +3,10 @@ import { rubyfulClient } from "./index";
 
 /**
  * ルビ表示の切り替えロジックを管理するカスタムフック
+ *
+ * このフックは PopoverContent 内の RubyToggle からのみ使われ、
+ * ポップオーバーを開くまでマウントされない。ページ表示のたびに送るべき
+ * GAトラッキングは、常時マウントされる RubyfulInitializer 側で行う。
  */
 export function useRubyToggle() {
   const [rubyEnabled, setRubyEnabled] = useState(false);


### PR DESCRIPTION
* Add GA state tracking for difficulty and furigana display toggles

Send the current difficulty level and furigana display setting to GA as state events on every page view (not just on toggle), so usage rate can be aggregated by the current setting rather than only the toggle action count.

* Fix GA state events to fire from single always-mounted components

Both events were firing from components that don't reliably mount once per page view:
- difficulty_state fired from DifficultySelector, which is also auto-injected into every bill's markdown content (DifficultyInfoCard), causing a duplicate send on every bill detail page. Moved to HeaderClient, which mounts exactly once per page.
- furigana_state fired from useRubyToggle, which is only used inside a Popover that isn't mounted until opened, so most page views never sent it. Moved to RubyfulInitializer, which is always mounted.

Found via Codex review and a team-mirai reviewer-persona panel review.