### PR TITLE
UI実装の抜けを繰り返さないための規約とスクリプトを追加する

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,9 @@ cd ../mirai-gikai-<branch-name> && pnpm install --frozen-lockfile
 1. **`/simplify` を実行**: 変更コードの重複・可読性・効率の観点から自己修正を行う。明らかな問題を先に潰しておくことで、後段の `/review` の指摘ノイズを減らす。
 2. **`/review` を実行**: Codexレビュー・`test-guidelines-checker` によるテストガイドラインチェック・`code-quality-checker` によるコード品質チェックを同時に実行する。指摘があれば修正する。
 
-両方を通過したら、ユーザーに確認せずそのままコミット → push → PR作成まで一気に進めること（`gh pr create`）。
+3. **`node scripts/check-orphan-exports.mjs` を実行**: 差分で追加・変更したファイルの export のうち、どこからも参照されていないものを検出する。共通化のために切り出したまま差し替えを忘れた、という抜けを拾う。
+
+すべて通過したら、ユーザーに確認せずそのままコミット → push → PR作成まで一気に進めること（`gh pr create`）。
 
 ### UI変更時のスクリーンショット必須
 PR作成後、変更差分にUI関連ファイル（`web/src/`, `admin/src/` 配下の `.tsx`, `.css` 等）が含まれる場合は、必ず `/pr-screenshot` スキルを実行すること。スキルが自動でdevサーバー起動→スクリーンショット撮影→R2アップロード→PR本文更新まで行う。
@@ -119,6 +121,11 @@ Repository レイヤーの詳細は [docs/repository-layer.md](docs/repository-l
 - **ボタン**: `<button>` タグの使用は禁止です。必ず `@/components/ui/button` の `Button` コンポーネントを使用してください。
 - **色**: インラインカラーコード（`text-[#xxx]`, `bg-[#xxx]`, `border-[#xxx]` 等の arbitrary value や style 属性での直接指定）は**禁止**です。必ず `globals.css` の `@theme inline` で定義済みのカラートークン（`text-mirai-text`, `bg-primary`, `border-primary-accent` 等）を使用してください。新しい色が必要な場合は、まず `globals.css` にトークンを追加してから使用すること。既存トークン一覧は `web/src/app/globals.css` の `@theme inline` ブロックを参照。
 - **Figma実装**: FigmaのURLからUIを実装する際、スクリーンショットだけで色やサイズを推測しないこと。必ず `get_variable_defs` や `get_design_context` でカラーコード・フォントサイズ・スペーシング等の正確な値を取得し、既存のデザイントークンとの対応を確認してから実装する。
+- **Claude Design 実装**: `.dc.html` からUIを実装する際、ソースを読んで仕様を推測しないこと。次の2点を守る。
+  - **正は `data-props` の `default`**。`hint-placeholder-val` / `hint-placeholder-count` はプレビュー用の仮値であり、作者の選択ではない。スクリプト側の `?? "既定値"` も props 未指定時のフォールバックなので、`data-props` と食い違うことがある。
+  - **実装前に必ずデザインを描画して見る**。`.dc.html` は React の UMD ビルドと `support.js` を読み込む形に書き換えればブラウザで開ける。節ごとに読むと、条件分岐で出し分けている要素やブロックごと見落とす。描画したものと実装を並べて比べる。
+- **既存コンポーネントとの統一**: 同種のコンポーネントを新規に作る・既存に手を入れるときは、**兄弟にあたる既存実装の枠線・角丸・影・余白・文字の扱いを先に読んで揃える**こと。カード系（`BillCard` / `CompactBillCard` / `BillSearchCard`）やチップ系のように複数ある系統は、1つだけ直すと画面間でずれる。
+- **共通化は差し替えまで完了させる**: 重複を減らすためにコンポーネントや関数を切り出したら、**元の重複箇所をすべて差し替えるまでを1つの作業とする**こと。切り出しただけで放置すると、使われない新ファイルと重複した実装が同時に残る。`node scripts/check-orphan-exports.mjs` で参照の無い export を検出できる。
 
 ### admin 内部ルート定義
 - admin アプリの内部リンク（Link href, router.push, redirect）には `@/lib/routes` の関数を使用すること。文字列リテラルでのルート直書きは禁止。

--- a/scripts/check-orphan-exports.mjs
+++ b/scripts/check-orphan-exports.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+/**
+ * 差分で追加・変更したファイルの export が、どこからも参照されていないかを調べる。
+ *
+ * 共通化のためにコンポーネントを切り出したのに差し替えを忘れる、という抜けを
+ * 拾うために置いている。「重複を減らすつもりが、使われない新ファイルと重複した
+ * 実装が同時に残る」という形の事故が実際に起きた。
+ *
+ * 使い方:
+ *   node scripts/check-orphan-exports.mjs [base]
+ *
+ * base の既定は develop。参照が無い export が見つかったら exit 1。
+ */
+
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+
+const base = process.argv[2] ?? "develop";
+
+/** 参照を数えなくてよいもの。 */
+const IGNORED_PATHS = [
+  /\.test\.tsx?$/,
+  /\.integration\.test\.tsx?$/,
+  // Next.js の規約ファイルはフレームワークが呼ぶ。
+  /\/(page|layout|route|sitemap|robots|not-found|error|loading|template)\.tsx?$/,
+  /\/(middleware|instrumentation)\.ts$/,
+  // 設定ファイルは実行環境が読む。
+  /\.config\.[cm]?[jt]s$/,
+];
+
+/** default export と、フレームワークが名前で拾う export。 */
+const IGNORED_NAMES = new Set(["default", "metadata", "generateMetadata"]);
+
+function git(args) {
+  return execFileSync("git", args, { encoding: "utf8" });
+}
+
+function changedFiles() {
+  return git(["diff", "--name-only", "--diff-filter=AM", `${base}...HEAD`])
+    .split("\n")
+    .filter((path) => /\.tsx?$/.test(path))
+    .filter((path) => !IGNORED_PATHS.some((pattern) => pattern.test(path)));
+}
+
+/**
+ * export された名前を拾う。
+ *
+ * 構文解析まではしない。`export function foo` / `export const foo` /
+ * `export type Foo` / `export { foo }` の形だけを見る。取りこぼしても
+ * 誤検知にはならず、見逃しになるだけなので、この粗さで足りる。
+ */
+function exportedNames(source) {
+  const names = new Set();
+
+  const declaration =
+    /^export\s+(?:async\s+)?(?:function|const|let|class|type|interface|enum)\s+(\w+)/gm;
+  for (const match of source.matchAll(declaration)) {
+    names.add(match[1]);
+  }
+
+  const braced = /^export\s+(?:type\s+)?\{([^}]+)\}/gm;
+  for (const match of source.matchAll(braced)) {
+    for (const part of match[1].split(",")) {
+      const name = part.trim().split(/\s+as\s+/).pop()?.trim();
+      if (name) names.add(name);
+    }
+  }
+
+  for (const name of IGNORED_NAMES) names.delete(name);
+  return [...names];
+}
+
+/** その名前を、自分以外のファイルが書いているか。 */
+function isReferenced(name, ownPath) {
+  let output = "";
+  try {
+    output = git([
+      "grep",
+      "-l",
+      "-w",
+      "-e",
+      name,
+      "--",
+      "web/src",
+      "admin/src",
+      "packages",
+      "tests",
+    ]);
+  } catch {
+    // git grep は一致0件で exit 1 を返す。
+    return false;
+  }
+
+  return output
+    .split("\n")
+    .filter(Boolean)
+    .some((path) => path !== ownPath);
+}
+
+const orphans = [];
+for (const path of changedFiles()) {
+  let source = "";
+  try {
+    source = readFileSync(path, "utf8");
+  } catch {
+    continue;
+  }
+
+  for (const name of exportedNames(source)) {
+    if (!isReferenced(name, path)) {
+      orphans.push({ path, name });
+    }
+  }
+}
+
+if (orphans.length === 0) {
+  console.log("参照の無い export はありません。");
+  process.exit(0);
+}
+
+console.error("どこからも参照されていない export があります:\n");
+for (const { path, name } of orphans) {
+  console.error(`  ${path}: ${name}`);
+}
+console.error(
+  "\n切り出したまま差し替えを忘れていないか確認してください。" +
+    "意図して外部に出していない場合は export を外すか、ファイルを削除してください。"
+);
+process.exit(1);

--- a/scripts/serve-claude-design.mjs
+++ b/scripts/serve-claude-design.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+/**
+ * Claude Design の `.dc.html` をブラウザで開ける形にして配信する。
+ *
+ * `.dc.html` は `window.React` / `window.ReactDOM` が用意済みであることを
+ * 前提にしているため、そのまま開いても何も描画されない。UMD ビルドを先に
+ * 読み込む形へ書き換えたコピーを作って配信する。
+ *
+ * ソースを読んで仕様を推測すると外す。`hint-placeholder-val` はプレビュー用の
+ * 仮値で作者の選択ではなく、スクリプト側の `?? "既定値"` も `data-props` の
+ * `default` と食い違うことがある。どちらが効くかは描画しないと分からない。
+ *
+ * 使い方:
+ *   node scripts/serve-claude-design.mjs <デザインを置いたディレクトリ> [port]
+ *
+ * ディレクトリには Claude Design からダウンロードした `.dc.html` と、
+ * 同梱の `support.js` などの資材を置く。
+ */
+
+import { createServer } from "node:http";
+import { readdirSync, readFileSync, existsSync } from "node:fs";
+import { extname, join, resolve } from "node:path";
+
+const dir = resolve(process.argv[2] ?? ".");
+const port = Number(process.argv[3] ?? 8780);
+
+const REACT_UMD = [
+  '<script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>',
+  '<script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>',
+].join("\n");
+
+const MIME = {
+  ".html": "text/html; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".webp": "image/webp",
+  ".svg": "image/svg+xml",
+};
+
+/** support.js の読み込み前に React を挿す。既に入っていれば触らない。 */
+function withReact(html) {
+  if (html.includes("react.production")) return html;
+
+  const marker = '<script src="./support.js"></script>';
+  if (!html.includes(marker)) {
+    throw new Error(
+      "support.js の読み込み位置が見つかりません。デザイン一式を同じディレクトリに置いてください。"
+    );
+  }
+
+  return html.replace(marker, `${REACT_UMD}\n${marker}`);
+}
+
+const server = createServer((request, response) => {
+  const path = decodeURIComponent((request.url ?? "/").split("?")[0]);
+
+  if (path === "/") {
+    const designs = readdirSync(dir).filter((name) => name.endsWith(".html"));
+    const links = designs
+      .map((name) => `<li><a href="/${name}">${name}</a></li>`)
+      .join("");
+    response.writeHead(200, { "content-type": MIME[".html"] });
+    response.end(`<ul>${links}</ul>`);
+    return;
+  }
+
+  // ディレクトリの外へ出る参照を弾く。
+  const file = resolve(join(dir, path));
+  if (!file.startsWith(dir) || !existsSync(file)) {
+    response.writeHead(404).end("not found");
+    return;
+  }
+
+  const extension = extname(file);
+  try {
+    const body =
+      extension === ".html"
+        ? withReact(readFileSync(file, "utf8"))
+        : readFileSync(file);
+    response.writeHead(200, {
+      "content-type": MIME[extension] ?? "application/octet-stream",
+    });
+    response.end(body);
+  } catch (error) {
+    response.writeHead(500).end(String(error));
+  }
+});
+
+server.listen(port, () => {
+  console.log(`デザインを配信します: http://localhost:${port}/`);
+  console.log(`配信元: ${dir}`);
+});

--- a/web/src/features/bills/shared/utils/highlight-match.ts
+++ b/web/src/features/bills/shared/utils/highlight-match.ts
@@ -6,7 +6,7 @@
  * 大小文字だけを無視した素の部分一致で位置を探す。見つからなければ
  * ハイライトなしで返す。
  */
-export type MatchSegment = { text: string; matched: boolean };
+type MatchSegment = { text: string; matched: boolean };
 
 export function highlightMatch(text: string, query: string): MatchSegment[] {
   const needle = query.trim();


### PR DESCRIPTION
UI刷新（#953 / #954 / #955 / #958）で受けた指摘を振り返り、同じ抜けを繰り返さないための規約とスクリプトを追加する。

追加したものはすべて、実際に起きた事故に1対1で対応している。

## 何が起きたか

**デザインのソースを読んで仕様を推測し、2回間違えた。** `.dc.html` の `hint-placeholder-val` を作者の選択だと読んだが、これはプレビュー用の仮値で、正は `data-props` の `default` だった。さらに `cardPattern` は `data-props` が `"A: 画像左"`、スクリプト側のフォールバックが `"標準"` で食い違っており、どちらが効くかは描画しないと分からなかった。節ごとに読んだ結果、衆議院リンクのブロックを丸ごと見落とした。

**共通化を切り出したまま差し替えを忘れ、使われないファイルと4箇所の重複が同時に残った。** `TagChipLink` を「同じ見た目を2箇所に書かない」ために作ったのに配線しておらず、レビュー3件が同じ指摘をした。

**同種のカードで枠線・角丸・影がバラバラだった。** `CompactBillCard` が 0.5px 灰・16px 角丸、`BillCard` が 1px 黒・12px＋影、`BillSearchCard` が 1px 黒・12px・影なし。1つだけ直すと画面間でずれる状態だった。

## 追加した規約

`AGENTS.md` の Coding Style に3つ足した。既にある Figma の規約（「スクリーンショットだけで推測しない」）と同じ位置づけ。

- **Claude Design 実装**: `data-props` の `default` が正。`hint-placeholder-val` とスクリプトのフォールバックは信用しない。実装前に描画して見る
- **既存コンポーネントとの統一**: 兄弟にあたる既存実装の枠線・角丸・影・余白を先に読んで揃える
- **共通化は差し替えまで完了させる**: 切り出しと差し替えを1つの作業とする

## 追加したスクリプト

**`scripts/check-orphan-exports.mjs`** — 差分で追加・変更したファイルの export のうち、どこからも参照されていないものを検出する。依存なしの node スクリプトで、`git grep` で参照を数える。

事故が起きたコミット（`9fc039d3`）に対して実行すると、当時レビューで指摘された2件をそのまま拾う。

```
$ node scripts/check-orphan-exports.mjs
どこからも参照されていない export があります:

  web/src/features/bills/client/components/bill-list/tag-chip-link.tsx: TagChipLink
  web/src/features/bills/shared/utils/tag-chip-items.ts: TagChipItem
```

`page.tsx` などフレームワークが呼ぶ規約ファイル、テスト、設定ファイルは対象外にしている。構文解析はせず正規表現で export 名を拾うので、取りこぼしはあっても誤検知は出ない作りにした。

セルフレビューの手順（`/simplify` → `/review`）の3番目として `AGENTS.md` に足した。

**`scripts/serve-claude-design.mjs`** — `.dc.html` をブラウザで開ける形にして配信する。`.dc.html` は `window.React` を前提にしているためそのままでは何も描画されず、これが「読んで推測する」に流れる原因だった。React の UMD を先に読み込む形へ書き換えて返す。

## あわせて直したもの

`highlight-match.ts` の `MatchSegment` を内部型にした。#958 に入れるつもりが間に合わなかったもので、上のスクリプトが検出した1件。

## Expected behavior

- `node scripts/check-orphan-exports.mjs` が参照の無い export で exit 1 になる
- `node scripts/serve-claude-design.mjs <dir>` でデザインが描画される。ディレクトリ外への参照は 404

## テスト

```
pnpm lint / pnpm typecheck   OK
pnpm --filter web test        925件成功
```

スクリプトは手元で動作を確認した。参照検出は事故のコミットで再現し、配信は一覧・React挿入・ディレクトリ外の拒否を確認している。

## 相談したいこと

`check-orphan-exports.mjs` を CI に入れるかは決めていない。今はセルフレビューの手順に置いただけで、`code_check.yml` には足していない。実行は数秒で終わるので入れてよいと思うが、既存コードに未参照の export が残っていると develop が赤くなるため、先に棚卸しが必要か確認したい。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **リファクタリング**
  * 内部型の公開範囲を見直しました。
  * エンドユーザー向けの動作や表示に変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->