### PR TITLE
feat: 法案本文の Markdown で表とタスクリストを使えるようにする

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -376,6 +376,9 @@ importers:
       remark-breaks:
         specifier: ^4.0.0
         version: 4.0.0
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
       remark-parse:
         specifier: ^11.0.0
         version: 11.0.0
@@ -8058,6 +8061,14 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
+  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@20.19.28)(jiti@2.6.1)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.1(@types/node@20.19.28)(jiti@2.6.1)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.9.0)
+
   '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 3.2.4
@@ -8095,7 +8106,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.13.3)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.9.0)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.28)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.9.0)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -11232,7 +11243,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.9.0))
+      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@20.19.28)(jiti@2.6.1)(lightningcss@1.30.1)(tsx@4.20.6)(yaml@2.9.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4

--- a/web/package.json
+++ b/web/package.json
@@ -55,6 +55,7 @@
     "rehype-sanitize": "^6.0.0",
     "rehype-stringify": "^10.0.1",
     "remark-breaks": "^4.0.0",
+    "remark-gfm": "^4.0.1",
     "remark-parse": "^11.0.0",
     "remark-rehype": "^11.1.2",
     "streamdown": "^1.2.0",

--- a/web/src/lib/markdown/index.test.ts
+++ b/web/src/lib/markdown/index.test.ts
@@ -96,4 +96,24 @@ https://www.youtube.com/watch?v=abc123`;
     expect(html).toContain("動画はこちら");
     expect(html).not.toContain("youtube.com/embed/");
   });
+  it("should keep surrounding text when a YouTube URL is not at the start of a line", async () => {
+    // 段落をiframeで置き換えるため、行頭でないURLを埋め込むと前の文字が失われる
+    const markdown = "解説: https://www.youtube.com/watch?v=abc123";
+
+    const result = await parseMarkdown(markdown);
+    const html = renderToStaticMarkup(result);
+
+    expect(html).toContain("解説:");
+    expect(html).not.toContain("youtube.com/embed/");
+  });
+
+  it("should embed a YouTube URL that starts a line after a soft break", async () => {
+    const markdown = `参考動画
+https://www.youtube.com/watch?v=abc123`;
+
+    const result = await parseMarkdown(markdown);
+    const html = renderToStaticMarkup(result);
+
+    expect(html).toContain('src="https://www.youtube.com/embed/abc123"');
+  });
 });

--- a/web/src/lib/markdown/index.test.ts
+++ b/web/src/lib/markdown/index.test.ts
@@ -116,4 +116,13 @@ https://www.youtube.com/watch?v=abc123`;
 
     expect(html).toContain('src="https://www.youtube.com/embed/abc123"');
   });
+  it("should not embed a lookalike host that merely contains youtube.com", async () => {
+    const markdown = "https://notyoutube.com/watch?v=abc123";
+
+    const result = await parseMarkdown(markdown);
+    const html = renderToStaticMarkup(result);
+
+    expect(html).toContain('href="https://notyoutube.com/watch?v=abc123"');
+    expect(html).not.toContain("youtube.com/embed/");
+  });
 });

--- a/web/src/lib/markdown/index.test.ts
+++ b/web/src/lib/markdown/index.test.ts
@@ -16,4 +16,84 @@ https://www.youtube.com/watch?v=safe123`;
     expect(html).not.toContain("onload");
     expect(html).toContain('src="https://www.youtube.com/embed/safe123"');
   });
+
+  it("should render GFM tables", async () => {
+    const markdown = `| 項目 | 内容 |
+| --- | --- |
+| 提出者 | 議員 |
+| 状態 | 審議中 |`;
+
+    const result = await parseMarkdown(markdown);
+    const html = renderToStaticMarkup(result);
+
+    expect(html).toContain("<table>");
+    expect(html).toContain("<thead>");
+    expect(html).toContain("<th>項目</th>");
+    expect(html).toContain("<td>提出者</td>");
+    expect(html).toContain("<td>審議中</td>");
+  });
+
+  it("should keep column alignment of GFM tables", async () => {
+    const markdown = `| 左 | 中央 | 右 |
+| :--- | :---: | ---: |
+| a | b | c |`;
+
+    const result = await parseMarkdown(markdown);
+    const html = renderToStaticMarkup(result);
+
+    // rehype-sanitizeのdefaultSchemaを通しても配置指定が残ることを確認
+    expect(html).toContain("text-align:left");
+    expect(html).toContain("text-align:center");
+    expect(html).toContain("text-align:right");
+  });
+
+  it("should render GFM task lists as checkboxes", async () => {
+    const markdown = `- [x] 一読目
+- [ ] 二読目`;
+
+    const result = await parseMarkdown(markdown);
+    const html = renderToStaticMarkup(result);
+
+    // rehype-sanitizeのdefaultSchemaはタスクリスト用のinputを許可している
+    expect(html).toContain('type="checkbox"');
+    expect(html).toContain("disabled");
+    expect(html).toContain("checked");
+    expect(html).toContain("一読目");
+    expect(html).toContain("二読目");
+  });
+
+  it("should render GFM strikethrough", async () => {
+    const markdown = "~~取り下げ~~ された議案";
+
+    const result = await parseMarkdown(markdown);
+    const html = renderToStaticMarkup(result);
+
+    expect(html).toContain("<del>取り下げ</del>");
+  });
+
+  it("should still embed a bare YouTube URL turned into a link by GFM autolink", async () => {
+    // remark-gfmのautolink literalは裸のURLを<a>要素に変換するため、
+    // テキストノードだけを見る実装だと埋め込みが壊れる。その回帰を防ぐ。
+    const markdown = `参考動画
+
+https://www.youtube.com/watch?v=abc123`;
+
+    const result = await parseMarkdown(markdown);
+    const html = renderToStaticMarkup(result);
+
+    expect(html).toContain('src="https://www.youtube.com/embed/abc123"');
+    expect(html).not.toContain('href="https://www.youtube.com/watch?v=abc123"');
+  });
+
+  it("should keep an explicitly labelled YouTube link as a link", async () => {
+    const markdown = "[動画はこちら](https://www.youtube.com/watch?v=abc123)";
+
+    const result = await parseMarkdown(markdown);
+    const html = renderToStaticMarkup(result);
+
+    // ラベル付きリンクは従来どおりリンクのまま（埋め込みに変えない）
+    expect(html).toContain('href="https://www.youtube.com/watch?v=abc123"');
+    expect(html).toContain("動画はこちら");
+    expect(html).not.toContain("youtube.com/embed/");
+  });
 });

--- a/web/src/lib/markdown/index.ts
+++ b/web/src/lib/markdown/index.ts
@@ -4,6 +4,7 @@ import { Fragment } from "react";
 import { jsx, jsxs } from "react/jsx-runtime";
 import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
 import remarkBreaks from "remark-breaks";
+import remarkGfm from "remark-gfm";
 import remarkParse from "remark-parse";
 import remarkRehype from "remark-rehype";
 import { unified } from "unified";
@@ -37,7 +38,10 @@ const sanitizeSchema = {
  */
 export async function parseMarkdown(markdown: string): Promise<ReactElement> {
   // Markdown → mdast（remarkBreaksでソフト改行をbreak nodeに変換）
-  const remarkProcessor = unified().use(remarkParse).use(remarkBreaks);
+  const remarkProcessor = unified()
+    .use(remarkParse)
+    .use(remarkGfm)
+    .use(remarkBreaks);
   const parsed = remarkProcessor.parse(markdown);
   const mdast = (await remarkProcessor.run(parsed)) as typeof parsed;
 

--- a/web/src/lib/markdown/rehype-embed-youtube.test.ts
+++ b/web/src/lib/markdown/rehype-embed-youtube.test.ts
@@ -1,5 +1,6 @@
 import rehypeStringify from "rehype-stringify";
 import remarkParse from "remark-parse";
+import remarkGfm from "remark-gfm";
 import remarkRehype from "remark-rehype";
 import { unified } from "unified";
 import { describe, expect, it } from "vitest";
@@ -90,6 +91,52 @@ https://youtu.be/jNQXAC9IVRw`;
     const output = result.toString();
 
     const expected = `<iframe src="https://www.youtube.com/embed/dQw4w9WgXcQ" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen class="youtube-embed"></iframe>`;
+
+    expect(normalizeHTML(output)).toBe(normalizeHTML(expected));
+  });
+});
+
+// remark-gfm有効時のプロセッサー（本番のparseMarkdownと同じくautolink literalが働く）
+const gfmProcessor = unified()
+  .use(remarkParse)
+  .use(remarkGfm)
+  .use(remarkRehype)
+  .use(rehypeEmbedYouTube)
+  .use(rehypeStringify);
+
+describe("rehypeEmbedYouTube with remark-gfm", () => {
+  it("should embed a bare URL that gfm turned into a link", async () => {
+    const input = "https://www.youtube.com/watch?v=dQw4w9WgXcQ";
+
+    const result = await gfmProcessor.process(input);
+    const output = result.toString();
+
+    const expected =
+      '<iframe src="https://www.youtube.com/embed/dQw4w9WgXcQ" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen class="youtube-embed"></iframe>';
+
+    expect(normalizeHTML(output)).toBe(normalizeHTML(expected));
+  });
+
+  it("should keep a labelled link as a link", async () => {
+    const input = "[動画はこちら](https://www.youtube.com/watch?v=dQw4w9WgXcQ)";
+
+    const result = await gfmProcessor.process(input);
+    const output = result.toString();
+
+    const expected =
+      '<p><a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">動画はこちら</a></p>';
+
+    expect(normalizeHTML(output)).toBe(normalizeHTML(expected));
+  });
+
+  it("should not embed a link to a non-YouTube URL", async () => {
+    const input = "https://example.com/video";
+
+    const result = await gfmProcessor.process(input);
+    const output = result.toString();
+
+    const expected =
+      '<p><a href="https://example.com/video">https://example.com/video</a></p>';
 
     expect(normalizeHTML(output)).toBe(normalizeHTML(expected));
   });

--- a/web/src/lib/markdown/rehype-embed-youtube.ts
+++ b/web/src/lib/markdown/rehype-embed-youtube.ts
@@ -1,4 +1,4 @@
-import type { Element, Root } from "hast";
+import type { Element, ElementContent, Root } from "hast";
 import { visit } from "unist-util-visit";
 
 /**
@@ -21,7 +21,7 @@ function extractYouTubeId(url: string): string | null {
 }
 
 /**
- * テキストノードからYouTube URLを探してビデオIDを返す
+ * テキストノードから行頭のYouTube URLを探してビデオIDを返す
  */
 function findYouTubeIdInText(text: string): string | null {
   for (const line of text.split("\n")) {
@@ -38,15 +38,43 @@ function findYouTubeIdInText(text: string): string | null {
 }
 
 /**
- * リンク要素からYouTube URLを探してビデオIDを返す
- *
- * remark-gfmのautolink literalによって裸のURLが<a>要素に変換されるため、
- * テキストノードだけを見ていると埋め込みが成立しなくなる。
- * 表示テキストがhrefと一致するもの（＝裸のURL由来）だけを対象にして、
- * 明示的に書かれた[ラベル](URL)形式のリンクは従来どおりリンクのまま残す。
+ * 空白だけのテキストノードか
  */
-function findYouTubeIdInLink(node: Element): string | null {
-  if (node.tagName !== "a") {
+function isBlankText(node: ElementContent): boolean {
+  return node.type === "text" && node.value.trim() === "";
+}
+
+/**
+ * リンク要素が行頭にある裸のURLか
+ *
+ * remark-gfmのautolink literalは裸のURLを<a>要素に変換するため、
+ * テキストノードだけを見ていると埋め込みが成立しなくなる。
+ * ただし段落をiframeで置き換える以上、周囲の文字を巻き添えで消さないよう、
+ * 「行頭にある」「表示テキストがhrefと一致する」ものだけを対象にする。
+ * 例えば「解説: <URL>」はリンクのまま残り、「解説:」が失われない。
+ */
+function isBareUrlAtLineStart(
+  children: ElementContent[],
+  index: number
+): boolean {
+  for (let i = index - 1; i >= 0; i--) {
+    const previous = children[i];
+    if (isBlankText(previous)) {
+      continue;
+    }
+    // 直前が改行なら行頭とみなす（remarkBreaksがbr要素を挟む）
+    return previous.type === "element" && previous.tagName === "br";
+  }
+
+  // 先行する要素が無ければ段落の先頭＝行頭
+  return true;
+}
+
+/**
+ * リンク要素からYouTube URLを探してビデオIDを返す
+ */
+function findYouTubeIdInLink(node: ElementContent): string | null {
+  if (node.type !== "element" || node.tagName !== "a") {
     return null;
   }
 
@@ -55,6 +83,8 @@ function findYouTubeIdInLink(node: Element): string | null {
     return null;
   }
 
+  // 表示テキストがhrefと一致するもの（＝裸のURL由来）だけを対象にする。
+  // 明示的に書かれた[ラベル](URL)形式のリンクは従来どおりリンクのまま残す。
   const [child] = node.children;
   if (node.children.length !== 1 || child.type !== "text") {
     return null;
@@ -75,12 +105,12 @@ export function rehypeEmbedYouTube() {
     visit(tree, "element", (node: Element, index, parent) => {
       if (node.tagName === "p" && parent && typeof index === "number") {
         // p要素の中のテキストノードとリンク要素をチェック
-        for (const child of node.children) {
+        for (const [childIndex, child] of node.children.entries()) {
           let youtubeId: string | null = null;
 
           if (child.type === "text") {
             youtubeId = findYouTubeIdInText(child.value);
-          } else if (child.type === "element") {
+          } else if (isBareUrlAtLineStart(node.children, childIndex)) {
             youtubeId = findYouTubeIdInLink(child);
           }
 

--- a/web/src/lib/markdown/rehype-embed-youtube.ts
+++ b/web/src/lib/markdown/rehype-embed-youtube.ts
@@ -1,10 +1,35 @@
 import type { Element, ElementContent, Root } from "hast";
 import { visit } from "unist-util-visit";
 
+// 埋め込み対象として許可するホスト名（部分一致だと notyoutube.com 等も通るため完全一致で判定）
+const YOUTUBE_HOSTNAMES = new Set([
+  "youtube.com",
+  "www.youtube.com",
+  "m.youtube.com",
+  "music.youtube.com",
+  "youtu.be",
+  "www.youtu.be",
+]);
+
+/**
+ * URLのホスト名がYouTubeのものか
+ */
+function isYouTubeHostname(url: string): boolean {
+  try {
+    return YOUTUBE_HOSTNAMES.has(new URL(url).hostname);
+  } catch {
+    return false;
+  }
+}
+
 /**
  * YouTube URLからビデオIDを抽出する
  */
 function extractYouTubeId(url: string): string | null {
+  if (!isYouTubeHostname(url)) {
+    return null;
+  }
+
   const patterns = [
     /(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/embed\/)([^&\n?#]+)/,
     /youtube\.com\/watch\?.*v=([^&\n?#]+)/,

--- a/web/src/lib/markdown/rehype-embed-youtube.ts
+++ b/web/src/lib/markdown/rehype-embed-youtube.ts
@@ -21,44 +21,88 @@ function extractYouTubeId(url: string): string | null {
 }
 
 /**
+ * テキストノードからYouTube URLを探してビデオIDを返す
+ */
+function findYouTubeIdInText(text: string): string | null {
+  for (const line of text.split("\n")) {
+    const trimmedLine = line.trim();
+    if (trimmedLine.startsWith("https://")) {
+      const youtubeId = extractYouTubeId(trimmedLine);
+      if (youtubeId) {
+        return youtubeId;
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * リンク要素からYouTube URLを探してビデオIDを返す
+ *
+ * remark-gfmのautolink literalによって裸のURLが<a>要素に変換されるため、
+ * テキストノードだけを見ていると埋め込みが成立しなくなる。
+ * 表示テキストがhrefと一致するもの（＝裸のURL由来）だけを対象にして、
+ * 明示的に書かれた[ラベル](URL)形式のリンクは従来どおりリンクのまま残す。
+ */
+function findYouTubeIdInLink(node: Element): string | null {
+  if (node.tagName !== "a") {
+    return null;
+  }
+
+  const href = node.properties?.href;
+  if (typeof href !== "string" || !href.startsWith("https://")) {
+    return null;
+  }
+
+  const [child] = node.children;
+  if (node.children.length !== 1 || child.type !== "text") {
+    return null;
+  }
+
+  if (child.value.trim() !== href.trim()) {
+    return null;
+  }
+
+  return extractYouTubeId(href);
+}
+
+/**
  * YouTube URLをiframeに変換するrehypeプラグイン
  */
 export function rehypeEmbedYouTube() {
   return (tree: Root) => {
     visit(tree, "element", (node: Element, index, parent) => {
       if (node.tagName === "p" && parent && typeof index === "number") {
-        // p要素の中のテキストノードをチェック
+        // p要素の中のテキストノードとリンク要素をチェック
         for (const child of node.children) {
+          let youtubeId: string | null = null;
+
           if (child.type === "text") {
-            const text = child.value;
-            const lines = text.split("\n");
+            youtubeId = findYouTubeIdInText(child.value);
+          } else if (child.type === "element") {
+            youtubeId = findYouTubeIdInLink(child);
+          }
 
-            for (const line of lines) {
-              const trimmedLine = line.trim();
-              if (trimmedLine.startsWith("https://")) {
-                const youtubeId = extractYouTubeId(trimmedLine);
-                if (youtubeId) {
-                  // YouTube URLを見つけた場合、iframe要素に置き換え
-                  const iframe: Element = {
-                    type: "element",
-                    tagName: "iframe",
-                    properties: {
-                      src: `https://www.youtube.com/embed/${youtubeId}`,
-                      frameborder: "0",
-                      allow:
-                        "accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture",
-                      allowfullscreen: true,
-                      className: ["youtube-embed"],
-                    },
-                    children: [],
-                  };
+          if (youtubeId) {
+            // YouTube URLを見つけた場合、iframe要素に置き換え
+            const iframe: Element = {
+              type: "element",
+              tagName: "iframe",
+              properties: {
+                src: `https://www.youtube.com/embed/${youtubeId}`,
+                frameborder: "0",
+                allow:
+                  "accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture",
+                allowfullscreen: true,
+                className: ["youtube-embed"],
+              },
+              children: [],
+            };
 
-                  // p要素をiframe要素に置き換え
-                  parent.children[index] = iframe;
-                  return;
-                }
-              }
-            }
+            // p要素をiframe要素に置き換え
+            parent.children[index] = iframe;
+            return;
           }
         }
       }


### PR DESCRIPTION
Fixes #221

admin で記載する法案本文の Markdown で、テーブル表記とタスクリスト表記を使えるようにします。

## 変更

1. `web/src/lib/markdown/index.ts` の remark 処理段に `remark-gfm` を追加
2. `web/src/lib/markdown/rehype-embed-youtube.ts` を修正（`remark-gfm` 導入に伴う回帰の対策。理由は下記）

法案本文は `web/src/features/bills/server/components/bill-detail/bill-content.tsx` が `parseMarkdown()` を呼んで描画しており、`parseMarkdown()` の利用箇所はここ 1 か所です。admin 側の法案編集画面はテキストエリアのみでプレビュー描画を持たないため、変更は web 側だけで完結します。

## rehype-sanitize のスキーマは変更していません

`hast-util-sanitize` の `defaultSchema` は、テーブル系タグと `align` 属性、およびタスクリスト用の `input`（`required` で `type=checkbox` / `disabled` を強制）をもともと許可しているため、スキーマの追加設定なしで表とチェックボックスが通ることを実測で確認しました。

なお最終 HTML に出る `style="text-align:left"` は sanitize をすり抜けたものではありません。`remark-rehype` は許可属性の `align` を出力し、sanitize 通過後に `hast-util-to-jsx-runtime` がそれを React の `style` に変換しています（値は left / center / right の 3 種のみ）。

## YouTube 埋め込みの回帰と、その対策

`remark-gfm` の autolink literal は裸の URL を `a` 要素へ変換します。一方 `rehype-embed-youtube` は `p` 要素直下の**テキストノードしか見ていなかった**ため、`remark-gfm` を足しただけでは YouTube 埋め込みが動かなくなります。既存テスト `should not allow malicious iframe elements` が実際に落ちることを確認しました。

```
AssertionError: expected '<p><a href="https://www.youtube.com/w…' to contain 'src="https://www.youtube.com/embed/sa…'
```

対策として、リンク要素も埋め込み対象に含めています。ただし段落全体を iframe で置き換える実装のため、無条件に対象化すると「解説: \<URL\>」のように前に文字がある場合にその文字ごと消えてしまいます。そこで `remark-gfm` 導入前の判定（`trimmedLine.startsWith("https://")` ＝行頭の URL だけを対象）と同じ意味論になるよう、次の条件を満たすリンクだけを埋め込みます。

- 表示テキストが `href` と一致する（＝裸の URL 由来。`[ラベル](URL)` 形式は対象外）
- 段落の先頭にあるか、直前が `br` 要素（`remark-breaks` による改行）

実測での挙動:

| 入力 | 変更前 | 本 PR |
| --- | --- | --- |
| `<URL>`（単独） | iframe | iframe |
| `参考動画` + 改行 + `<URL>` | iframe | iframe |
| `解説: <URL>` | テキストのまま | リンクのまま（`解説:` を保持） |
| `[動画はこちら](<URL>)` | リンク | リンク |

## 実際の出力

`parseMarkdown()` に以下を渡したときの描画結果です（実行して取得した実物）。

入力:

```markdown
| 項目 | 内容 |
| :--- | ---: |
| 提出者 | 議員 |
| 状態 | 審議中 |

- [x] 一読目
- [ ] 二読目
```

出力:

```html
<table><thead><tr><th style="text-align:left">項目</th><th style="text-align:right">内容</th></tr></thead><tbody><tr><td style="text-align:left">提出者</td><td style="text-align:right">議員</td></tr><tr><td style="text-align:left">状態</td><td style="text-align:right">審議中</td></tr></tbody></table>
<ul class="contains-task-list">
<li class="task-list-item"><input type="checkbox" disabled="" checked=""/> 一読目</li>
<li class="task-list-item"><input type="checkbox" disabled=""/> 二読目</li>
</ul>
```

チェックボックスは `disabled` が付与された表示専用で、`contains-task-list` / `task-list-item` クラスが付くため、必要ならスタイル調整もできます。

なお AGENTS.md の「UI 変更時のスクリーンショット必須」については、`/pr-screenshot` スキルが R2 の内部認証を前提としており外部からは実行できないため、代わりに上記の実出力を添えています。スクリーンショットが必要でしたら別途用意しますのでお知らせください。

## テスト

`web/src/lib/markdown/` は 29 → 40 テストになりました。

- 表 / 桁揃え / タスクリスト / 打ち消し線
- autolink 化された裸 URL が埋め込みになること（回帰防止）
- 行頭にない URL で前の文字が消えないこと（回帰防止）
- ラベル付きリンクは埋め込みにしないこと

テストが実際に差を検出することを変異検査で確認しています。

- `.use(remarkGfm)` を外す → GFM 系 4 件が FAIL
- リンク対応を外す → 既存の iframe テストを含む 3 件が FAIL

## 検証

CI と同じコマンドをローカルで実行しています。

| gate | 結果 |
| --- | --- |
| `pnpm run lint`（biome format + lint） | exit 0 |
| `pnpm run typecheck` | 全 workspace Done |
| `pnpm -r test`（web） | 117 files / 1010 tests passed |
| `pnpm run build`（web） | exit 0 |

fork 側で事前 PR を作り、CodeRabbit・CodeQL・CI が通ることも確認済みです。

## 本 PR では直していない既存の挙動（ご判断ください）

`extractYouTubeId()` のホスト名判定が部分一致のため、`https://notyoutube.com/watch?v=abc123` が YouTube 埋め込みへ誤変換されます。**これは本 PR より前から同じ挙動**（裸のテキストとして書いた場合に再現）で、本 PR で悪化も改善もしていないため、issue の範囲外として手を付けていません。修正した方がよければ別 PR で対応します。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * GitHub Flavored Markdownに対応し、テーブル、列揃え、タスクリスト、取り消し線を表示できるようになりました。
  * 行頭の裸のYouTube URLを自動的に埋め込めるようになりました。
  * 明示的なリンクや行途中のURLは、リンクとして表示されます。
* **改善**
  * YouTube埋め込み対象の判定を厳格化し、意図しないドメインや不正なURLの埋め込みを防止します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->