### PR TITLE
インタビューチャットのローダー選択を純粋関数に切り出して認可分岐のテストを追加

### DIFF
--- a/web/src/features/interview-session/server/services/handle-interview-chat-request.ts
+++ b/web/src/features/interview-session/server/services/handle-interview-chat-request.ts
@@ -17,6 +17,7 @@ import {
 } from "@/features/chat/server/services/cost-tracker";
 import { ChatError, ChatErrorCode } from "@/features/chat/shared/types/errors";
 import { getInterviewConfig } from "@/features/interview-config/server/loaders/get-interview-config";
+import { resolveInterviewChatLoaders } from "@/features/interview-session/shared/utils/resolve-interview-chat-loaders";
 import type { InterviewConfig } from "@/features/interview-config/server/loaders/get-interview-config-admin";
 import { getInterviewConfigAdmin } from "@/features/interview-config/server/loaders/get-interview-config-admin";
 import { getInterviewQuestions } from "@/features/interview-config/server/loaders/get-interview-questions";
@@ -93,19 +94,23 @@ export async function handleInterviewChatRequest({
   // プレビュートークンが有効な場合のみ、非公開の議案・インタビュー設定も読める
   // 管理者用ローダーを使う。トークンがない/無効なリクエスト（＝一般公開の経路）は
   // 公開ローダーに限定し、未公開議案の本文や非公開設定へ到達させない。
-  // トークン検証は指定された場合のみ実行し、公開経路のTTFBには影響させない。
-  const isPreviewAuthorized = previewToken
-    ? await validatePreviewToken(billId, previewToken)
-    : false;
+  const loaders = await resolveInterviewChatLoaders({
+    billId,
+    previewToken,
+    validate: validatePreviewToken,
+    adminLoaders: {
+      getInterviewConfig: getInterviewConfigAdmin,
+      getBill: getBillByIdAdmin,
+    },
+    publicLoaders: { getInterviewConfig, getBill: getBillById },
+  });
 
   // TTFB短縮のため、互いに依存しないDBアクセスは並列実行する。
   // 日次コスト制限チェック（fail-closed: エラー時もリクエストをブロック）と
   // インタビュー設定・法案情報の取得（テスト時はdeps経由でNext.js依存をバイパス）
   const getInterviewConfigFn =
-    deps?.getInterviewConfig ??
-    (isPreviewAuthorized ? getInterviewConfigAdmin : getInterviewConfig);
-  const getBillFn =
-    deps?.getBill ?? (isPreviewAuthorized ? getBillByIdAdmin : getBillById);
+    deps?.getInterviewConfig ?? loaders.getInterviewConfig;
+  const getBillFn = deps?.getBill ?? loaders.getBill;
   const [isWithinLimit, interviewConfig, bill] = await Promise.all([
     isWithinDailyCostLimit(userId, env.chat.dailyUserCostLimitUsd),
     getInterviewConfigFn(billId),

--- a/web/src/features/interview-session/shared/utils/resolve-interview-chat-loaders.test.ts
+++ b/web/src/features/interview-session/shared/utils/resolve-interview-chat-loaders.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import {
+  type InterviewChatLoaders,
+  resolveInterviewChatLoaders,
+} from "./resolve-interview-chat-loaders";
+
+const adminLoaders: InterviewChatLoaders<string, string> = {
+  getInterviewConfig: async () => "admin-config",
+  getBill: async () => "admin-bill",
+};
+
+const publicLoaders: InterviewChatLoaders<string, string> = {
+  getInterviewConfig: async () => "public-config",
+  getBill: async () => "public-bill",
+};
+
+/** 呼び出し引数を記録する検証関数のフェイク */
+function createValidator(result: boolean) {
+  const calls: Array<{ billId: string; token: string }> = [];
+  return {
+    calls,
+    validate: async (billId: string, token: string) => {
+      calls.push({ billId, token });
+      return result;
+    },
+  };
+}
+
+describe("resolveInterviewChatLoaders", () => {
+  it("有効なプレビュートークンの場合は管理者用ローダーを返す", async () => {
+    const { validate, calls } = createValidator(true);
+
+    const loaders = await resolveInterviewChatLoaders({
+      billId: "bill-1",
+      previewToken: "valid-token",
+      validate,
+      adminLoaders,
+      publicLoaders,
+    });
+
+    expect(await loaders.getInterviewConfig("bill-1")).toBe("admin-config");
+    expect(await loaders.getBill("bill-1")).toBe("admin-bill");
+    expect(calls).toEqual([{ billId: "bill-1", token: "valid-token" }]);
+  });
+
+  it("無効なプレビュートークンの場合は公開ローダーを返す", async () => {
+    const { validate, calls } = createValidator(false);
+
+    const loaders = await resolveInterviewChatLoaders({
+      billId: "bill-1",
+      previewToken: "invalid-token",
+      validate,
+      adminLoaders,
+      publicLoaders,
+    });
+
+    expect(await loaders.getInterviewConfig("bill-1")).toBe("public-config");
+    expect(await loaders.getBill("bill-1")).toBe("public-bill");
+    expect(calls).toEqual([{ billId: "bill-1", token: "invalid-token" }]);
+  });
+
+  it("プレビュートークン未指定の場合は検証せずに公開ローダーを返す", async () => {
+    const { validate, calls } = createValidator(true);
+
+    const loaders = await resolveInterviewChatLoaders({
+      billId: "bill-1",
+      previewToken: undefined,
+      validate,
+      adminLoaders,
+      publicLoaders,
+    });
+
+    expect(await loaders.getInterviewConfig("bill-1")).toBe("public-config");
+    expect(await loaders.getBill("bill-1")).toBe("public-bill");
+    expect(calls).toEqual([]);
+  });
+
+  it("空文字のプレビュートークンは検証せずに公開ローダーを返す", async () => {
+    const { validate, calls } = createValidator(true);
+
+    const loaders = await resolveInterviewChatLoaders({
+      billId: "bill-1",
+      previewToken: "",
+      validate,
+      adminLoaders,
+      publicLoaders,
+    });
+
+    expect(await loaders.getInterviewConfig("bill-1")).toBe("public-config");
+    expect(calls).toEqual([]);
+  });
+});

--- a/web/src/features/interview-session/shared/utils/resolve-interview-chat-loaders.ts
+++ b/web/src/features/interview-session/shared/utils/resolve-interview-chat-loaders.ts
@@ -1,0 +1,37 @@
+/** 議案・インタビュー設定の取得関数の組 */
+export type InterviewChatLoaders<TConfig, TBill> = {
+  getInterviewConfig: (billId: string) => Promise<TConfig>;
+  getBill: (billId: string) => Promise<TBill>;
+};
+
+type ResolveInterviewChatLoadersParams<TConfig, TBill> = {
+  billId: string;
+  previewToken: string | undefined;
+  validate: (billId: string, token: string) => Promise<boolean>;
+  adminLoaders: InterviewChatLoaders<TConfig, TBill>;
+  publicLoaders: InterviewChatLoaders<TConfig, TBill>;
+};
+
+/**
+ * プレビュートークンの検証結果に応じて、使用するローダーの組を決定する。
+ *
+ * 管理者用ローダーは未公開議案や非公開インタビュー設定も読めるため、
+ * 有効なプレビュートークンが提示された場合に限り選択する。
+ * トークンが指定されていない場合は検証自体を行わない（公開経路の
+ * TTFB に検証コストを乗せないため）。
+ */
+export async function resolveInterviewChatLoaders<TConfig, TBill>({
+  billId,
+  previewToken,
+  validate,
+  adminLoaders,
+  publicLoaders,
+}: ResolveInterviewChatLoadersParams<TConfig, TBill>): Promise<
+  InterviewChatLoaders<TConfig, TBill>
+> {
+  const isPreviewAuthorized = previewToken
+    ? await validate(billId, previewToken)
+    : false;
+
+  return isPreviewAuthorized ? adminLoaders : publicLoaders;
+}


### PR DESCRIPTION
## 概要

#942 の CodeRabbit レビュー指摘（Major）への対応です。#942 のマージ後に指摘へ対応したため、別 PR として切り出しています。

インタビューチャットにおける「プレビュートークンが有効な場合のみ管理者用ローダーを使う」という認可分岐に、回帰テストがありませんでした。

## 課題

`handleInterviewChatRequest` では、ローダーの選択が次の形になっていました。

```ts
const getInterviewConfigFn =
  deps?.getInterviewConfig ??
  (isPreviewAuthorized ? getInterviewConfigAdmin : getInterviewConfig);
```

テスト時は `deps` を注入するため `??` の左辺が採用され、**分岐そのものが評価されません**。そのためサービス経由では認可分岐を検証できませんでした。

## 変更内容

判定ロジックを純粋関数として `web/src/features/interview-session/shared/utils/resolve-interview-chat-loaders.ts` に切り出し、同階層にテストを追加します。

- `resolveInterviewChatLoaders` は、プレビュートークンの検証結果に応じて管理者用／公開のローダーの組を返します。
- 検証関数は引数で受け取るため、外部依存なしにテストできます。
- サービス側は `deps` による上書きの優先順位を含め、**従来の挙動を維持**しています（トークン検証の呼び出しタイミングも変更していません）。

## テスト観点

`resolve-interview-chat-loaders.test.ts` で以下を検証します。

| ケース | 期待 |
| --- | --- |
| 有効なトークン | 管理者用ローダーを返す（検証関数が billId とトークンで呼ばれる） |
| 無効なトークン | 公開ローダーを返す |
| トークン未指定 | 検証関数を呼ばずに公開ローダーを返す |
| 空文字のトークン | 検証関数を呼ばずに公開ローダーを返す |

## 実行したテスト

- `pnpm lint` — pass
- `pnpm typecheck` — pass
- `pnpm build` — pass
- `pnpm test` — 全パッケージ pass（shared 92 / topic-analysis-core 79 / admin 505 / web 792）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * プレビュー時の認証状態に応じて、適切な設定や法案情報を取得できるようになりました。
  * プレビュー用トークンが有効な場合はプレビュー向け情報を、未指定または無効な場合は公開向け情報を表示します。
  * テスト環境では、指定された検証用設定を引き続き優先します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->