### PR TITLE
AIインタビューのデフォルトモデルをClaude Haiku 4.5に変更

### DIFF
--- a/admin/src/features/interview-reports/server/services/batch-moderation-scoring.ts
+++ b/admin/src/features/interview-reports/server/services/batch-moderation-scoring.ts
@@ -3,7 +3,7 @@ import "server-only";
 import { buildModerationPrompt } from "@mirai-gikai/shared/moderation/build-prompt";
 import { moderationResultSchema } from "@mirai-gikai/shared/moderation/schemas";
 import { generateObject } from "ai";
-import { DEFAULT_INTERVIEW_CHAT_MODEL } from "@/lib/ai/models";
+import { DEFAULT_MODERATION_MODEL } from "@/lib/ai/models";
 import { parseOpinions } from "../../shared/utils/parse-opinions";
 import {
   findInterviewMessagesBySessionId,
@@ -46,7 +46,7 @@ export async function runSingleModerationScoring(
   });
 
   const { object } = await generateObject({
-    model: DEFAULT_INTERVIEW_CHAT_MODEL,
+    model: DEFAULT_MODERATION_MODEL,
     schema: moderationResultSchema,
     prompt,
   });

--- a/admin/src/features/interview-reports/server/services/content-richness-scoring.ts
+++ b/admin/src/features/interview-reports/server/services/content-richness-scoring.ts
@@ -3,7 +3,7 @@ import "server-only";
 import { buildContentRichnessPrompt } from "@mirai-gikai/shared/content-richness/build-prompt";
 import { contentRichnessResultSchema } from "@mirai-gikai/shared/content-richness/schemas";
 import { generateObject } from "ai";
-import { DEFAULT_INTERVIEW_CHAT_MODEL } from "@/lib/ai/models";
+import { DEFAULT_CONTENT_RICHNESS_MODEL } from "@/lib/ai/models";
 import { parseOpinions } from "../../shared/utils/parse-opinions";
 import {
   findInterviewMessagesBySessionId,
@@ -35,7 +35,7 @@ export async function runSingleContentRichnessScoring(
   });
 
   const { object } = await generateObject({
-    model: DEFAULT_INTERVIEW_CHAT_MODEL,
+    model: DEFAULT_CONTENT_RICHNESS_MODEL,
     schema: contentRichnessResultSchema,
     prompt,
   });

--- a/admin/src/lib/ai/models.ts
+++ b/admin/src/lib/ai/models.ts
@@ -1,5 +1,7 @@
 export {
   AI_MODELS,
   type AiModel,
+  DEFAULT_CONTENT_RICHNESS_MODEL,
   DEFAULT_INTERVIEW_CHAT_MODEL,
+  DEFAULT_MODERATION_MODEL,
 } from "@mirai-gikai/shared/ai/models";

--- a/packages/shared/src/ai/models.ts
+++ b/packages/shared/src/ai/models.ts
@@ -43,4 +43,10 @@ export function isKnownModel(model: string): model is AiModel {
 }
 
 /** インタビューチャットのデフォルトモデル */
-export const DEFAULT_INTERVIEW_CHAT_MODEL = AI_MODELS.gpt5_2;
+export const DEFAULT_INTERVIEW_CHAT_MODEL = AI_MODELS.claude_haiku_4_5;
+/** モデレーション評価のデフォルトモデル */
+export const DEFAULT_MODERATION_MODEL = AI_MODELS.gpt5_2;
+/** コンテンツ充実度評価のデフォルトモデル */
+export const DEFAULT_CONTENT_RICHNESS_MODEL = AI_MODELS.gpt5_2;
+/** 意見バックフィル（再抽出）のデフォルトモデル */
+export const DEFAULT_OPINION_BACKFILL_MODEL = AI_MODELS.gpt5_2;

--- a/packages/topic-analysis-core/src/shared/constants.ts
+++ b/packages/topic-analysis-core/src/shared/constants.ts
@@ -1,4 +1,4 @@
-import { AI_MODELS, DEFAULT_INTERVIEW_CHAT_MODEL } from "@mirai-gikai/shared/ai/models";
+import { AI_MODELS, DEFAULT_OPINION_BACKFILL_MODEL } from "@mirai-gikai/shared/ai/models";
 
 // ── 分析（analyze）──
 /** Phase1 一次抽出のバッチサイズ（§A.3: 30〜50件/バッチ） */
@@ -37,5 +37,5 @@ export const STALE_RUNNING_MS = 70 * 60_000;
 export const OPINION_BACKFILL_CHUNK_SIZE = 30;
 /** チャンク内のLLM並列実行数 */
 export const OPINION_BACKFILL_CONCURRENCY = 30;
-/** 再抽出に使うモデル（本番のレポート生成と同じ） */
-export const OPINION_BACKFILL_MODEL = DEFAULT_INTERVIEW_CHAT_MODEL;
+/** 再抽出に使うモデル */
+export const OPINION_BACKFILL_MODEL = DEFAULT_OPINION_BACKFILL_MODEL;

--- a/web/src/features/interview-session/server/services/evaluate-moderation-score.ts
+++ b/web/src/features/interview-session/server/services/evaluate-moderation-score.ts
@@ -1,7 +1,7 @@
 import "server-only";
 
 import { generateObject, type LanguageModel } from "ai";
-import { DEFAULT_INTERVIEW_CHAT_MODEL } from "@/lib/ai/models";
+import { DEFAULT_MODERATION_MODEL } from "@/lib/ai/models";
 import { moderationResultSchema } from "@mirai-gikai/shared/moderation/schemas";
 import { buildModerationPrompt } from "@mirai-gikai/shared/moderation/build-prompt";
 import {
@@ -35,7 +35,7 @@ export async function evaluateModerationScore(
   deps?: ModerationDeps
 ): Promise<ModerationOutput> {
   const prompt = buildModerationPrompt(input);
-  const model = deps?.model ?? DEFAULT_INTERVIEW_CHAT_MODEL;
+  const model = deps?.model ?? DEFAULT_MODERATION_MODEL;
 
   const { object } = await generateObject({
     model,

--- a/web/src/lib/ai/models.ts
+++ b/web/src/lib/ai/models.ts
@@ -2,4 +2,5 @@ export {
   AI_MODELS,
   type AiModel,
   DEFAULT_INTERVIEW_CHAT_MODEL,
+  DEFAULT_MODERATION_MODEL,
 } from "@mirai-gikai/shared/ai/models";


### PR DESCRIPTION
## 概要

Resolves #375

Linear GIKAI-375 での比較検証（GPT-5.2 / Haiku 4.5 / GPT-5.6 Terra / Sonnet 4.6、定量・定性の両面）の結果、モデル間でインタビューの質に有意差はなく、コスト重視でClaude Haiku 4.5への切り替えが妥当という結論になったため対応しました。

Slackでのやり取りで、モデル切り替えのスコープをインタビュー本体のみに限定し、これを機にタスクごとに独立したデフォルトモデル定数を持たせる方針になったため、あわせて対応しています。

## 変更内容

- `packages/shared/src/ai/models.ts`
  - `DEFAULT_INTERVIEW_CHAT_MODEL` を `AI_MODELS.gpt5_2` → `AI_MODELS.claude_haiku_4_5` に変更（実際のユーザー向けAIインタビューのみに影響）
  - `DEFAULT_MODERATION_MODEL` / `DEFAULT_CONTENT_RICHNESS_MODEL` / `DEFAULT_OPINION_BACKFILL_MODEL` を新設し、いずれも現行の `AI_MODELS.gpt5_2` を維持（挙動は変えず、インタビューのデフォルトから切り離しただけ）
- モデレーション評価・content richness評価・topic-analysisのバックフィルの呼び出し元を、それぞれ新設した専用定数を参照するように変更（従来は全て `DEFAULT_INTERVIEW_CHAT_MODEL` を共有参照していたため、インタビュー側の変更が意図せず波及していた）

## スコープ外

- 管理画面のインタビューシミュレーション機能（`admin/src/features/interview-simulation/shared/constants.ts` の `DEFAULT_INTERVIEWER_MODEL` 等）は対象外。今回のLinear検証はこの機能を使って行われたものですが、実際のユーザー向けインタビューのデフォルトとは独立した定数のため変更していません。
- 既に `interview_configs.chat_model` で個別モデル指定済みのbill/インタビュー設定には影響しません（未設定＝NULLのもののみ今回のデフォルト変更が反映されます）。

## テスト

- `pnpm lint` — 変更ファイルにエラーなし
- `pnpm typecheck` — admin / web / packages/shared / packages/topic-analysis-core すべて通過
- `pnpm --filter web test` — 752 tests passed
- `pnpm --filter admin test` — 497 tests passed
- `pnpm --filter @mirai-gikai/shared test` / `pnpm --filter @mirai-gikai/topic-analysis-core test` — 全テストpassed
- `pnpm build` — web/adminともにコンパイルは成功。ただしadmin側のフルビルド（`next build`のページデータ収集）はこのローカル環境に `.env` の実行時Supabase設定がなく最後まで検証できませんでした（`/api/auth/callback` が環境変数未設定でエラー）。今回の変更（AIモデル定数の差し替え）とは無関係な環境変数依存箇所のため、CI側での確認をお願いします。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **機能改善**
  * モデレーション評価とコンテンツ充実度評価で、それぞれ専用の既定AIモデルを使用するようになりました。
  * 意見分析のバックフィル処理にも専用の既定AIモデルを適用しました。
  * インタビューチャットの既定AIモデルを更新しました。
* **安定性向上**
  * 個別にモデルを指定した場合は、引き続き指定モデルが優先されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->