### PR TITLE
「もう一度新たに回答する」で古い未完了セッションが再開される問題を修正

### DIFF
--- a/web/src/features/interview-session/server/loaders/get-interview-session.integration.test.ts
+++ b/web/src/features/interview-session/server/loaders/get-interview-session.integration.test.ts
@@ -84,6 +84,63 @@ describe("getInterviewSession 統合テスト", () => {
     expect(session).toBeNull();
   });
 
+  it("完了済みセッションより古い未完了セッションが残っていてもnullを返す", async () => {
+    // 途中で離脱した古いセッションをアーカイブせずに残したまま、
+    // それより新しいセッションを完了済みにする。
+    // LP は最新の未アーカイブセッション（完了済み）を見て
+    // 「もう一度新たに回答する」を表示するため、ここで古い未完了セッションを
+    // 拾ってしまうと過去の途中経過から再開されてしまう。
+    await adminClient
+      .from("interview_sessions")
+      .update({ created_at: new Date(Date.now() - 60_000).toISOString() })
+      .eq("id", sessionId);
+
+    const { data: completedSession } = await adminClient
+      .from("interview_sessions")
+      .insert({
+        interview_config_id: interviewConfigId,
+        user_id: testUser.id,
+        completed_at: new Date().toISOString(),
+      })
+      .select("id")
+      .single();
+
+    const session = await getInterviewSession(interviewConfigId, {
+      getUser: createGetUser(testUser.id),
+    });
+
+    expect(session).toBeNull();
+    expect(completedSession?.id).not.toBe(sessionId);
+  });
+
+  it("最新の未アーカイブセッションが未完了なら再開対象として返す", async () => {
+    // 完了済みセッションが過去に存在しても、その後に開始された
+    // 未完了セッションは再開できる必要がある。
+    await adminClient
+      .from("interview_sessions")
+      .update({
+        completed_at: new Date().toISOString(),
+        created_at: new Date(Date.now() - 60_000).toISOString(),
+      })
+      .eq("id", sessionId);
+
+    const { data: activeSession } = await adminClient
+      .from("interview_sessions")
+      .insert({
+        interview_config_id: interviewConfigId,
+        user_id: testUser.id,
+      })
+      .select("id")
+      .single();
+
+    const session = await getInterviewSession(interviewConfigId, {
+      getUser: createGetUser(testUser.id),
+    });
+
+    expect(session?.id).toBe(activeSession?.id);
+    expect(session?.completed_at).toBeNull();
+  });
+
   it("別ユーザーのセッションはnullを返す", async () => {
     const otherUser = await createTestUser();
     try {

--- a/web/src/features/interview-session/server/repositories/interview-session-repository.ts
+++ b/web/src/features/interview-session/server/repositories/interview-session-repository.ts
@@ -15,6 +15,11 @@ import type {
 
 /**
  * アクティブ（未完了・未アーカイブ）なインタビューセッションを取得
+ *
+ * 判定対象は「最新の未アーカイブセッション」のみで、それが完了済みなら null を返す。
+ * 完了済みセッションを飛び越えて古い未完了セッションを拾うと、LP の
+ * findLatestNonArchivedSession（最新の未アーカイブセッション）による表示と食い違い、
+ * 「もう一度新たに回答する」を押したのに過去の途中経過から再開されてしまう。
  */
 export async function findActiveInterviewSession(
   interviewConfigId: string,
@@ -26,7 +31,6 @@ export async function findActiveInterviewSession(
     .select("*")
     .eq("interview_config_id", interviewConfigId)
     .eq("user_id", userId)
-    .is("completed_at", null)
     .is("archived_at", null)
     .order("created_at", { ascending: false })
     .limit(1)
@@ -36,6 +40,10 @@ export async function findActiveInterviewSession(
     throw new Error(
       `Failed to fetch active interview session: ${error.message}`
     );
+  }
+
+  if (!data || data.completed_at !== null) {
+    return null;
   }
 
   return data;


### PR DESCRIPTION
## 概要

AIインタビューのLPで「もう一度新たに回答する」を押しても、新規インタビューが始まらず過去の途中経過から再開されてしまう場合がある問題を修正します。

## 原因

セッションの状態判定に、LP側とチャット側で**食い違い**がありました。どちらも `created_at DESC LIMIT 1` ですが、絞り込み条件が異なります。

| 関数 | 条件 | 用途 |
| --- | --- | --- |
| `findLatestNonArchivedSession` | `archived_at IS NULL` | LPのボタン表示（`getLatestInterviewSession`） |
| `findActiveInterviewSession` | `archived_at IS NULL` **かつ** `completed_at IS NULL` | チャットの再開判定（`getInterviewSession` / `initializeInterviewChat`） |

LP は「最新の未アーカイブセッション」を見るため、それが完了済みなら「もう一度新たに回答する」を表示します（`interview-action-buttons.tsx:31`）。

一方チャット側は完了済みを条件から除外するため、**完了済みセッションを飛び越えて、それより古い未完了セッションを拾ってしまいます**。その結果 `findInterviewMessagesBySessionId` が当時のメッセージ履歴を読み込み、「続きから」の状態で表示されます。

なお `NewInterviewButton` は既存セッションをアーカイブせず遷移するだけ（`new-interview-button.tsx:23-27`）なので、途中離脱した未完了セッションが残っていると上記の状態になります。

## 変更内容

`findActiveInterviewSession` の判定対象を「最新の未アーカイブセッション」のみに変更し、それが完了済みなら `null` を返すようにしました。これにより LP の表示判定と完全に一致します。

- 最新の未アーカイブが未完了 → そのセッションを返す（再開）
- 最新の未アーカイブが完了済み → `null`（新規セッションを作成）
- 未アーカイブなし → `null`（新規セッションを作成）

古い未完了セッションはアーカイブせずそのまま残しますが、再開対象にはならなくなります。

呼び出し元は `getInterviewSession`（チャットAPI）と `initializeInterviewChat`（チャットページ）の2箇所のみで、どちらも「ユーザーが今いるセッション」を求める用途のため、この変更で意図が揃います。

## テスト

`get-interview-session.integration.test.ts` に統合テストを2件追加しました（ローカルSupabaseに実接続）。

- **完了済みセッションより古い未完了セッションが残っていても `null` を返す** — 本件の回帰テスト
- **最新の未アーカイブセッションが未完了なら再開対象として返す** — 過剰修正の防止

前者が修正前の実装で確実に失敗することを確認済みです。

```
× 完了済みセッションより古い未完了セッションが残っていてもnullを返す
AssertionError: expected { …(10) } to be null
```

## 実行したテスト

- `pnpm lint` — pass
- `pnpm typecheck` — pass
- `pnpm build` — pass
- `pnpm test` — 全パッケージ pass（shared 92 / topic-analysis-core 79 / admin 505 / web 788）
- `pnpm test:integration` — supabase 187 / mcp 65 / web 152、いずれも pass

## 補足

実機での再現は行っておらず、コードとDBの状態からの診断にもとづく修正です。上記の状態（完了済みより古い未完了セッションが残る）がどの操作経路で発生したかまでは特定できていませんが、どの経路で発生した場合でもこの修正で解消されます。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 面接セッションの再開時、完了済みセッションより古い未完了セッションが誤って選択される問題を修正しました。
  * 過去に完了したセッションが存在する場合でも、最新の未完了セッションを正しく再開できるようになりました。


<!-- end of auto-generated comment: release notes by coderabbit.ai -->