### PR TITLE
デプロイPRではSupabase previewブランチ管理をスキップ

### DIFF
--- a/.github/workflows/supabase_preview.yml
+++ b/.github/workflows/supabase_preview.yml
@@ -16,8 +16,14 @@ concurrency:
 jobs:
   manage-preview-branch:
     runs-on: ubuntu-latest
-    # fork からの PR は secrets を参照できないため対象外
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    # fork からの PR は secrets を参照できないため対象外。
+    # また head が develop の PR（本番反映 PR 等）も対象外。develop は Supabase の
+    # staging ブランチに紐付いており、同じ git ブランチへの preview ブランチ作成は
+    # "Failed to provision branch project"（409/500）で失敗する。仮に成功しても
+    # Vercel の develop 向け環境変数（= staging）を preview DB に向け替えてしまう
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.head.ref != 'develop'
     environment: staging
     env:
       SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}


### PR DESCRIPTION
## 概要

デプロイPR（develop→main の本番反映PR）に `supabase/` 配下の変更が含まれると、`Supabase Preview Branch` ワークフローが失敗する問題を修正します。

### 原因

- Supabase の `staging` ブランチは git branch `develop` に紐付いている
- デプロイPRは head が `develop` のため、`develop-pr<番号>` の preview ブランチを `--git-branch develop` で作成しようとして衝突し、`Failed to provision branch project`（#952 では 409、#956 では 500）で失敗する
- 過去のデプロイPR（#945, #952, #956）で毎回同じ失敗が発生していた（close 時のクリーンアップ run のみ成功）

また、仮にブランチ作成が成功した場合、後続の step が Vercel の `develop` ブランチ向け Preview 環境変数（= staging 環境）を preview DB に向け替えてしまうリスクがあった。

### 対応

head が `develop` の PR では `manage-preview-branch` ジョブ全体をスキップする条件を追加。

## 実行テスト記録

- `npx yaml-lint .github/workflows/supabase_preview.yml`（構文チェック通過）
- ワークフローYAMLのみの変更のため、アプリのlint/test/buildは対象外

🤖 Generated with [Claude Code](https://claude.com/claude-code)