### PR TITLE
オープンデータAPIに議案一覧・詳細とチームみらいの賛否取得を追加

### DIFF
--- a/supabase/migrations/20260809000000_add_bills_open_data_pagination_index.sql
+++ b/supabase/migrations/20260809000000_add_bills_open_data_pagination_index.sql
@@ -1,0 +1,4 @@
+-- オープンデータAPIの議案一覧が使うキーセットページネーション
+-- （publish_status = 'published' かつ created_at DESC, id DESC）用のインデックス
+create index if not exists idx_bills_publish_status_created_at_id
+  on bills (publish_status, created_at desc, id desc);

--- a/web/public/openapi/open-data-api.json
+++ b/web/public/openapi/open-data-api.json
@@ -2,13 +2,23 @@
   "openapi": "3.1.0",
   "info": {
     "title": "みらい議会オープンデータAPI",
-    "version": "1.0.0",
-    "description": "みらい議会のAIインタビューを通じて取得した回答データのうち、回答者本人が公開に同意し、二次利用を許諾したものをオープンデータとして取得できるAPIです。\n\n- データはクリエイティブ・コモンズ 表示 4.0 国際ライセンス（CC BY 4.0）の下で提供されます\n- 利用には[みらい議会AIインタビューデータ利用規約](/developers/interview-data-terms)への同意が必要です。同意の表明として、すべてのリクエストに `agreeToTerms=true` を付与してください\n- APIキーの発行や事前登録は不要ですが、レートリミットがあります\n  - IPあたり毎分30リクエスト、API全体で毎分300リクエスト\n  - 超過時は 429 を返し、`Retry-After` ヘッダーで再試行までの秒数を示します\n- 成果物には利用規約第4条に基づく出典表示を行ってください\n\n  ```text\n  # 表示例\n  データ出典：「みらい議会AIインタビュー（チームみらい）」\n  提供元URL：https://gikai.team-mir.ai/\n  規約URL：https://gikai.team-mir.ai/developers/interview-data-terms\n  ライセンス：CC BY 4.0（https://creativecommons.org/licenses/by/4.0/deed.ja）\n  ```\n\n### 提供されるデータの範囲\n\n- 回答者本人が公開に同意し、二次利用（オープンデータとしての第三者提供）を許諾したインタビューのみ\n- 公開中の議案に紐づくもののみ\n- 議案あたりの公開レポート数が一定数以上ある議案のみ（少数回答の議案は回答者保護のため除外されます）\n\n回答者が公開設定を変更した場合、そのデータは以降のレスポンスに含まれなくなります。データセットを継続的に利用する場合は、提供対象から除外されたデータを利用し続けないことを推奨します。"
+    "version": "1.1.0",
+    "description": "みらい議会のデータをプログラムから取得できるオープンデータAPIです。\n\nAPIキーの発行や事前登録は不要ですが、レートリミットがあります。\n\n- IPあたり毎分30リクエスト、API全体で毎分300リクエスト\n- 超過時は 429 を返し、`Retry-After` ヘッダーで再試行までの秒数を示します\n\n### AIインタビューデータAPI\n\nみらい議会のAIインタビューを通じて取得した回答データのうち、回答者本人が公開に同意し、二次利用を許諾したものを取得できます。\n\n- データはクリエイティブ・コモンズ 表示 4.0 国際ライセンス（CC BY 4.0）の下で提供されます\n- 利用には[みらい議会AIインタビューデータ利用規約](/developers/interview-data-terms)への同意が必要です。同意の表明として、すべてのリクエストに `agreeToTerms=true` を付与してください\n- 成果物には利用規約第4条に基づく出典表示を行ってください\n\n  ```text\n  # 表示例\n  データ出典：「みらい議会AIインタビュー（チームみらい）」\n  提供元URL：https://gikai.team-mir.ai/\n  規約URL：https://gikai.team-mir.ai/developers/interview-data-terms\n  ライセンス：CC BY 4.0（https://creativecommons.org/licenses/by/4.0/deed.ja）\n  ```\n\n#### 提供されるデータの範囲\n\n- 回答者本人が公開に同意し、二次利用（オープンデータとしての第三者提供）を許諾したインタビューのみ\n- 公開中の議案に紐づくもののみ\n- 議案あたりの公開レポート数が一定数以上ある議案のみ（少数回答の議案は回答者保護のため除外されます）\n\n回答者が公開設定を変更した場合、そのデータは以降のレスポンスに含まれなくなります。データセットを継続的に利用する場合は、提供対象から除外されたデータを利用し続けないことを推奨します。\n\n### 議案データAPI\n\nみらい議会で公開中の議案の一覧・詳細と、議案に対するチームみらいの賛否を取得できます。\n\n- 公開中の議案のみが対象です。議案が非公開になった場合、そのデータは以降のレスポンスに含まれなくなります\n- `difficulty` パラメータで解説コンテンツの難易度（`normal`: 中学生レベル / `hard`: 専門用語を含む詳細な内容）を選択できます"
   },
   "servers": [
     {
       "url": "https://gikai.team-mir.ai",
       "description": "ベースURL"
+    }
+  ],
+  "tags": [
+    {
+      "name": "AIインタビューデータ",
+      "description": "AIインタビューの回答データ"
+    },
+    {
+      "name": "議案データ",
+      "description": "公開中の議案とチームみらいの賛否"
     }
   ],
   "paths": {
@@ -17,6 +27,7 @@
         "summary": "インタビューデータの取得",
         "description": "二次利用許諾済みの公開インタビューデータを新しい順に返します。`nextCursor` を次のリクエストの `cursor` に指定することで全件を取得できます。",
         "operationId": "listOpenDataInterviews",
+        "tags": ["AIインタビューデータ"],
         "parameters": [
           {
             "name": "agreeToTerms",
@@ -28,27 +39,8 @@
               "enum": ["true"]
             }
           },
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "description": "1ページあたりの取得件数（1〜100）。",
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "maximum": 100,
-              "default": 20
-            }
-          },
-          {
-            "name": "cursor",
-            "in": "query",
-            "required": false,
-            "description": "ページネーション用カーソル。前のレスポンスの `nextCursor` をそのまま指定します。",
-            "schema": {
-              "type": "string"
-            }
-          }
+          { "$ref": "#/components/parameters/Limit" },
+          { "$ref": "#/components/parameters/Cursor" }
         ],
         "responses": {
           "200": {
@@ -90,33 +82,153 @@
               }
             }
           },
-          "429": {
-            "description": "レートリミット超過。`Retry-After` ヘッダで再試行までの秒数を案内します。",
-            "headers": {
-              "Retry-After": {
-                "description": "再試行までの秒数",
-                "schema": { "type": "integer" }
+          "429": { "$ref": "#/components/responses/TooManyRequests" },
+          "500": { "$ref": "#/components/responses/InternalServerError" }
+        }
+      }
+    },
+    "/api/open-data/bills": {
+      "get": {
+        "summary": "議案一覧の取得",
+        "description": "公開中の議案を新しい順（作成日時の降順）に返します。各議案には難易度別の解説（タイトル・概要）、チームみらいの賛否、タグが含まれます。`nextCursor` を次のリクエストの `cursor` に指定することで全件を取得できます。",
+        "operationId": "listOpenDataBills",
+        "tags": ["議案データ"],
+        "parameters": [
+          { "$ref": "#/components/parameters/Limit" },
+          { "$ref": "#/components/parameters/Cursor" },
+          { "$ref": "#/components/parameters/Difficulty" }
+        ],
+        "responses": {
+          "200": {
+            "description": "取得成功",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/OpenDataBillsResponse" }
               }
-            },
+            }
+          },
+          "400": {
+            "description": "パラメータ不正（limit の範囲外・cursor の形式不正・difficulty の不正値）",
             "content": {
               "application/json": {
                 "schema": { "$ref": "#/components/schemas/ErrorResponse" }
               }
             }
           },
-          "500": {
-            "description": "サーバーエラー",
+          "429": { "$ref": "#/components/responses/TooManyRequests" },
+          "500": { "$ref": "#/components/responses/InternalServerError" }
+        }
+      }
+    },
+    "/api/open-data/bills/{billId}": {
+      "get": {
+        "summary": "議案詳細の取得",
+        "description": "公開中の議案を1件返します。一覧の項目に加えて、議案の本文解説（Markdown）が含まれます。",
+        "operationId": "getOpenDataBill",
+        "tags": ["議案データ"],
+        "parameters": [
+          {
+            "name": "billId",
+            "in": "path",
+            "required": true,
+            "description": "議案のID（UUID）。",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          { "$ref": "#/components/parameters/Difficulty" }
+        ],
+        "responses": {
+          "200": {
+            "description": "取得成功",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/OpenDataBillDetail" }
+              }
+            }
+          },
+          "400": {
+            "description": "パラメータ不正（billId がUUID形式でない・difficulty の不正値）",
             "content": {
               "application/json": {
                 "schema": { "$ref": "#/components/schemas/ErrorResponse" }
               }
             }
-          }
+          },
+          "404": {
+            "description": "議案が存在しない、または公開されていない",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+              }
+            }
+          },
+          "429": { "$ref": "#/components/responses/TooManyRequests" },
+          "500": { "$ref": "#/components/responses/InternalServerError" }
         }
       }
     }
   },
   "components": {
+    "parameters": {
+      "Limit": {
+        "name": "limit",
+        "in": "query",
+        "required": false,
+        "description": "1ページあたりの取得件数（1〜100）。",
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100,
+          "default": 20
+        }
+      },
+      "Cursor": {
+        "name": "cursor",
+        "in": "query",
+        "required": false,
+        "description": "ページネーション用カーソル。前のレスポンスの `nextCursor` をそのまま指定します。",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "Difficulty": {
+        "name": "difficulty",
+        "in": "query",
+        "required": false,
+        "description": "解説コンテンツの難易度。`normal`: 中学生レベル / `hard`: 専門用語を含む詳細な内容。",
+        "schema": {
+          "type": "string",
+          "enum": ["normal", "hard"],
+          "default": "normal"
+        }
+      }
+    },
+    "responses": {
+      "TooManyRequests": {
+        "description": "レートリミット超過。`Retry-After` ヘッダで再試行までの秒数を案内します。",
+        "headers": {
+          "Retry-After": {
+            "description": "再試行までの秒数",
+            "schema": { "type": "integer" }
+          }
+        },
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+          }
+        }
+      },
+      "InternalServerError": {
+        "description": "サーバーエラー",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+          }
+        }
+      }
+    },
     "schemas": {
       "OpenDataInterviewsResponse": {
         "type": "object",
@@ -220,6 +332,168 @@
             "description": "回答日時（ISO 8601）"
           }
         }
+      },
+      "OpenDataBillsResponse": {
+        "type": "object",
+        "required": ["items", "nextCursor"],
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/OpenDataBillItem" }
+          },
+          "nextCursor": {
+            "type": ["string", "null"],
+            "description": "次ページのカーソル。最終ページでは null。"
+          }
+        }
+      },
+      "OpenDataBillItem": {
+        "type": "object",
+        "required": [
+          "billId",
+          "name",
+          "title",
+          "summary",
+          "status",
+          "statusLabel",
+          "statusNote",
+          "originatingHouse",
+          "originatingHouseLabel",
+          "submittedDate",
+          "publishedAt",
+          "tags",
+          "miraiStance",
+          "createdAt"
+        ],
+        "properties": {
+          "billId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "議案のID"
+          },
+          "name": {
+            "type": "string",
+            "description": "議案の正式名称"
+          },
+          "title": {
+            "type": "string",
+            "description": "わかりやすいタイトル（難易度別コンテンツ由来）"
+          },
+          "summary": {
+            "type": "string",
+            "description": "議案の概要（難易度別コンテンツ由来）"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "preparing",
+              "introduced",
+              "in_originating_house",
+              "in_receiving_house",
+              "enacted",
+              "rejected"
+            ],
+            "description": "審議状況"
+          },
+          "statusLabel": {
+            "type": "string",
+            "description": "審議状況の日本語ラベル（衆議院審議中 / 成立 など）"
+          },
+          "statusNote": {
+            "type": ["string", "null"],
+            "description": "審議状況の補足"
+          },
+          "originatingHouse": {
+            "type": "string",
+            "enum": ["HR", "HC"],
+            "description": "提出元の議院（HR: 衆議院 / HC: 参議院）"
+          },
+          "originatingHouseLabel": {
+            "type": "string",
+            "description": "提出元議院の日本語ラベル"
+          },
+          "submittedDate": {
+            "type": ["string", "null"],
+            "format": "date",
+            "description": "提出日"
+          },
+          "publishedAt": {
+            "type": ["string", "null"],
+            "format": "date-time",
+            "description": "みらい議会での公開日時（ISO 8601）"
+          },
+          "tags": {
+            "type": "array",
+            "description": "議案のタグ",
+            "items": {
+              "type": "object",
+              "required": ["id", "label"],
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "format": "uuid",
+                  "description": "タグのID"
+                },
+                "label": { "type": "string", "description": "タグ名" }
+              }
+            }
+          },
+          "miraiStance": {
+            "oneOf": [
+              { "$ref": "#/components/schemas/OpenDataMiraiStance" },
+              { "type": "null" }
+            ],
+            "description": "チームみらいの賛否。未表明の場合は null。"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "作成日時（ISO 8601）。一覧の並び順のキー。"
+          }
+        }
+      },
+      "OpenDataMiraiStance": {
+        "type": "object",
+        "required": ["type", "label", "comment"],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "for",
+              "against",
+              "neutral",
+              "conditional_for",
+              "conditional_against",
+              "considering",
+              "continued_deliberation",
+              "free_vote"
+            ],
+            "description": "賛否の種別"
+          },
+          "label": {
+            "type": "string",
+            "description": "賛否種別の日本語ラベル（賛成 / 反対 / 条件付き賛成 など）"
+          },
+          "comment": {
+            "type": ["string", "null"],
+            "description": "賛否についての補足コメント"
+          }
+        }
+      },
+      "OpenDataBillDetail": {
+        "allOf": [
+          { "$ref": "#/components/schemas/OpenDataBillItem" },
+          {
+            "type": "object",
+            "required": ["content"],
+            "properties": {
+              "content": {
+                "type": "string",
+                "description": "議案の本文解説（Markdown、難易度別コンテンツ由来）"
+              }
+            }
+          }
+        ]
       },
       "ErrorResponse": {
         "type": "object",

--- a/web/src/app/api/open-data/bills/[billId]/route.integration.test.ts
+++ b/web/src/app/api/open-data/bills/[billId]/route.integration.test.ts
@@ -1,0 +1,72 @@
+import {
+  cleanupTestBill,
+  createTestBill,
+  createTestBillContent,
+  createTestMiraiStance,
+} from "@test-utils/utils";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { GET } from "./route";
+
+function callRoute(billId: string, query = ""): Promise<Response> {
+  const request = new Request(
+    `http://localhost:3000/api/open-data/bills/${billId}${query}`,
+    // レートリミットの干渉を避けるためテスト専用IPを使う
+    { headers: { "x-forwarded-for": "198.51.100.2" } }
+  );
+  return GET(request, { params: Promise.resolve({ billId }) });
+}
+
+describe("GET /api/open-data/bills/[billId]", () => {
+  let publishedBillId: string;
+  let draftBillId: string;
+
+  beforeAll(async () => {
+    const published = await createTestBill({ publish_status: "published" });
+    publishedBillId = published.id;
+    await createTestBillContent(publishedBillId, {
+      difficulty_level: "normal",
+      content: "本文テスト",
+    });
+    await createTestMiraiStance(publishedBillId, { type: "against" });
+
+    const draft = await createTestBill({ publish_status: "draft" });
+    draftBillId = draft.id;
+    await createTestBillContent(draftBillId, { difficulty_level: "normal" });
+  });
+
+  afterAll(async () => {
+    await cleanupTestBill(publishedBillId);
+    await cleanupTestBill(draftBillId);
+  });
+
+  it("billId がUUID形式でない場合は400を返す", async () => {
+    const res = await callRoute("not-a-uuid");
+    expect(res.status).toBe(400);
+  });
+
+  it("difficulty が不正な場合は400を返す", async () => {
+    const res = await callRoute(publishedBillId, "?difficulty=expert");
+    expect(res.status).toBe(400);
+  });
+
+  it("非公開の議案は404を返す", async () => {
+    const res = await callRoute(draftBillId);
+    expect(res.status).toBe(404);
+  });
+
+  it("公開中の議案を本文・賛否付きでno-storeで返す", async () => {
+    const res = await callRoute(publishedBillId);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+
+    const body = await res.json();
+    expect(body.billId).toBe(publishedBillId);
+    expect(body.content).toBe("本文テスト");
+    expect(body.miraiStance).toEqual({
+      type: "against",
+      label: "反対",
+      comment: expect.any(String),
+    });
+  });
+});

--- a/web/src/app/api/open-data/bills/[billId]/route.ts
+++ b/web/src/app/api/open-data/bills/[billId]/route.ts
@@ -1,0 +1,46 @@
+import { getOpenDataBillDetail } from "@/features/open-data/server/services/get-open-data-bill-detail";
+import { checkRateLimit } from "@/features/open-data/server/utils/rate-limit-guard";
+import { parseDifficultyQuery } from "@/features/open-data/shared/utils/parse-bills-query";
+import { isUuid } from "@/features/open-data/shared/utils/uuid";
+import { jsonNoStore } from "@/lib/api/response";
+
+/**
+ * 議案詳細のオープンデータ取得API。
+ *
+ * - 公開中（publish_status = published）の議案のみを、本文解説・
+ *   チームみらいの賛否・タグ付きで返す
+ * - APIキーは発行せず、オープンデータAPI全体でレートリミットを設ける
+ */
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ billId: string }> }
+) {
+  const { billId } = await params;
+  if (!isUuid(billId)) {
+    return jsonNoStore({ error: "billId はUUID形式で指定してください" }, 400);
+  }
+
+  const url = new URL(request.url);
+  const difficultyQuery = parseDifficultyQuery(url.searchParams);
+  if (!difficultyQuery.ok) {
+    return jsonNoStore({ error: difficultyQuery.error }, 400);
+  }
+  const { difficulty } = difficultyQuery;
+
+  try {
+    const rateLimited = await checkRateLimit(request);
+    if (rateLimited) {
+      return rateLimited;
+    }
+
+    const bill = await getOpenDataBillDetail({ billId, difficulty });
+    if (bill === null) {
+      return jsonNoStore({ error: "指定された議案が見つかりません" }, 404);
+    }
+    return jsonNoStore(bill);
+  } catch (error) {
+    // 内部エラーの詳細（DBエラーメッセージ等）は公開APIのレスポンスに含めない
+    console.error("[OpenData] bill detail read failed:", error);
+    return jsonNoStore({ error: "サーバー内部でエラーが発生しました" }, 500);
+  }
+}

--- a/web/src/app/api/open-data/bills/route.integration.test.ts
+++ b/web/src/app/api/open-data/bills/route.integration.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { GET } from "./route";
+
+function buildRequest(query = ""): Request {
+  // レートリミットの干渉を避けるためテスト専用IPを使う
+  return new Request(`http://localhost:3000/api/open-data/bills${query}`, {
+    headers: { "x-forwarded-for": "198.51.100.1" },
+  });
+}
+
+describe("GET /api/open-data/bills", () => {
+  it("limit が不正な場合は400を返す", async () => {
+    const res = await GET(buildRequest("?limit=0"));
+    expect(res.status).toBe(400);
+  });
+
+  it("difficulty が不正な場合は400を返す", async () => {
+    const res = await GET(buildRequest("?difficulty=expert"));
+    expect(res.status).toBe(400);
+  });
+
+  it("cursor が不正な場合は400を返す", async () => {
+    const res = await GET(buildRequest("?cursor=invalid!!"));
+    expect(res.status).toBe(400);
+  });
+
+  it("一覧をno-storeで返す", async () => {
+    const res = await GET(buildRequest());
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+
+    const body = await res.json();
+    expect(Array.isArray(body.items)).toBe(true);
+    expect("nextCursor" in body).toBe(true);
+  });
+});

--- a/web/src/app/api/open-data/bills/route.ts
+++ b/web/src/app/api/open-data/bills/route.ts
@@ -1,0 +1,35 @@
+import { getOpenDataBills } from "@/features/open-data/server/services/get-open-data-bills";
+import { checkRateLimit } from "@/features/open-data/server/utils/rate-limit-guard";
+import { parseBillsQuery } from "@/features/open-data/shared/utils/parse-bills-query";
+import { jsonNoStore } from "@/lib/api/response";
+
+/**
+ * 公開中の議案一覧のオープンデータ取得API。
+ *
+ * - 公開中（publish_status = published）の議案のみを、難易度別コンテンツ・
+ *   チームみらいの賛否・タグ付きで新しい順に返す
+ * - APIキーは発行せず、オープンデータAPI全体でレートリミットを設ける
+ */
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+
+  const query = parseBillsQuery(url.searchParams);
+  if (!query.ok) {
+    return jsonNoStore({ error: query.error }, 400);
+  }
+  const { limit, cursor, difficulty } = query;
+
+  try {
+    const rateLimited = await checkRateLimit(request);
+    if (rateLimited) {
+      return rateLimited;
+    }
+
+    const result = await getOpenDataBills({ limit, cursor, difficulty });
+    return jsonNoStore(result);
+  } catch (error) {
+    // 内部エラーの詳細（DBエラーメッセージ等）は公開APIのレスポンスに含めない
+    console.error("[OpenData] bills read failed:", error);
+    return jsonNoStore({ error: "サーバー内部でエラーが発生しました" }, 500);
+  }
+}

--- a/web/src/app/api/open-data/bills/route.ts
+++ b/web/src/app/api/open-data/bills/route.ts
@@ -9,6 +9,8 @@ import { jsonNoStore } from "@/lib/api/response";
  * - 公開中（publish_status = published）の議案のみを、難易度別コンテンツ・
  *   チームみらいの賛否・タグ付きで新しい順に返す
  * - APIキーは発行せず、オープンデータAPI全体でレートリミットを設ける
+ * - インタビューAPIと異なり license / termsUrl は返さない（インタビュー
+ *   データ利用規約はインタビューデータ専用のため意図的に含めていない）
  */
 export async function GET(request: Request) {
   const url = new URL(request.url);

--- a/web/src/app/api/open-data/interviews/route.ts
+++ b/web/src/app/api/open-data/interviews/route.ts
@@ -1,29 +1,10 @@
-import { consumeRateLimit } from "@/features/open-data/server/repositories/open-data-repository";
 import { getOpenDataInterviews } from "@/features/open-data/server/services/get-open-data-interviews";
-import { getClientIp } from "@/features/open-data/shared/utils/client-ip";
-import {
-  parseInterviewsQuery,
-  toPositiveInt,
-} from "@/features/open-data/shared/utils/parse-interviews-query";
-import {
-  getRetryAfterSeconds,
-  getWindowStart,
-} from "@/features/open-data/shared/utils/rate-limit-window";
-import { NextResponse } from "next/server";
+import { checkRateLimit } from "@/features/open-data/server/utils/rate-limit-guard";
+import { parsePaginationQuery } from "@/features/open-data/shared/utils/parse-pagination-query";
+import { jsonNoStore } from "@/lib/api/response";
 import { routes } from "@/lib/routes";
 
 const LICENSE = "CC BY 4.0";
-const RATE_LIMIT_WINDOW_SECONDS = 60;
-
-const json = (body: unknown, status = 200, headers: HeadersInit = {}) =>
-  NextResponse.json(body, {
-    status,
-    headers: {
-      // 同意撤回・非公開化が即座に反映されるようキャッシュしない
-      "Cache-Control": "no-store",
-      ...headers,
-    },
-  });
 
 /**
  * AIインタビューデータのオープンデータ取得API。
@@ -41,7 +22,7 @@ export async function GET(request: Request) {
 
   // 規約同意の表明（クリックスルー相当）を必須にする
   if (url.searchParams.get("agreeToTerms") !== "true") {
-    return json(
+    return jsonNoStore(
       {
         error:
           "みらい議会AIインタビューデータ利用規約に同意の上、agreeToTerms=true を指定してください",
@@ -51,68 +32,23 @@ export async function GET(request: Request) {
     );
   }
 
-  const query = parseInterviewsQuery(url.searchParams);
+  const query = parsePaginationQuery(url.searchParams);
   if (!query.ok) {
-    return json({ error: query.error }, 400);
+    return jsonNoStore({ error: query.error }, 400);
   }
   const { limit, cursor } = query;
 
   try {
-    // レートリミット（IP単位 + API全体、環境変数で上書き可能）。
-    // モジュールロード時に固定せずリクエスト毎に読むことで、env変更の即時反映と
-    // テストの簡素化（動的import不要）を両立する
-    const perIpLimit = toPositiveInt(
-      process.env.OPEN_DATA_RATE_LIMIT_PER_IP,
-      30
-    );
-    const globalLimit = toPositiveInt(
-      process.env.OPEN_DATA_RATE_LIMIT_GLOBAL,
-      300
-    );
-    // IP制限を先に判定し、通過したリクエストだけがグローバル枠を消費する
-    // （超過IPの連投が全体枠を食い潰し、他クライアントを巻き込むのを防ぐ）
-    const now = new Date();
-    const windowStart = getWindowStart(
-      now,
-      RATE_LIMIT_WINDOW_SECONDS
-    ).toISOString();
-    const clientIp = getClientIp(request.headers) ?? "unknown";
-    const tooManyRequests = () =>
-      json(
-        {
-          error: "リクエストが多すぎます。しばらく待ってから再試行してください",
-        },
-        429,
-        {
-          "Retry-After": String(
-            getRetryAfterSeconds(now, RATE_LIMIT_WINDOW_SECONDS)
-          ),
-        }
-      );
-
-    const ipAllowed = await consumeRateLimit({
-      key: `open-data:ip:${clientIp}`,
-      windowStart,
-      limit: perIpLimit,
-    });
-    if (!ipAllowed) {
-      return tooManyRequests();
-    }
-
-    const globalAllowed = await consumeRateLimit({
-      key: "open-data:global",
-      windowStart,
-      limit: globalLimit,
-    });
-    if (!globalAllowed) {
-      return tooManyRequests();
+    const rateLimited = await checkRateLimit(request);
+    if (rateLimited) {
+      return rateLimited;
     }
 
     const result = await getOpenDataInterviews({ limit, cursor });
-    return json({ ...result, license: LICENSE, termsUrl });
+    return jsonNoStore({ ...result, license: LICENSE, termsUrl });
   } catch (error) {
     // 内部エラーの詳細（DBエラーメッセージ等）は公開APIのレスポンスに含めない
     console.error("[OpenData] interviews read failed:", error);
-    return json({ error: "サーバー内部でエラーが発生しました" }, 500);
+    return jsonNoStore({ error: "サーバー内部でエラーが発生しました" }, 500);
   }
 }

--- a/web/src/features/bill-difficulty/shared/utils/is-difficulty-level.test.ts
+++ b/web/src/features/bill-difficulty/shared/utils/is-difficulty-level.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { isDifficultyLevel } from "./is-difficulty-level";
+
+describe("isDifficultyLevel", () => {
+  it("有効な難易度レベルならtrueを返す", () => {
+    expect(isDifficultyLevel("normal")).toBe(true);
+    expect(isDifficultyLevel("hard")).toBe(true);
+  });
+
+  it("無効な値はfalseを返す", () => {
+    expect(isDifficultyLevel("expert")).toBe(false);
+    expect(isDifficultyLevel("")).toBe(false);
+    expect(isDifficultyLevel(null)).toBe(false);
+    expect(isDifficultyLevel(undefined)).toBe(false);
+  });
+});

--- a/web/src/features/bill-difficulty/shared/utils/is-difficulty-level.ts
+++ b/web/src/features/bill-difficulty/shared/utils/is-difficulty-level.ts
@@ -1,0 +1,14 @@
+import {
+  type DifficultyLevelEnum,
+  VALID_DIFFICULTY_LEVELS,
+} from "../types/index";
+
+/**
+ * 有効な難易度レベルかを判定する型ガード。
+ */
+export function isDifficultyLevel(
+  value: string | null | undefined
+): value is DifficultyLevelEnum {
+  if (!value) return false;
+  return VALID_DIFFICULTY_LEVELS.includes(value as DifficultyLevelEnum);
+}

--- a/web/src/features/bill-difficulty/shared/utils/parse-difficulty-level.ts
+++ b/web/src/features/bill-difficulty/shared/utils/parse-difficulty-level.ts
@@ -1,8 +1,5 @@
-import {
-  DEFAULT_DIFFICULTY,
-  type DifficultyLevelEnum,
-  VALID_DIFFICULTY_LEVELS,
-} from "../types/index";
+import { DEFAULT_DIFFICULTY, type DifficultyLevelEnum } from "../types/index";
+import { isDifficultyLevel } from "./is-difficulty-level";
 
 /**
  * Cookie値から難易度レベルをパースする純粋関数
@@ -11,13 +8,5 @@ import {
 export function parseDifficultyLevel(
   cookieValue: string | undefined
 ): DifficultyLevelEnum {
-  if (!cookieValue) {
-    return DEFAULT_DIFFICULTY;
-  }
-
-  if (VALID_DIFFICULTY_LEVELS.includes(cookieValue as DifficultyLevelEnum)) {
-    return cookieValue as DifficultyLevelEnum;
-  }
-
-  return DEFAULT_DIFFICULTY;
+  return isDifficultyLevel(cookieValue) ? cookieValue : DEFAULT_DIFFICULTY;
 }

--- a/web/src/features/open-data/server/repositories/open-data-repository.ts
+++ b/web/src/features/open-data/server/repositories/open-data-repository.ts
@@ -1,6 +1,7 @@
 import "server-only";
 
 import { createAdminClient } from "@mirai-gikai/supabase";
+import type { DifficultyLevelEnum } from "@/features/bill-difficulty/shared/types";
 import type { OpenDataCursor } from "../../shared/utils/cursor";
 
 export type OpenDataReportRow = {
@@ -73,6 +74,83 @@ export async function findMessagesBySessionIds(
     throw new Error(`Failed to fetch open data messages: ${error.message}`);
   }
   return data ?? [];
+}
+
+// 一覧では本文（content）を含めず、詳細でのみ含める。
+// as const で template literal 型を保ち、Supabase の行型推論を効かせる
+const openDataBillSelect = <C extends string>(contentColumns: C) =>
+  `
+  id,
+  name,
+  status,
+  status_note,
+  originating_house,
+  submitted_date,
+  published_at,
+  created_at,
+  bill_contents!inner (${contentColumns}),
+  mirai_stances (type, comment),
+  bills_tags (tags (id, label))
+` as const;
+
+/**
+ * 公開中の議案を難易度別コンテンツ・チームみらいの賛否・タグ付きで
+ * 新しい順（created_at DESC, id DESC）に取得する。
+ * 指定難易度のコンテンツが存在しない議案は含めない。
+ */
+export async function findOpenDataPublishedBills(params: {
+  limit: number;
+  cursor: OpenDataCursor | null;
+  difficulty: DifficultyLevelEnum;
+}) {
+  const supabase = createAdminClient();
+  let query = supabase
+    .from("bills")
+    .select(openDataBillSelect("title, summary"))
+    .eq("publish_status", "published")
+    .eq("bill_contents.difficulty_level", params.difficulty);
+
+  if (params.cursor) {
+    // カーソル値は decodeCursor で ISO タイムスタンプ・UUID 形式に
+    // 検証済みのため、フィルタ文字列に安全に埋め込める
+    const { createdAt, id } = params.cursor;
+    query = query.or(
+      `created_at.lt."${createdAt}",and(created_at.eq."${createdAt}",id.lt."${id}")`
+    );
+  }
+
+  const { data, error } = await query
+    .order("created_at", { ascending: false })
+    .order("id", { ascending: false })
+    .limit(params.limit);
+
+  if (error) {
+    throw new Error(`Failed to fetch open data bills: ${error.message}`);
+  }
+  return data;
+}
+
+/**
+ * 公開中の議案を1件、難易度別コンテンツ・チームみらいの賛否・タグ付きで取得する。
+ * 非公開・存在しない・指定難易度のコンテンツがない場合は null。
+ */
+export async function findOpenDataPublishedBillById(params: {
+  billId: string;
+  difficulty: DifficultyLevelEnum;
+}) {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("bills")
+    .select(openDataBillSelect("title, summary, content"))
+    .eq("id", params.billId)
+    .eq("publish_status", "published")
+    .eq("bill_contents.difficulty_level", params.difficulty)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`Failed to fetch open data bill: ${error.message}`);
+  }
+  return data;
 }
 
 /**

--- a/web/src/features/open-data/server/services/get-open-data-bill-detail.ts
+++ b/web/src/features/open-data/server/services/get-open-data-bill-detail.ts
@@ -1,0 +1,20 @@
+import "server-only";
+
+import type { DifficultyLevelEnum } from "@/features/bill-difficulty/shared/types";
+import type { OpenDataBillDetail } from "../../shared/types/open-data-bills";
+import { toOpenDataBillDetail } from "../../shared/utils/to-open-data-bill";
+import { findOpenDataPublishedBillById } from "../repositories/open-data-repository";
+
+/**
+ * 公開データAPI用の議案詳細を取得する。
+ * 非公開・存在しない・指定難易度のコンテンツがない場合は null。
+ */
+export async function getOpenDataBillDetail(params: {
+  billId: string;
+  difficulty: DifficultyLevelEnum;
+}): Promise<OpenDataBillDetail | null> {
+  const row = await findOpenDataPublishedBillById(params);
+  if (!row) return null;
+
+  return toOpenDataBillDetail(row);
+}

--- a/web/src/features/open-data/server/services/get-open-data-bills.integration.test.ts
+++ b/web/src/features/open-data/server/services/get-open-data-bills.integration.test.ts
@@ -9,6 +9,9 @@ import {
   createTestTag,
 } from "@test-utils/utils";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { DifficultyLevelEnum } from "@/features/bill-difficulty/shared/types";
+import type { OpenDataBillItem } from "../../shared/types/open-data-bills";
+import { decodeCursor, type OpenDataCursor } from "../../shared/utils/cursor";
 import { getOpenDataBillDetail } from "./get-open-data-bill-detail";
 import { getOpenDataBills } from "./get-open-data-bills";
 
@@ -87,15 +90,31 @@ describe("getOpenDataBills / getOpenDataBillDetail", () => {
     draftBillId,
   ];
 
+  /**
+   * 全ページを走査して議案を収集する。ローカルDBの件数が1ページ分を
+   * 超えてもテストが影響を受けないようにする。
+   */
+  const fetchAllBills = async (
+    difficulty: DifficultyLevelEnum,
+    cursor: OpenDataCursor | null = null
+  ) => {
+    const items: OpenDataBillItem[] = [];
+    let currentCursor = cursor;
+    do {
+      const page = await getOpenDataBills({
+        limit: 100,
+        cursor: currentCursor,
+        difficulty,
+      });
+      items.push(...page.items);
+      currentCursor = page.nextCursor ? decodeCursor(page.nextCursor) : null;
+    } while (currentCursor);
+    return items;
+  };
+
   it("公開中の議案のみを新しい順に、賛否・タグ付きで返す", async () => {
-    const page = await getOpenDataBills({
-      limit: 1000,
-      cursor: null,
-      difficulty: "normal",
-    });
-    const mine = page.items.filter((item) =>
-      testBillIds().includes(item.billId)
-    );
+    const items = await fetchAllBills("normal");
+    const mine = items.filter((item) => testBillIds().includes(item.billId));
 
     expect(mine.map((item) => item.billId)).toEqual([
       publishedBillId,
@@ -118,35 +137,24 @@ describe("getOpenDataBills / getOpenDataBillDetail", () => {
   });
 
   it("difficulty=hard ではhardコンテンツを持つ議案のみを返す", async () => {
-    const page = await getOpenDataBills({
-      limit: 1000,
-      cursor: null,
-      difficulty: "hard",
-    });
-    const mine = page.items.filter((item) =>
-      testBillIds().includes(item.billId)
-    );
+    const items = await fetchAllBills("hard");
+    const mine = items.filter((item) => testBillIds().includes(item.billId));
 
     expect(mine.map((item) => item.billId)).toEqual([publishedBillId]);
     expect(mine[0]?.title).toBe("難しいタイトル");
   });
 
   it("cursor 以降のページには古い議案だけが含まれる", async () => {
-    const page = await getOpenDataBills({
-      limit: 1000,
-      cursor: null,
-      difficulty: "normal",
-    });
-    const newer = page.items.find((item) => item.billId === publishedBillId);
+    const items = await fetchAllBills("normal");
+    const newer = items.find((item) => item.billId === publishedBillId);
     expect(newer).toBeTruthy();
     if (!newer) return;
 
-    const afterCursor = await getOpenDataBills({
-      limit: 1000,
-      cursor: { createdAt: newer.createdAt, id: newer.billId },
-      difficulty: "normal",
+    const afterCursor = await fetchAllBills("normal", {
+      createdAt: newer.createdAt,
+      id: newer.billId,
     });
-    const mine = afterCursor.items.filter((item) =>
+    const mine = afterCursor.filter((item) =>
       testBillIds().includes(item.billId)
     );
     expect(mine.map((item) => item.billId)).toEqual([

--- a/web/src/features/open-data/server/services/get-open-data-bills.integration.test.ts
+++ b/web/src/features/open-data/server/services/get-open-data-bills.integration.test.ts
@@ -1,0 +1,183 @@
+import {
+  adminClient,
+  cleanupTestBill,
+  cleanupTestTag,
+  createTestBill,
+  createTestBillContent,
+  createTestBillTag,
+  createTestMiraiStance,
+  createTestTag,
+} from "@test-utils/utils";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { getOpenDataBillDetail } from "./get-open-data-bill-detail";
+import { getOpenDataBills } from "./get-open-data-bills";
+
+/**
+ * 公開議案の一覧・詳細サービスを実DBで検証する。
+ * ローカルDBには他の議案が存在し得るため、検証はこのテストで作成した
+ * 議案の行だけに絞って行う。
+ */
+describe("getOpenDataBills / getOpenDataBillDetail", () => {
+  let publishedBillId: string;
+  let publishedBillWithoutStanceId: string;
+  let draftBillId: string;
+  let tagId: string;
+
+  beforeAll(async () => {
+    // 新しい方: 賛否・タグ・両難易度コンテンツあり
+    const published = await createTestBill({ publish_status: "published" });
+    publishedBillId = published.id;
+    await createTestBillContent(publishedBillId, {
+      difficulty_level: "normal",
+      title: "ふつうタイトル",
+      summary: "ふつう概要",
+      content: "ふつう本文",
+    });
+    await createTestBillContent(publishedBillId, {
+      difficulty_level: "hard",
+      title: "難しいタイトル",
+      summary: "難しい概要",
+      content: "難しい本文",
+    });
+    await createTestMiraiStance(publishedBillId, {
+      type: "for",
+      comment: "賛成コメント",
+    });
+    const tag = await createTestTag();
+    tagId = tag.id;
+    await createTestBillTag(publishedBillId, tagId);
+
+    // 古い方: 賛否なし・normalコンテンツのみ
+    const withoutStance = await createTestBill({ publish_status: "published" });
+    publishedBillWithoutStanceId = withoutStance.id;
+    await createTestBillContent(publishedBillWithoutStanceId, {
+      difficulty_level: "normal",
+    });
+
+    // 非公開: 一覧・詳細どちらにも含まれない
+    const draft = await createTestBill({ publish_status: "draft" });
+    draftBillId = draft.id;
+    await createTestBillContent(draftBillId, { difficulty_level: "normal" });
+
+    // created_at で並び順・カーソルを検証できるよう明示的にずらす
+    const setCreatedAt = async (billId: string, createdAt: string) => {
+      const { error } = await adminClient
+        .from("bills")
+        .update({ created_at: createdAt })
+        .eq("id", billId);
+      if (error) throw new Error(error.message);
+    };
+    await setCreatedAt(publishedBillId, "2026-01-02T00:00:00+00:00");
+    await setCreatedAt(
+      publishedBillWithoutStanceId,
+      "2026-01-01T00:00:00+00:00"
+    );
+  });
+
+  afterAll(async () => {
+    await cleanupTestBill(publishedBillId);
+    await cleanupTestBill(publishedBillWithoutStanceId);
+    await cleanupTestBill(draftBillId);
+    await cleanupTestTag(tagId);
+  });
+
+  const testBillIds = () => [
+    publishedBillId,
+    publishedBillWithoutStanceId,
+    draftBillId,
+  ];
+
+  it("公開中の議案のみを新しい順に、賛否・タグ付きで返す", async () => {
+    const page = await getOpenDataBills({
+      limit: 1000,
+      cursor: null,
+      difficulty: "normal",
+    });
+    const mine = page.items.filter((item) =>
+      testBillIds().includes(item.billId)
+    );
+
+    expect(mine.map((item) => item.billId)).toEqual([
+      publishedBillId,
+      publishedBillWithoutStanceId,
+    ]);
+
+    const [withStance, withoutStance] = mine;
+    expect(withStance?.title).toBe("ふつうタイトル");
+    expect(withStance?.summary).toBe("ふつう概要");
+    expect(withStance?.miraiStance).toEqual({
+      type: "for",
+      label: "賛成",
+      comment: "賛成コメント",
+    });
+    expect(withStance?.tags).toEqual([
+      { id: tagId, label: expect.any(String) },
+    ]);
+    expect(withoutStance?.miraiStance).toBeNull();
+    expect(withoutStance?.tags).toEqual([]);
+  });
+
+  it("difficulty=hard ではhardコンテンツを持つ議案のみを返す", async () => {
+    const page = await getOpenDataBills({
+      limit: 1000,
+      cursor: null,
+      difficulty: "hard",
+    });
+    const mine = page.items.filter((item) =>
+      testBillIds().includes(item.billId)
+    );
+
+    expect(mine.map((item) => item.billId)).toEqual([publishedBillId]);
+    expect(mine[0]?.title).toBe("難しいタイトル");
+  });
+
+  it("cursor 以降のページには古い議案だけが含まれる", async () => {
+    const page = await getOpenDataBills({
+      limit: 1000,
+      cursor: null,
+      difficulty: "normal",
+    });
+    const newer = page.items.find((item) => item.billId === publishedBillId);
+    expect(newer).toBeTruthy();
+    if (!newer) return;
+
+    const afterCursor = await getOpenDataBills({
+      limit: 1000,
+      cursor: { createdAt: newer.createdAt, id: newer.billId },
+      difficulty: "normal",
+    });
+    const mine = afterCursor.items.filter((item) =>
+      testBillIds().includes(item.billId)
+    );
+    expect(mine.map((item) => item.billId)).toEqual([
+      publishedBillWithoutStanceId,
+    ]);
+  });
+
+  it("詳細は本文を含めて返し、難易度で内容が切り替わる", async () => {
+    const normal = await getOpenDataBillDetail({
+      billId: publishedBillId,
+      difficulty: "normal",
+    });
+    expect(normal?.content).toBe("ふつう本文");
+    expect(normal?.miraiStance?.label).toBe("賛成");
+
+    const hard = await getOpenDataBillDetail({
+      billId: publishedBillId,
+      difficulty: "hard",
+    });
+    expect(hard?.content).toBe("難しい本文");
+  });
+
+  it("非公開の議案・指定難易度のコンテンツがない議案の詳細は null", async () => {
+    expect(
+      await getOpenDataBillDetail({ billId: draftBillId, difficulty: "normal" })
+    ).toBeNull();
+    expect(
+      await getOpenDataBillDetail({
+        billId: publishedBillWithoutStanceId,
+        difficulty: "hard",
+      })
+    ).toBeNull();
+  });
+});

--- a/web/src/features/open-data/server/services/get-open-data-bills.ts
+++ b/web/src/features/open-data/server/services/get-open-data-bills.ts
@@ -1,0 +1,31 @@
+import "server-only";
+
+import type { DifficultyLevelEnum } from "@/features/bill-difficulty/shared/types";
+import type { OpenDataBillsResult } from "../../shared/types/open-data-bills";
+import type { OpenDataCursor } from "../../shared/utils/cursor";
+import { paginateRows } from "../../shared/utils/paginate";
+import { toOpenDataBillItem } from "../../shared/utils/to-open-data-bill";
+import { findOpenDataPublishedBills } from "../repositories/open-data-repository";
+
+/**
+ * 公開データAPI用の議案一覧を取得する。
+ * limit+1 件取得して次ページの有無を判定し、nextCursor を組み立てる。
+ */
+export async function getOpenDataBills(params: {
+  limit: number;
+  cursor: OpenDataCursor | null;
+  difficulty: DifficultyLevelEnum;
+}): Promise<OpenDataBillsResult> {
+  const rows = await findOpenDataPublishedBills({
+    limit: params.limit + 1,
+    cursor: params.cursor,
+    difficulty: params.difficulty,
+  });
+
+  const { pageRows, nextCursor } = paginateRows(rows, params.limit, (row) => ({
+    createdAt: row.created_at,
+    id: row.id,
+  }));
+
+  return { items: pageRows.map(toOpenDataBillItem), nextCursor };
+}

--- a/web/src/features/open-data/server/services/get-open-data-interviews.integration.test.ts
+++ b/web/src/features/open-data/server/services/get-open-data-interviews.integration.test.ts
@@ -72,7 +72,8 @@ describe("getOpenDataInterviews", () => {
         });
       if (reportError) throw new Error(reportError.message);
 
-      // 新しい方の許諾済みセッションにだけ会話ログを付ける
+      // 新しい方の許諾済みセッションにだけ会話ログを付ける。
+      // 同一insertだと created_at が同値になり時系列順が不定になるため明示する
       if (i === 1) {
         const { error: messageError } = await adminClient
           .from("interview_messages")
@@ -81,11 +82,13 @@ describe("getOpenDataInterviews", () => {
               interview_session_id: session.id,
               role: "assistant",
               content: "質問です",
+              created_at: "2026-01-01T00:00:00+00:00",
             },
             {
               interview_session_id: session.id,
               role: "user",
               content: "回答です",
+              created_at: "2026-01-01T00:00:01+00:00",
             },
           ]);
         if (messageError) throw new Error(messageError.message);

--- a/web/src/features/open-data/server/services/get-open-data-interviews.ts
+++ b/web/src/features/open-data/server/services/get-open-data-interviews.ts
@@ -6,8 +6,9 @@ import type {
   OpenDataInterviewsResult,
   OpenDataMessage,
 } from "../../shared/types/open-data";
-import { encodeCursor, type OpenDataCursor } from "../../shared/utils/cursor";
+import type { OpenDataCursor } from "../../shared/utils/cursor";
 import { toOpenDataOpinions } from "../../shared/utils/opinions";
+import { paginateRows } from "../../shared/utils/paginate";
 import { toOpenDataMessage } from "../../shared/utils/to-open-data-message";
 import {
   findMessagesBySessionIds,
@@ -28,8 +29,10 @@ export async function getOpenDataInterviews(params: {
     cursor: params.cursor,
   });
 
-  const hasMore = rows.length > params.limit;
-  const pageRows = hasMore ? rows.slice(0, params.limit) : rows;
+  const { pageRows, nextCursor } = paginateRows(rows, params.limit, (row) => ({
+    createdAt: row.created_at,
+    id: row.report_id,
+  }));
 
   const messages = await findMessagesBySessionIds(
     pageRows.map((row) => row.interview_session_id)
@@ -54,12 +57,6 @@ export async function getOpenDataInterviews(params: {
     messages: messagesBySession.get(row.interview_session_id) ?? [],
     createdAt: row.created_at,
   }));
-
-  const lastRow = pageRows.at(-1);
-  const nextCursor =
-    hasMore && lastRow
-      ? encodeCursor({ createdAt: lastRow.created_at, id: lastRow.report_id })
-      : null;
 
   return { items, nextCursor };
 }

--- a/web/src/features/open-data/server/utils/rate-limit-guard.ts
+++ b/web/src/features/open-data/server/utils/rate-limit-guard.ts
@@ -1,0 +1,70 @@
+import "server-only";
+
+import { jsonNoStore } from "@/lib/api/response";
+import { getClientIp } from "../../shared/utils/client-ip";
+import { toPositiveInt } from "../../shared/utils/parse-pagination-query";
+import {
+  getRetryAfterSeconds,
+  getWindowStart,
+} from "../../shared/utils/rate-limit-window";
+import { consumeRateLimit } from "../repositories/open-data-repository";
+
+const RATE_LIMIT_WINDOW_SECONDS = 60;
+
+/**
+ * オープンデータAPI共通のレートリミット（IP単位 + API全体、環境変数で
+ * 上書き可能）を消費する。超過時は429レスポンスを、通過時は null を返す。
+ *
+ * - 制限値はモジュールロード時に固定せずリクエスト毎に env から読むことで、
+ *   env変更の即時反映とテストの簡素化（動的import不要）を両立する
+ * - IP制限を先に判定し、通過したリクエストだけがグローバル枠を消費する
+ *   （超過IPの連投が全体枠を食い潰し、他クライアントを巻き込むのを防ぐ）
+ */
+export async function checkRateLimit(
+  request: Request
+): Promise<Response | null> {
+  const perIpLimit = toPositiveInt(process.env.OPEN_DATA_RATE_LIMIT_PER_IP, 30);
+  const globalLimit = toPositiveInt(
+    process.env.OPEN_DATA_RATE_LIMIT_GLOBAL,
+    300
+  );
+
+  const now = new Date();
+  const windowStart = getWindowStart(
+    now,
+    RATE_LIMIT_WINDOW_SECONDS
+  ).toISOString();
+  const clientIp = getClientIp(request.headers) ?? "unknown";
+  const tooManyRequests = () =>
+    jsonNoStore(
+      {
+        error: "リクエストが多すぎます。しばらく待ってから再試行してください",
+      },
+      429,
+      {
+        "Retry-After": String(
+          getRetryAfterSeconds(now, RATE_LIMIT_WINDOW_SECONDS)
+        ),
+      }
+    );
+
+  const ipAllowed = await consumeRateLimit({
+    key: `open-data:ip:${clientIp}`,
+    windowStart,
+    limit: perIpLimit,
+  });
+  if (!ipAllowed) {
+    return tooManyRequests();
+  }
+
+  const globalAllowed = await consumeRateLimit({
+    key: "open-data:global",
+    windowStart,
+    limit: globalLimit,
+  });
+  if (!globalAllowed) {
+    return tooManyRequests();
+  }
+
+  return null;
+}

--- a/web/src/features/open-data/shared/types/open-data-bills.ts
+++ b/web/src/features/open-data/shared/types/open-data-bills.ts
@@ -1,0 +1,52 @@
+import type {
+  BillStatusEnum,
+  HouseEnum,
+  StanceTypeEnum,
+} from "@/features/bills/shared/types";
+
+export type OpenDataMiraiStance = {
+  /** 賛否の種別（for / against など） */
+  type: StanceTypeEnum;
+  /** 賛否種別の日本語ラベル（賛成 / 反対 など） */
+  label: string;
+  /** 賛否についての補足コメント */
+  comment: string | null;
+};
+
+export type OpenDataBillTag = {
+  id: string;
+  label: string;
+};
+
+export type OpenDataBillItem = {
+  billId: string;
+  /** 議案の正式名称 */
+  name: string;
+  /** わかりやすいタイトル（難易度別コンテンツ由来） */
+  title: string;
+  /** 議案の概要（難易度別コンテンツ由来） */
+  summary: string;
+  status: BillStatusEnum;
+  /** 審議状況の日本語ラベル（衆議院審議中 / 成立 など） */
+  statusLabel: string;
+  statusNote: string | null;
+  originatingHouse: HouseEnum;
+  /** 提出元議院の日本語ラベル（衆議院 / 参議院） */
+  originatingHouseLabel: string;
+  submittedDate: string | null;
+  publishedAt: string | null;
+  tags: OpenDataBillTag[];
+  /** チームみらいの賛否。未表明の場合は null */
+  miraiStance: OpenDataMiraiStance | null;
+  createdAt: string;
+};
+
+export type OpenDataBillsResult = {
+  items: OpenDataBillItem[];
+  nextCursor: string | null;
+};
+
+export type OpenDataBillDetail = OpenDataBillItem & {
+  /** 議案の本文解説（Markdown、難易度別コンテンツ由来） */
+  content: string;
+};

--- a/web/src/features/open-data/shared/utils/cursor.ts
+++ b/web/src/features/open-data/shared/utils/cursor.ts
@@ -5,8 +5,7 @@ export type OpenDataCursor = {
   id: string;
 };
 
-const UUID_PATTERN =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+import { isUuid } from "./uuid";
 
 // Postgres の timestamptz が受理できる ISO 8601 形式（DBから返る +00:00 形式も含む）
 const ISO_TIMESTAMP_PATTERN =
@@ -56,7 +55,7 @@ export function decodeCursor(value: string): OpenDataCursor | null {
   const createdAt = decoded.slice(0, separatorIndex);
   const id = decoded.slice(separatorIndex + 1);
   if (!isValidIsoTimestamp(createdAt)) return null;
-  if (!UUID_PATTERN.test(id)) return null;
+  if (!isUuid(id)) return null;
 
   return { createdAt, id };
 }

--- a/web/src/features/open-data/shared/utils/cursor.ts
+++ b/web/src/features/open-data/shared/utils/cursor.ts
@@ -1,11 +1,11 @@
+import { isUuid } from "./uuid";
+
 export type OpenDataCursor = {
   /** ISO 8601 の created_at */
   createdAt: string;
-  /** レポートID（UUID） */
+  /** レコードID（UUID）。レポート・議案など一覧対象のID */
   id: string;
 };
-
-import { isUuid } from "./uuid";
 
 // Postgres の timestamptz が受理できる ISO 8601 形式（DBから返る +00:00 形式も含む）
 const ISO_TIMESTAMP_PATTERN =

--- a/web/src/features/open-data/shared/utils/paginate.test.ts
+++ b/web/src/features/open-data/shared/utils/paginate.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { decodeCursor } from "./cursor";
+import { paginateRows } from "./paginate";
+
+type Row = { createdAt: string; id: string };
+
+const toCursor = (row: Row) => ({ createdAt: row.createdAt, id: row.id });
+
+const row = (n: number): Row => ({
+  createdAt: `2026-01-0${n}T00:00:00+00:00`,
+  id: `123e4567-e89b-12d3-a456-42661417400${n}`,
+});
+
+describe("paginateRows", () => {
+  it("limitを超える行がある場合はlimit件に切り詰め、最終行のカーソルを返す", () => {
+    const result = paginateRows([row(3), row(2), row(1)], 2, toCursor);
+    expect(result.pageRows).toEqual([row(3), row(2)]);
+    expect(result.nextCursor).not.toBeNull();
+    expect(decodeCursor(result.nextCursor ?? "")).toEqual(toCursor(row(2)));
+  });
+
+  it("limit以下の場合は全行を返し、nextCursorはnull", () => {
+    const result = paginateRows([row(1)], 2, toCursor);
+    expect(result.pageRows).toEqual([row(1)]);
+    expect(result.nextCursor).toBeNull();
+  });
+
+  it("空の場合は空配列とnullを返す", () => {
+    const result = paginateRows([], 2, toCursor);
+    expect(result.pageRows).toEqual([]);
+    expect(result.nextCursor).toBeNull();
+  });
+});

--- a/web/src/features/open-data/shared/utils/paginate.ts
+++ b/web/src/features/open-data/shared/utils/paginate.ts
@@ -1,0 +1,17 @@
+import { encodeCursor, type OpenDataCursor } from "./cursor";
+
+/**
+ * limit+1 件取得した行から次ページの有無を判定し、
+ * ページ内の行と nextCursor を組み立てる。
+ */
+export function paginateRows<T>(
+  rows: T[],
+  limit: number,
+  toCursor: (row: T) => OpenDataCursor
+): { pageRows: T[]; nextCursor: string | null } {
+  const pageRows = rows.slice(0, limit);
+  const lastRow = pageRows.at(-1);
+  const nextCursor =
+    rows.length > limit && lastRow ? encodeCursor(toCursor(lastRow)) : null;
+  return { pageRows, nextCursor };
+}

--- a/web/src/features/open-data/shared/utils/parse-bills-query.test.ts
+++ b/web/src/features/open-data/shared/utils/parse-bills-query.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { encodeCursor } from "./cursor";
+import { parseBillsQuery, parseDifficultyQuery } from "./parse-bills-query";
+import { DEFAULT_LIMIT } from "./parse-pagination-query";
+
+describe("parseBillsQuery", () => {
+  it("パラメータ未指定時は既定値を返す", () => {
+    const result = parseBillsQuery(new URLSearchParams());
+    expect(result).toEqual({
+      ok: true,
+      limit: DEFAULT_LIMIT,
+      cursor: null,
+      difficulty: "normal",
+    });
+  });
+
+  it("limit / cursor / difficulty をすべて解析する", () => {
+    const cursor = {
+      createdAt: "2026-01-01T00:00:00+00:00",
+      id: "123e4567-e89b-12d3-a456-426614174000",
+    };
+    const params = new URLSearchParams({
+      limit: "5",
+      cursor: encodeCursor(cursor),
+      difficulty: "hard",
+    });
+    expect(parseBillsQuery(params)).toEqual({
+      ok: true,
+      limit: 5,
+      cursor,
+      difficulty: "hard",
+    });
+  });
+
+  it("limit が不正な場合はエラーを返す", () => {
+    const result = parseBillsQuery(new URLSearchParams({ limit: "0" }));
+    expect(result.ok).toBe(false);
+  });
+
+  it("cursor が不正な場合はエラーを返す", () => {
+    const result = parseBillsQuery(new URLSearchParams({ cursor: "invalid" }));
+    expect(result.ok).toBe(false);
+  });
+
+  it("difficulty が不正な場合はエラーを返す", () => {
+    const result = parseBillsQuery(
+      new URLSearchParams({ difficulty: "expert" })
+    );
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe("parseDifficultyQuery", () => {
+  it("未指定は既定値 normal を返す", () => {
+    expect(parseDifficultyQuery(new URLSearchParams())).toEqual({
+      ok: true,
+      difficulty: "normal",
+    });
+  });
+
+  it("有効な値はそのまま返す", () => {
+    expect(
+      parseDifficultyQuery(new URLSearchParams({ difficulty: "hard" }))
+    ).toEqual({ ok: true, difficulty: "hard" });
+  });
+
+  it("不正な値はエラーを返す", () => {
+    const result = parseDifficultyQuery(
+      new URLSearchParams({ difficulty: "expert" })
+    );
+    expect(result.ok).toBe(false);
+  });
+});

--- a/web/src/features/open-data/shared/utils/parse-bills-query.ts
+++ b/web/src/features/open-data/shared/utils/parse-bills-query.ts
@@ -1,0 +1,59 @@
+import {
+  DEFAULT_DIFFICULTY,
+  type DifficultyLevelEnum,
+  VALID_DIFFICULTY_LEVELS,
+} from "@/features/bill-difficulty/shared/types";
+import { isDifficultyLevel } from "@/features/bill-difficulty/shared/utils/is-difficulty-level";
+import {
+  type ParsedPaginationQuery,
+  parsePaginationQuery,
+} from "./parse-pagination-query";
+
+export type ParsedDifficultyQuery =
+  | { ok: true; difficulty: DifficultyLevelEnum }
+  | { ok: false; error: string };
+
+/**
+ * difficulty パラメータを検証・解析する。未指定は既定値。
+ */
+export function parseDifficultyQuery(
+  searchParams: URLSearchParams
+): ParsedDifficultyQuery {
+  const value = searchParams.get("difficulty");
+  if (value === null) {
+    return { ok: true, difficulty: DEFAULT_DIFFICULTY };
+  }
+  if (!isDifficultyLevel(value)) {
+    return {
+      ok: false,
+      error: `difficulty は ${VALID_DIFFICULTY_LEVELS.join(" / ")} のいずれかで指定してください`,
+    };
+  }
+  return { ok: true, difficulty: value };
+}
+
+export type ParsedBillsQuery =
+  | (Extract<ParsedPaginationQuery, { ok: true }> & {
+      difficulty: DifficultyLevelEnum;
+    })
+  | { ok: false; error: string };
+
+/**
+ * 議案オープンデータAPIのクエリパラメータ
+ * （limit / cursor / difficulty）を検証・解析する。
+ */
+export function parseBillsQuery(
+  searchParams: URLSearchParams
+): ParsedBillsQuery {
+  const pagination = parsePaginationQuery(searchParams);
+  if (!pagination.ok) {
+    return pagination;
+  }
+
+  const difficulty = parseDifficultyQuery(searchParams);
+  if (!difficulty.ok) {
+    return difficulty;
+  }
+
+  return { ...pagination, difficulty: difficulty.difficulty };
+}

--- a/web/src/features/open-data/shared/utils/parse-pagination-query.test.ts
+++ b/web/src/features/open-data/shared/utils/parse-pagination-query.test.ts
@@ -2,13 +2,13 @@ import { describe, expect, it } from "vitest";
 import { encodeCursor } from "./cursor";
 import {
   DEFAULT_LIMIT,
-  parseInterviewsQuery,
+  parsePaginationQuery,
   toPositiveInt,
-} from "./parse-interviews-query";
+} from "./parse-pagination-query";
 
-describe("parseInterviewsQuery", () => {
+describe("parsePaginationQuery", () => {
   it("未指定時はデフォルトlimit・cursorなしで解析する", () => {
-    const result = parseInterviewsQuery(new URLSearchParams());
+    const result = parsePaginationQuery(new URLSearchParams());
     expect(result).toEqual({ ok: true, limit: DEFAULT_LIMIT, cursor: null });
   });
 
@@ -22,7 +22,7 @@ describe("parseInterviewsQuery", () => {
       cursor: encodeCursor(cursor),
     });
 
-    expect(parseInterviewsQuery(params)).toEqual({
+    expect(parsePaginationQuery(params)).toEqual({
       ok: true,
       limit: 50,
       cursor,
@@ -35,12 +35,12 @@ describe("parseInterviewsQuery", () => {
     "abc",
     "1.5",
   ])("不正な limit (%s) はエラーを返す", (limit) => {
-    const result = parseInterviewsQuery(new URLSearchParams({ limit }));
+    const result = parsePaginationQuery(new URLSearchParams({ limit }));
     expect(result.ok).toBe(false);
   });
 
   it("不正な cursor はエラーを返す", () => {
-    const result = parseInterviewsQuery(
+    const result = parsePaginationQuery(
       new URLSearchParams({ cursor: "invalid!!" })
     );
     expect(result.ok).toBe(false);

--- a/web/src/features/open-data/shared/utils/parse-pagination-query.ts
+++ b/web/src/features/open-data/shared/utils/parse-pagination-query.ts
@@ -3,16 +3,16 @@ import { decodeCursor, type OpenDataCursor } from "./cursor";
 export const DEFAULT_LIMIT = 20;
 export const MAX_LIMIT = 100;
 
-export type ParsedInterviewsQuery =
+export type ParsedPaginationQuery =
   | { ok: true; limit: number; cursor: OpenDataCursor | null }
   | { ok: false; error: string };
 
 /**
- * 公開データAPIのクエリパラメータ（limit / cursor）を検証・解析する。
+ * 公開データAPI共通のページネーションパラメータ（limit / cursor）を検証・解析する。
  */
-export function parseInterviewsQuery(
+export function parsePaginationQuery(
   searchParams: URLSearchParams
-): ParsedInterviewsQuery {
+): ParsedPaginationQuery {
   const limitParam = searchParams.get("limit");
   const limit = limitParam === null ? DEFAULT_LIMIT : Number(limitParam);
   if (!Number.isInteger(limit) || limit < 1 || limit > MAX_LIMIT) {

--- a/web/src/features/open-data/shared/utils/to-open-data-bill.test.ts
+++ b/web/src/features/open-data/shared/utils/to-open-data-bill.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import {
+  type OpenDataBillRow,
+  toOpenDataBillDetail,
+  toOpenDataBillItem,
+  toOpenDataMiraiStance,
+} from "./to-open-data-bill";
+
+const baseRow: OpenDataBillRow = {
+  id: "123e4567-e89b-12d3-a456-426614174000",
+  name: "テスト法案",
+  status: "in_originating_house",
+  status_note: null,
+  originating_house: "HR",
+  submitted_date: "2026-01-10",
+  published_at: "2026-01-15T00:00:00+00:00",
+  created_at: "2026-01-01T00:00:00+00:00",
+  bill_contents: [{ title: "わかりやすいタイトル", summary: "概要" }],
+  mirai_stances: { type: "conditional_for", comment: "条件付きで賛成" },
+  bills_tags: [{ tags: { id: "tag-1", label: "経済" } }],
+};
+
+describe("toOpenDataBillItem", () => {
+  it("議案行をAPIレスポンス形式に変換する", () => {
+    expect(toOpenDataBillItem(baseRow)).toEqual({
+      billId: "123e4567-e89b-12d3-a456-426614174000",
+      name: "テスト法案",
+      title: "わかりやすいタイトル",
+      summary: "概要",
+      status: "in_originating_house",
+      statusLabel: "衆議院審議中",
+      statusNote: null,
+      originatingHouse: "HR",
+      originatingHouseLabel: "衆議院",
+      submittedDate: "2026-01-10",
+      publishedAt: "2026-01-15T00:00:00+00:00",
+      tags: [{ id: "tag-1", label: "経済" }],
+      miraiStance: {
+        type: "conditional_for",
+        label: "条件付き賛成",
+        comment: "条件付きで賛成",
+      },
+      createdAt: "2026-01-01T00:00:00+00:00",
+    });
+  });
+
+  it("賛否・タグがない場合は null / 空配列を返す", () => {
+    const item = toOpenDataBillItem({
+      ...baseRow,
+      mirai_stances: null,
+      bills_tags: [],
+    });
+    expect(item.miraiStance).toBeNull();
+    expect(item.tags).toEqual([]);
+  });
+
+  it("タグの参照が欠けている場合は除外する", () => {
+    const item = toOpenDataBillItem({
+      ...baseRow,
+      bills_tags: [{ tags: null }, { tags: { id: "tag-2", label: "環境" } }],
+    });
+    expect(item.tags).toEqual([{ id: "tag-2", label: "環境" }]);
+  });
+});
+
+describe("toOpenDataBillDetail", () => {
+  it("一覧項目に本文（content）を加えて返す", () => {
+    const detail = toOpenDataBillDetail({
+      ...baseRow,
+      bill_contents: [
+        { title: "タイトル", summary: "概要", content: "# 本文" },
+      ],
+    });
+    expect(detail.title).toBe("タイトル");
+    expect(detail.content).toBe("# 本文");
+  });
+});
+
+describe("toOpenDataMiraiStance", () => {
+  it("賛否種別に日本語ラベルを付与する", () => {
+    expect(toOpenDataMiraiStance({ type: "for", comment: null })).toEqual({
+      type: "for",
+      label: "賛成",
+      comment: null,
+    });
+  });
+
+  it("null の場合は null を返す", () => {
+    expect(toOpenDataMiraiStance(null)).toBeNull();
+  });
+});

--- a/web/src/features/open-data/shared/utils/to-open-data-bill.ts
+++ b/web/src/features/open-data/shared/utils/to-open-data-bill.ts
@@ -1,0 +1,83 @@
+import {
+  type BillStatusEnum,
+  getBillStatusLabel,
+  HOUSE_LABELS,
+  type HouseEnum,
+  STANCE_LABELS,
+  type StanceTypeEnum,
+} from "@/features/bills/shared/types";
+import type {
+  OpenDataBillDetail,
+  OpenDataBillItem,
+  OpenDataMiraiStance,
+} from "../types/open-data-bills";
+
+export type OpenDataBillRow = {
+  id: string;
+  name: string;
+  status: BillStatusEnum;
+  status_note: string | null;
+  originating_house: HouseEnum;
+  submitted_date: string | null;
+  published_at: string | null;
+  created_at: string;
+  /** 難易度で絞り込み済みのため実質1件 */
+  bill_contents: { title: string; summary: string }[];
+  mirai_stances: { type: StanceTypeEnum; comment: string | null } | null;
+  bills_tags: { tags: { id: string; label: string } | null }[];
+};
+
+/**
+ * DBの議案行をオープンデータAPIのレスポンス項目に変換する。
+ */
+export function toOpenDataBillItem(row: OpenDataBillRow): OpenDataBillItem {
+  const content = row.bill_contents[0];
+  return {
+    billId: row.id,
+    name: row.name,
+    title: content?.title ?? "",
+    summary: content?.summary ?? "",
+    status: row.status,
+    statusLabel: getBillStatusLabel(row.status, row.originating_house),
+    statusNote: row.status_note,
+    originatingHouse: row.originating_house,
+    originatingHouseLabel: HOUSE_LABELS[row.originating_house],
+    submittedDate: row.submitted_date,
+    publishedAt: row.published_at,
+    tags: row.bills_tags.flatMap((billTag) =>
+      billTag.tags ? [{ id: billTag.tags.id, label: billTag.tags.label }] : []
+    ),
+    miraiStance: toOpenDataMiraiStance(row.mirai_stances),
+    createdAt: row.created_at,
+  };
+}
+
+export type OpenDataBillDetailRow = Omit<OpenDataBillRow, "bill_contents"> & {
+  bill_contents: { title: string; summary: string; content: string }[];
+};
+
+/**
+ * DBの議案行（本文付き）をオープンデータAPIの詳細レスポンスに変換する。
+ */
+export function toOpenDataBillDetail(
+  row: OpenDataBillDetailRow
+): OpenDataBillDetail {
+  return {
+    ...toOpenDataBillItem(row),
+    content: row.bill_contents[0]?.content ?? "",
+  };
+}
+
+/**
+ * チームみらいの賛否行をレスポンス形式（日本語ラベル付き）に変換する。
+ */
+export function toOpenDataMiraiStance(
+  stance: { type: StanceTypeEnum; comment: string | null } | null
+): OpenDataMiraiStance | null {
+  if (!stance) return null;
+  return {
+    type: stance.type,
+    label: STANCE_LABELS[stance.type],
+    comment: stance.comment,
+  };
+}

--- a/web/src/features/open-data/shared/utils/to-open-data-bill.ts
+++ b/web/src/features/open-data/shared/utils/to-open-data-bill.ts
@@ -31,12 +31,12 @@ export type OpenDataBillRow = {
  * DBの議案行をオープンデータAPIのレスポンス項目に変換する。
  */
 export function toOpenDataBillItem(row: OpenDataBillRow): OpenDataBillItem {
-  const content = row.bill_contents[0];
+  const billContent = row.bill_contents[0];
   return {
     billId: row.id,
     name: row.name,
-    title: content?.title ?? "",
-    summary: content?.summary ?? "",
+    title: billContent?.title ?? "",
+    summary: billContent?.summary ?? "",
     status: row.status,
     statusLabel: getBillStatusLabel(row.status, row.originating_house),
     statusNote: row.status_note,

--- a/web/src/features/open-data/shared/utils/uuid.test.ts
+++ b/web/src/features/open-data/shared/utils/uuid.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { isUuid } from "./uuid";
+
+describe("isUuid", () => {
+  it("UUID形式ならtrueを返す", () => {
+    expect(isUuid("123e4567-e89b-12d3-a456-426614174000")).toBe(true);
+    expect(isUuid("123E4567-E89B-12D3-A456-426614174000")).toBe(true);
+  });
+
+  it("UUID形式でなければfalseを返す", () => {
+    expect(isUuid("")).toBe(false);
+    expect(isUuid("not-a-uuid")).toBe(false);
+    expect(isUuid("123e4567-e89b-12d3-a456-42661417400")).toBe(false);
+    expect(isUuid("123e4567e89b12d3a456426614174000")).toBe(false);
+  });
+});

--- a/web/src/features/open-data/shared/utils/uuid.ts
+++ b/web/src/features/open-data/shared/utils/uuid.ts
@@ -1,0 +1,9 @@
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * UUID形式の文字列かを判定する。
+ */
+export function isUuid(value: string): boolean {
+  return UUID_PATTERN.test(value);
+}

--- a/web/src/lib/api/response.test.ts
+++ b/web/src/lib/api/response.test.ts
@@ -1,5 +1,26 @@
-import { describe, it, expect } from "vitest";
-import { textResponse, jsonResponse } from "./response";
+import { describe, expect, it } from "vitest";
+import { jsonNoStore, jsonResponse, textResponse } from "./response";
+
+describe("jsonNoStore", () => {
+  it("Cache-Control: no-store 付きのJSONレスポンスを返す", async () => {
+    const res = jsonNoStore({ items: [] });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("application/json");
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+    expect(await res.json()).toEqual({ items: [] });
+  });
+
+  it("ステータスコードと追加ヘッダを指定できる", () => {
+    const res = jsonNoStore({ error: "too many" }, 429, {
+      "Retry-After": "30",
+    });
+
+    expect(res.status).toBe(429);
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+    expect(res.headers.get("Retry-After")).toBe("30");
+  });
+});
 
 describe("textResponse", () => {
   it("指定されたメッセージとステータスコードでレスポンスを返す", async () => {

--- a/web/src/lib/api/response.ts
+++ b/web/src/lib/api/response.ts
@@ -15,3 +15,22 @@ export function jsonResponse(body: unknown, status: number): Response {
     headers: { "Content-Type": "application/json" },
   });
 }
+
+/**
+ * キャッシュさせないJSONレスポンス。
+ * 同意撤回・非公開化が即座に反映される必要がある公開APIで使う。
+ */
+export function jsonNoStore(
+  body: unknown,
+  status = 200,
+  headers: HeadersInit = {}
+): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+      "Cache-Control": "no-store",
+      ...headers,
+    },
+  });
+}

--- a/web/src/middleware.test.ts
+++ b/web/src/middleware.test.ts
@@ -3,7 +3,20 @@ import {
   isDevRoute,
   isHtmlAcceptHeader,
   isValidDifficultyLevel,
+  shouldApplyDifficultyCookie,
 } from "./middleware";
+
+describe("shouldApplyDifficultyCookie", () => {
+  it("通常のページパスではtrueを返す", () => {
+    expect(shouldApplyDifficultyCookie("/")).toBe(true);
+    expect(shouldApplyDifficultyCookie("/bills/abc")).toBe(true);
+  });
+
+  it("APIパスではfalseを返す（レスポンスにSet-Cookieを乗せない）", () => {
+    expect(shouldApplyDifficultyCookie("/api/open-data/bills")).toBe(false);
+    expect(shouldApplyDifficultyCookie("/api/chat")).toBe(false);
+  });
+});
 
 describe("isValidDifficultyLevel", () => {
   it("should return true for 'normal'", () => {

--- a/web/src/middleware.ts
+++ b/web/src/middleware.ts
@@ -3,8 +3,8 @@ import {
   DIFFICULTY_COOKIE_NAME,
   DIFFICULTY_COOKIE_OPTIONS,
   type DifficultyLevelEnum,
-  VALID_DIFFICULTY_LEVELS,
 } from "./features/bill-difficulty/shared/types";
+import { isDifficultyLevel } from "./features/bill-difficulty/shared/utils/is-difficulty-level";
 import {
   createUnauthorizedResponse,
   getBasicAuthConfig,
@@ -66,8 +66,7 @@ export async function middleware(request: NextRequest) {
 export function isValidDifficultyLevel(
   value: string | null
 ): value is DifficultyLevelEnum {
-  if (!value) return false;
-  return VALID_DIFFICULTY_LEVELS.includes(value as DifficultyLevelEnum);
+  return isDifficultyLevel(value);
 }
 
 /**
@@ -77,6 +76,10 @@ function _applyDifficultyCookie(
   request: NextRequest,
   response: NextResponse
 ): void {
+  // オープンデータAPI等も difficulty クエリを受け取るため、APIレスポンスに
+  // Set-Cookie が乗ってUIの表示設定を書き換えてしまわないよう除外する
+  if (request.nextUrl.pathname.startsWith("/api/")) return;
+
   const { searchParams } = new URL(request.url);
   const difficulty = searchParams.get("difficulty");
 

--- a/web/src/middleware.ts
+++ b/web/src/middleware.ts
@@ -70,15 +70,22 @@ export function isValidDifficultyLevel(
 }
 
 /**
+ * difficulty Cookie の付与対象パスか判定する。
+ * オープンデータAPI等も difficulty クエリを受け取るため、APIレスポンスに
+ * Set-Cookie が乗ってUIの表示設定を書き換えてしまわないよう除外する
+ */
+export function shouldApplyDifficultyCookie(pathname: string): boolean {
+  return !pathname.startsWith("/api/");
+}
+
+/**
  * URLパラメータからdifficultyを取得し、レスポンスのCookieにセット
  */
 function _applyDifficultyCookie(
   request: NextRequest,
   response: NextResponse
 ): void {
-  // オープンデータAPI等も difficulty クエリを受け取るため、APIレスポンスに
-  // Set-Cookie が乗ってUIの表示設定を書き換えてしまわないよう除外する
-  if (request.nextUrl.pathname.startsWith("/api/")) return;
+  if (!shouldApplyDifficultyCookie(request.nextUrl.pathname)) return;
 
   const { searchParams } = new URL(request.url);
   const difficulty = searchParams.get("difficulty");


### PR DESCRIPTION
## 概要

オープンデータAPIに、公開中の議案を取得できるエンドポイントを追加します。

- `GET /api/open-data/bills` — 公開中（`publish_status = published`）の議案一覧。難易度別の解説（タイトル・概要）、チームみらいの賛否（`miraiStance`: type / 日本語ラベル / コメント）、タグ付き。keysetページネーション（`limit` / `cursor`）対応
- `GET /api/open-data/bills/{billId}` — 議案詳細。一覧の項目に加えて本文解説（Markdown）を返す
- どちらも `difficulty`（normal / hard、既定 normal）で解説コンテンツを切替
- 既存のインタビューAPIと同じレートリミット（IP 30/分・全体 300/分、429 + Retry-After）を共有。議案データはインタビューデータと異なり同意ゲート・ライセンス表記は付けない
- OpenAPI仕様書（`web/public/openapi/open-data-api.json`）に両エンドポイントを追記し、インタビュー規約・CC BY 4.0 の記述をインタビューデータAPIのセクションにスコープ。/developers/open-data-api のScalarリファレンスに自動反映される

## リファクタリング（実装に伴う共通化）

- `parse-interviews-query.ts` → `parse-pagination-query.ts` にリネーム（limit/cursor解析は両API共通のため）
- 一覧APIのページ組み立て（limit+1 → nextCursor）を `paginate.ts` に共通化し、interviews サービスも利用
- `jsonNoStore`（no-store JSONレスポンス）を `web/src/lib/api/response.ts` へ、レートリミット消費を `rate-limit-guard.ts` へ切り出し、interviews ルートも共通化
- difficulty 判定の型ガード `isDifficultyLevel` を bill-difficulty feature に一元化（middleware・Cookieパーサーも利用）
- middleware: `/api/` 配下では difficulty クエリによる Cookie 書き換えを行わないよう修正（オープンデータAPIへのリクエストがUIの表示設定を変えてしまうのを防止）

## スキーマ変更

- `supabase/migrations/20260809000000_add_bills_open_data_pagination_index.sql`: 一覧のkeysetページネーション用インデックス `bills (publish_status, created_at desc, id desc)` を追加（インデックスのみ、型再生成不要）

## 実行テスト

- `pnpm lint` / `pnpm typecheck` / `pnpm build` パス
- `pnpm --filter web test`: 814件パス（新規: parse-bills-query / to-open-data-bill / paginate / uuid / is-difficulty-level）
- `pnpm --filter web test:integration`: 162件パス（新規: bills一覧・詳細のルート/サービス統合テスト。既存インタビューテストの会話ログ並び順フレークも created_at 明示で修正）
- Codexレビュー・4観点セルフレビュー（reuse / simplification / efficiency / altitude)実施済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 公開中の議案一覧・詳細を取得できるオープンデータAPIを追加しました。
  * 難易度指定、件数指定、カーソルによるページングに対応しました。
  * 議案本文、タグ、審議状況、チームみらいの賛否情報を提供します。
  * API仕様をバージョン1.1.0に更新しました。

* **改善**
  * レート制限、キャッシュ無効化、入力エラーへの応答を整備しました。
  * 存在しない議案には適切なエラーを返すようにしました。
  * インタビューデータAPIのページング処理を改善しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->